### PR TITLE
Instalação no Codex: dois atalhos e /aft-doctor ciente do assistente

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,19 @@ como trocar (`/model`), e siga só depois que ele decidir. Para `sonnet` e `haik
 interrompa. O `model:` do cabeçalho é a única fonte: nunca copie essa informação para
 outro lugar.
 
-## O atalho das skills (máquina, não repositório)
+## Os dois atalhos do Codex (máquina, não repositório)
 
-`~/.agents/skills` é um atalho para `~/.claude/skills` — uma pasta só, dois endereços,
-para que Codex e Claude Code enxerguem as mesmas skills. É da máquina de cada um, está no
-`.gitignore` e nunca é versionado. No Mac/Linux: `ln -s ../.claude/skills ~/.agents/skills`;
-no Windows: `mklink /J %USERPROFILE%\.agents\skills %USERPROFILE%\.claude\skills`.
+São **dois** atalhos, os dois na máquina de cada um — nunca versionados:
+
+- `~/.agents/skills` → `~/.claude/skills`: uma pasta só, dois endereços, para que Codex e
+  Claude Code enxerguem as mesmas skills. A pasta física é sempre `~/.claude/skills`,
+  inclusive para quem não usa o Claude — é o caminho escrito dentro dos SKILL.md.
+- `~/.codex/AGENTS.md` → `~/.claude/CLAUDE.md`: o perfil do auditor, para o Codex saber
+  que o usuário é AFT e não programador.
+
+Mac/Linux: `ln -s ../.claude/skills ~/.agents/skills` e
+`ln -s ../.claude/CLAUDE.md ~/.codex/AGENTS.md`. Windows: `mklink /J` para a pasta e
+`mklink /H` para o arquivo (nenhum dos dois pede administrador). **Atalho, nunca cópia:**
+o `/aft-atualizar` reescreve o `CLAUDE.md` por dentro, então o link se mantém em dia
+sozinho. Quem instala é o Passo 0 do `/aft-setup`; o roteiro para o AFT está em
+`COMO-INSTALAR.md`.

--- a/COMO-INSTALAR.md
+++ b/COMO-INSTALAR.md
@@ -1,6 +1,8 @@
-# Como instalar o AFT Toolkit no seu Claude Code (Windows)
+# Como instalar o AFT Toolkit (Claude Code ou Codex — Windows)
 
 Instalação em **4 passos** — você instala manualmente só o aplicativo e o Git; do Python em diante, quem digita comando é o Claude. Tempo total: ~15 minutos.
+
+> **Usa o Codex em vez do Claude — ou quer usar os dois?** As mesmas skills funcionam nos dois assistentes. Vá para [Usando o toolkit no Codex](#usando-o-toolkit-no-codex): são dois atalhos para quem já tem o toolkit instalado, e a instalação do zero para quem prefere o Codex.
 
 ---
 
@@ -140,6 +142,139 @@ Peça ao Claude, numa conversa qualquer: **"Atualize o AFT Toolkit"** (ou `/aft-
 
 ---
 
+## Usando o toolkit no Codex
+
+O AFT Toolkit não é feito só para o Claude: as skills são texto e os scripts são Python,
+e o **Codex** (o assistente de código da OpenAI) lê as duas coisas. Quem quiser trabalhar
+no Codex — em vez do Claude ou junto com ele — não instala nada diferente: instala o
+mesmo toolkit e cria **dois atalhos**.
+
+> 🔑 **A regra que explica tudo:** a pasta de verdade das skills continua sendo
+> `~/.claude/skills`, **mesmo para quem nunca vai abrir o Claude**. Os comandos dentro
+> das skills apontam para lá (`~/.claude/skills/_scripts/...`), em mais de 40 arquivos.
+> O Codex procura as skills em `~/.agents/skills` — então o que se faz é dar um **segundo
+> nome** à mesma pasta, não uma segunda cópia. Duas cópias sempre divergem; um atalho,
+> nunca.
+
+Os dois atalhos são:
+
+| Atalho | Aponta para | Serve para |
+|---|---|---|
+| `~/.agents/skills` | `~/.claude/skills` | o Codex enxergar as 46 skills |
+| `~/.codex/AGENTS.md` | `~/.claude/CLAUDE.md` | o Codex saber que você é AFT e como trabalhar com você |
+
+O segundo é tão importante quanto o primeiro: é o arquivo de perfil (instalado pelo
+`/aft-setup`) que diz ao assistente que você é auditor-fiscal e não programador, que
+**quem digita comando é ele**, e quais skills usar em cada situação. Sem ele, o Codex
+enxerga as skills mas trata você como um desenvolvedor — e manda você ao terminal.
+
+---
+
+### Caminho 1 — Já uso o Claude e quero usar o Codex também
+
+Se o toolkit já está instalado e funcionando no Claude, não desinstale nada: os dois
+assistentes convivem na mesma pasta, com os mesmos arquivos de fiscalização. **Peça ao
+Claude, numa conversa qualquer:**
+
+```
+Quero usar o AFT Toolkit também no Codex. Crie os dois atalhos: ~/.agents/skills apontando
+para ~/.claude/skills, e ~/.codex/AGENTS.md apontando para ~/.claude/CLAUDE.md. No Windows
+use "mklink /J" para a pasta e "mklink /H" para o arquivo (nenhum dos dois pede
+administrador). Se eu já tiver um ~/.codex/AGENTS.md escrito, não sobrescreva: me mostre o
+que tem lá e junte os dois textos. No final, confirme que os atalhos apontam para o lugar
+certo.
+```
+
+Se preferir ver o que ele vai rodar, é isto:
+
+**macOS / Linux**
+
+```bash
+mkdir -p ~/.agents ~/.codex && ln -s ../.claude/skills ~/.agents/skills && ln -s ../.claude/CLAUDE.md ~/.codex/AGENTS.md
+```
+
+**Windows** (Prompt de Comando, sem precisar de administrador)
+
+```
+md "%USERPROFILE%\.agents" "%USERPROFILE%\.codex" 2>nul & mklink /J "%USERPROFILE%\.agents\skills" "%USERPROFILE%\.claude\skills" & mklink /H "%USERPROFILE%\.codex\AGENTS.md" "%USERPROFILE%\.claude\CLAUDE.md"
+```
+
+**Por que atalho e não cópia?** Porque o `/aft-atualizar` mantém o seu perfil em dia
+reescrevendo o `~/.claude/CLAUDE.md` **por dentro** — com o atalho, o Codex recebe a
+atualização no mesmo instante; com uma cópia, ele ficaria para trás sem ninguém perceber.
+Vale para as skills também: você atualiza uma vez, os dois assistentes ficam em dia.
+
+Feche e reabra o Codex. Pronto — as mesmas skills, as mesmas pastas de fiscalização, os
+mesmos arquivos. Você escolhe em qual assistente trabalhar a cada dia; nada precisa ser
+"migrado" de um para o outro.
+
+---
+
+### Caminho 2 — Vou começar do zero e prefiro o Codex
+
+Mesma instalação dos Passos 1 a 5 lá em cima, com três trocas. O tempo é o mesmo,
+~15 minutos.
+
+**Passo 1 — Instale o Codex** em vez do Claude (<https://developers.openai.com/codex>) e
+entre com a sua conta. Você precisa de um plano que inclua o Codex.
+
+**Passo 2 — Instale o Git**, exatamente como no Passo 2 acima: é ele que baixa o toolkit
+e busca as atualizações futuras. Baixe em <https://git-scm.com/download/win> e instale
+clicando "Next" até o fim.
+
+**Passo 3 — Deixe o Codex instalar o resto.** As mesmas três mensagens do Passo 3, uma de
+cada vez — só a terceira muda, porque ela cria os atalhos junto:
+
+**Mensagem 1** — igual à do Passo 3 (Git, Python e a ferramenta de ementas).
+
+**Mensagem 2** — igual à do Passo 3 (baixar o toolkit e ler o que veio).
+
+**Mensagem 3 — instalar (só depois que ele responder a mensagem 2):**
+
+```
+Agora mova todo o conteúdo da pasta Documentos\aft-toolkit, inclusive a pasta oculta .git,
+para ~/.claude/skills. O resultado tem que ser ~/.claude/skills/aft-setup/SKILL.md — e NÃO
+~/.claude/skills/aft-toolkit/aft-setup. Se ~/.claude/skills já tiver alguma coisa dentro,
+preserve o que existe e apenas acrescente. A pasta precisa ser essa mesmo, ~/.claude, ainda
+que eu não use o Claude: é o caminho que está escrito dentro das skills. Em seguida crie o
+atalho ~/.agents/skills apontando para ~/.claude/skills (no Windows, mklink /J), que é onde
+você procura skills. No final, liste as skills e me diga se preciso reiniciar o aplicativo.
+```
+
+**Passo 4 — Reinicie e configure.** Feche e reabra o Codex e peça a configuração inicial
+**avisando qual assistente você usa**:
+
+```
+Rode a skill aft-setup. Estou no Codex, não no Claude Code.
+```
+
+O `/aft-setup` cria a pasta `Documentos\AFT`, pergunta seu nome, CIF e UORG, instala as
+bibliotecas Python — e, sabendo que você está no Codex, cria o atalho do perfil
+(`~/.codex/AGENTS.md`) e pula sozinho as partes que só existem no app do Claude. Ao final,
+peça o `/aft-doctor` para conferir.
+
+**Passo 5 — Traga as suas fiscalizações**, igual ao Passo 5 acima (copiar as pastas para
+`OS ATIVAS` e pedir o `/aft-organiza-os`).
+
+---
+
+### O que muda no dia a dia
+
+Tudo o que é trabalho de fiscalização funciona igual: as 46 skills, os autos, o TXT do
+Sistema Auditor, o painel, os relatórios, o ementário do NotebookLM, as planilhas de CAT.
+As diferenças são de conforto, e nenhuma delas atrapalha uma auditoria:
+
+| No Claude | No Codex |
+|---|---|
+| Cada skill escolhe sozinha o modelo de que precisa | O modelo vale para a conversa inteira: quando a skill pedir o modelo mais forte (PGR, AET, acidente, laudo de NR-12, manutenção de interdição), ele avisa e você troca com `/model` — a tabela de equivalência está no `AGENTS.md` do toolkit |
+| Uma sessão de conversa por empresa, criada sozinha no menu lateral | Não existe; organize as conversas do seu jeito |
+| O diário anota o dia trabalhado mesmo fora de skill (gancho automático) | As skills continuam anotando; o registro fora de skill você pede ("registra que trabalhei nessa empresa hoje") e o `/aft-diario` monta o mês igual |
+| Revisor de autos e varredura do Sistema Auditor rodam em conversa separada | Rodam na própria conversa, com o mesmo resultado |
+| Lista de bloqueios de segurança no `settings.json` (senhas, dados de trabalhador) | Não é lida: a proteção equivalente é o modo de aprovação/sandbox do próprio Codex — **mantenha a aprovação por comando ligada** |
+| O painel pode ser publicado como página compartilhável | Só a versão local, que abre no seu navegador |
+
+---
+
 ## Plano B — instalação manual
 
 Só se o Passo 3 falhar (computador sem winget, rede corporativa bloqueando, **ou o assistente recusar a instalação por precaução de segurança** — pode acontecer, e não é sinal de problema com o toolkit):
@@ -181,5 +316,8 @@ Regra geral: **descreva o problema ao próprio Claude** no `</> Code` ("o comand
 | Skill `/notebooklm` não aparece (mas o comando `notebooklm --help` funciona) | É **opcional** — as skills do toolkit usam o comando de terminal, não essa skill. Se quiser tê-la, peça ao Claude: "rode notebooklm skill install" e feche e reabra o app |
 | NotebookLM responde "sem acesso" | Solicite acesso em https://notebooks-aft.vercel.app e aguarde a liberação do mantenedor |
 | NotebookLM parou ("authentication expired") | A sessão expira de tempos em tempos. Peça ao Claude "reconecte o notebooklm" — ele reabre o login, sem terminal |
+| Codex não encontra as skills (`/aft-...` não faz nada) | Confira o atalho: `~/.agents/skills` precisa apontar para `~/.claude/skills`. Peça ao assistente: "confira o atalho ~/.agents/skills e recrie se estiver faltando" |
+| Codex trata você como programador (manda ao terminal, usa jargão) | Falta o atalho do perfil. Peça: "crie o atalho ~/.codex/AGENTS.md apontando para ~/.claude/CLAUDE.md" e reabra o Codex |
+| `/aft-doctor` acusa agentes, deny-list ou vigia de sessões faltando, e você está no Codex | É esperado: essas três coisas só existem no app do Claude. Nenhuma skill depende delas |
 
 Dúvidas? Fale com o Ricardo (SRTE/GO).

--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -7,6 +7,31 @@ rever tudo, basta abrir este arquivo.
 ---
 
 ## 14/08/2026
+<!-- commit: instalar-no-codex -->
+
+**O toolkit agora tem instalação para quem usa o Codex — e para quem quer usar os dois
+assistentes ao mesmo tempo.**
+As skills e os scripts sempre funcionaram no Codex; o que faltava era o roteiro. Ele está
+no `COMO-INSTALAR.md`, na seção "Usando o toolkit no Codex", com dois caminhos:
+
+- **Já uso o Claude e quero o Codex também:** dois atalhos e pronto — mesma pasta de
+  skills, mesmas fiscalizações, nada duplicado. Você pede ao assistente e ele cria.
+- **Vou começar do zero no Codex:** a mesma instalação de sempre, com três trocas
+  (instalar o Codex no lugar do Claude, uma mensagem diferente no Passo 3, e avisar ao
+  `/aft-setup` que você está no Codex).
+
+O `/aft-setup` e o `/aft-atualizar` passaram a reconhecer em qual assistente estão: no
+Codex eles criam os atalhos e pulam sozinhos as quatro coisas que só existem no app do
+Claude (agentes, lista de bloqueios do `settings.json`, vigia de sessões e gancho do
+diário). Nenhuma skill depende delas — a tabela "O que muda no dia a dia", no
+`COMO-INSTALAR.md`, diz exatamente o que se ganha e o que se perde de cada lado.
+
+O `/aft-doctor` também aprendeu a diferença: se você usa o Codex, ele confere os dois
+atalhos e para de cobrar essas três coisas que não existem lá — em vez de três avisos
+vermelhos sem nada a fazer. Quem usa os dois assistentes continua vendo os avisos, porque
+para esse caso eles são pendência de verdade.
+
+## 14/08/2026
 <!-- commit: agents-md-contexto -->
 
 **O contexto de cada auditoria passa a ser lido por qualquer assistente, não só pelo

--- a/_scripts/aft_doctor.py
+++ b/_scripts/aft_doctor.py
@@ -35,6 +35,7 @@ except Exception:
     pass
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -49,6 +50,35 @@ HOME = Path.home()
 # o import falhar - no Windows com OneDrive ele costuma estar errado.
 AFT_DIR = HOME / "Documents" / "AFT"
 OS_DIR = None  # idem; a checagem 15 so roda se a 6 tiver resolvido
+
+# Assistente em uso (Claude Code ou Codex) -----------------------------------
+# O toolkit roda nos dois. A pasta FISICA das skills e sempre ~/.claude/skills
+# (e o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo
+# atalho ~/.agents/skills e le o perfil do auditor pelo atalho
+# ~/.codex/AGENTS.md. Tres coisas so existem no app do Claude - agentes,
+# deny-list do settings.json e vigia de sessoes. Para quem so usa o Codex elas
+# nao sao pendencia nenhuma: seriam tres avisos assustadores sem nada a fazer,
+# por isso viram informativo. Detectamos "uso do Claude" por rastros que o app
+# deixa na primeira conversa (o ~/.claude/skills existe sempre, ate no Codex).
+CLAUDE_DIR = SKILLS_DIR.parent
+ATALHO_SKILLS = HOME / ".agents" / "skills"
+ATALHO_PERFIL = HOME / ".codex" / "AGENTS.md"
+# Os sinais sao do APP (sempre em ~/.claude), nao da pasta do repositorio: um
+# clone fora do lugar nao pode fazer o doutor achar que o Claude nunca rodou.
+_SINAIS_CLAUDE = (HOME / ".claude" / "projects", HOME / ".claude.json",
+                  HOME / ".claude" / "statsig", HOME / ".claude" / "history.jsonl")
+USA_CLAUDE = any(p.exists() for p in _SINAIS_CLAUDE)
+USA_CODEX = (HOME / ".codex").is_dir()
+SO_CODEX = USA_CODEX and not USA_CLAUDE
+
+
+def mesmo_arquivo(a, b):
+    """True se a e b sao o MESMO arquivo/pasta - symlink, junction ou hardlink."""
+    try:
+        return a.exists() and b.exists() and os.path.samefile(str(a), str(b))
+    except OSError:
+        return False
+
 
 checks = []
 
@@ -110,6 +140,31 @@ else:
         "Provavel clone aninhado (ex.: ~/.claude/skills/aft-toolkit/...). "
         "O repositorio precisa SER a pasta ~/.claude/skills.")
 
+# 3a-bis. Atalhos do Codex ----------------------------------------------------
+# So aparece na maquina de quem tem o Codex. Sao os dois enderecos que fazem o
+# Codex enxergar a MESMA pasta de skills e o MESMO perfil do auditor - atalho,
+# nunca copia (o /aft-atualizar reescreve o CLAUDE.md por dentro, entao o link
+# se mantem em dia sozinho). Ver Passo 0 do /aft-setup.
+if USA_CODEX:
+    _skills_ok = mesmo_arquivo(ATALHO_SKILLS, SKILLS_DIR)
+    _perfil_alvo = CLAUDE_DIR / "CLAUDE.md"
+    _perfil_ok = mesmo_arquivo(ATALHO_PERFIL, _perfil_alvo)
+    _faltam = []
+    if not _skills_ok:
+        _faltam.append("~/.agents/skills (o Codex nao acha as skills)")
+    if not _perfil_ok and _perfil_alvo.is_file():
+        _faltam.append("~/.codex/AGENTS.md (o Codex nao le o seu perfil de AFT)")
+    if not _faltam:
+        add("Atalhos do Codex", "ok",
+            "~/.agents/skills e ~/.codex/AGENTS.md apontam para os arquivos certos")
+    else:
+        add("Atalhos do Codex", "aviso",
+            "Atalho faltando ou apontando para o lugar errado: " + "; ".join(_faltam),
+            "Peca 'crie os atalhos do Codex' (Passo 0 do /aft-setup). No Mac: "
+            "ln -s ../.claude/skills ~/.agents/skills e "
+            "ln -s ../.claude/CLAUDE.md ~/.codex/AGENTS.md. No Windows: "
+            "mklink /J para a pasta e mklink /H para o arquivo.")
+
 # 3b. Agentes do toolkit (~/.claude/agents) ----------------------------------
 # As skills /aft-revisa-auto e /aft-autos-lavrados despacham o trabalho pesado
 # para agentes isolados. O repositorio os traz em skills/agents/, mas o Claude
@@ -118,7 +173,11 @@ else:
 # quebra (as skills degradam para o modo inline), por isso severidade aviso.
 agents_src = SKILLS_DIR / "agents"
 agents_dst = SKILLS_DIR.parent / "agents"
-if agents_src.is_dir():
+if SO_CODEX:
+    add("Agentes do toolkit", "ok",
+        "nao se aplica no Codex - as skills que usariam agentes rodam em modo "
+        "inline, com o mesmo resultado")
+elif agents_src.is_dir():
     fontes_ag = sorted(agents_src.glob("*.md"))
     pendentes_ag = []
     for f in fontes_ag:
@@ -172,7 +231,12 @@ if settings_json.is_file():
         deny_list = (_data.get("permissions") or {}).get("deny") or []
     except (OSError, json.JSONDecodeError):
         deny_list = []
-if MARCO_DENY in deny_list:
+if SO_CODEX and MARCO_DENY not in deny_list:
+    add("Deny-list de seguranca", "ok",
+        "nao se aplica no Codex - ele nao le o settings.json do Claude",
+        "No Codex quem faz esse papel e o modo de aprovacao/sandbox do proprio "
+        "app: mantenha a aprovacao por comando ligada.")
+elif MARCO_DENY in deny_list:
     add("Deny-list de seguranca", "ok",
         f"{settings_json} ({len(deny_list)} regras de bloqueio)")
 elif settings_json.is_file():
@@ -779,7 +843,11 @@ elif sys.platform.startswith("win"):
 else:
     _vigia_ok = None
 
-if _vigia_ok is True:
+if SO_CODEX and _vigia_ok is not True:
+    add("Vigia de sessoes", "ok",
+        "nao se aplica no Codex - as sessoes por empresa sao do menu lateral do "
+        "app do Claude")
+elif _vigia_ok is True:
     add("Vigia de sessoes", "ok",
         "instalado - as sessoes por empresa (grupo OS ATIVAS) sao criadas "
         "sozinhas quando o app fecha")

--- a/aft-atualizar/SKILL.md
+++ b/aft-atualizar/SKILL.md
@@ -265,6 +265,11 @@ Aja conforme a **única linha** de saída:
 
 ## Passo 2f — Vigia de sessões (garantir instalado, sem perguntar)
 
+> **No Codex, pule os Passos 2f, 2f-bis e 2g** (vigia de sessões, gancho do diário e
+> agentes só existem no app do Claude). No lugar deles, confira em uma linha se os dois
+> atalhos continuam de pé — `~/.agents/skills` → `~/.claude/skills` e `~/.codex/AGENTS.md`
+> → `~/.claude/CLAUDE.md` — e recrie o que faltar (ver Passo 0 do `/aft-setup`).
+
 As sessões por empresa (grupo "OS ATIVAS" do menu lateral) são automáticas via **vigia de
 sessões** — parte padrão da instalação. Confira e garanta:
 

--- a/aft-setup/SKILL.md
+++ b/aft-setup/SKILL.md
@@ -30,6 +30,35 @@ pela primeira vez. Explique o que cada passo faz em uma frase, sem jargão.
 
 ---
 
+## Passo 0 — Em qual assistente você está? (você resolve sozinho, sem perguntar)
+
+O toolkit roda no **Claude Code** e no **Codex**. Você sabe em qual está rodando — não
+pergunte ao AFT, e não faça disso um assunto. Só o que muda:
+
+| | Claude Code | Codex |
+|---|---|---|
+| Pasta física das skills | `~/.claude/skills` | `~/.claude/skills` (a mesma — os comandos das skills apontam para lá) |
+| Atalho das skills | não precisa | `~/.agents/skills` → `~/.claude/skills` |
+| Perfil do auditor | `~/.claude/CLAUDE.md` (Passo 5b) | o mesmo arquivo + atalho `~/.codex/AGENTS.md` → `~/.claude/CLAUDE.md` |
+| Passos 2b (agentes), 5c (deny-list), 7e (vigia) e 7e-bis (gancho do diário) | instale | **pule** — só existem no app do Claude |
+
+**No Codex**, garanta os dois atalhos antes de seguir (idempotente; no Windows use
+`mklink /J` para a pasta e `mklink /H` para o arquivo — nenhum dos dois pede
+administrador):
+
+```bash
+mkdir -p ~/.agents ~/.codex
+[ -e ~/.agents/skills ] || ln -s ../.claude/skills ~/.agents/skills
+```
+
+O atalho do perfil (`~/.codex/AGENTS.md`) só depois do Passo 5b, quando o
+`~/.claude/CLAUDE.md` já existir. Se o AFT já tiver um `~/.codex/AGENTS.md` escrito por
+ele, **não apague**: mostre o que há lá e pergunte se junta os dois textos.
+
+> Por que atalho e não cópia: o `/aft-atualizar` reescreve o `~/.claude/CLAUDE.md` por
+> dentro para manter o perfil em dia — com atalho, o Codex recebe na hora; com cópia,
+> ficaria para trás sem ninguém perceber.
+
 ## Passo 1 — Verificar e completar pré-requisitos (você instala, não o AFT)
 
 Rode e interprete:
@@ -217,6 +246,10 @@ autorizado ou prefere não conectar conta nenhuma:
 
 ## Passo 2b — Instalar os agentes do toolkit
 
+> **No Codex, pule este passo.** Os agentes são um recurso do app do Claude; as duas
+> skills que os usam (`/aft-revisa-auto` e `/aft-autos-lavrados`) rodam em modo inline,
+> com o mesmo resultado.
+
 Além das skills, o toolkit traz **agentes** — ajudantes que trabalham numa conversa
 isolada, sem entulhar a principal (hoje: o revisor de autos `aft-revisor-autos` e a
 varredura do Sistema Auditor `aft-autos-lavrados`). Eles vêm no repositório em
@@ -340,6 +373,12 @@ que o AFT pedir.
 
 ## Passo 5b — Instalar o perfil do auditor (CLAUDE.md global)
 
+> **No Codex**, o arquivo é o mesmo (`~/.claude/CLAUDE.md`) — o que muda é que, logo
+> depois de gravá-lo, você cria o atalho que o Codex lê:
+> `ln -s ../.claude/CLAUDE.md ~/.codex/AGENTS.md` (Windows:
+> `mklink /H "%USERPROFILE%\.codex\AGENTS.md" "%USERPROFILE%\.claude\CLAUDE.md"`).
+> Sem ele, o Codex enxerga as skills mas trata o AFT como programador.
+
 O toolkit traz um perfil pronto que diz ao Claude, em toda conversa, quem é o usuário
 (um AFT, não um programador), como tratar dados sensíveis e quais skills usar. Ele vai
 em `~/.claude/CLAUDE.md`:
@@ -364,6 +403,10 @@ em `~/.claude/CLAUDE.md`:
 > mais preciso rodar `/aft-setup` de novo só para atualizar o CLAUDE.md).
 
 ## Passo 5c — Instalar a deny-list de segurança (settings.json)
+
+> **No Codex, pule este passo** — esse arquivo não é lido. Diga ao AFT, em uma frase, que
+> no Codex quem faz esse papel é o modo de aprovação/sandbox do próprio app, e que ele deve
+> **manter a aprovação por comando ligada**.
 
 O toolkit traz uma lista de **bloqueios de segurança** que impede o Claude de ler
 arquivos de credencial (`~/.ssh`, `~/.aws`, `.env`), de ler os mapas `.depara_*.json`
@@ -601,6 +644,9 @@ login único do Google, feito com segurança pela interface do Claude."*
 
 ## Passo 7e — Vigia de sessões (parte padrão da instalação)
 
+> **No Codex, pule este passo** — as sessões por empresa são do menu lateral do app do
+> Claude e não existem lá.
+
 As sessões por empresa no menu lateral (grupo "OS ATIVAS") são **automáticas**: um
 serviço em segundo plano — o **vigia de sessões** — observa as pastas de `OS ATIVAS/` e,
 toda vez que o app do Claude é fechado, cria as sessões que faltam (título = empresa,
@@ -617,6 +663,10 @@ resumo e siga (o `/aft-atualizar` tenta de novo). Quem não quiser o automático
 "remover o vigia de sessões" a qualquer momento.
 
 ## Passo 7e-bis — Gancho do diário de atividades (parte padrão da instalação)
+
+> **No Codex, pule este passo** — o gancho é um recurso do app do Claude. As skills
+> continuam registrando o diário sozinhas e o `/aft-diario` monta o mês igual; o que se
+> perde é só a anotação automática do dia quando o AFT edita um `memory.md` fora de skill.
 
 O **diário de atividades** registra, no `## Registro de atividades` de cada OS, os dias
 trabalhados e o tipo de atividade (letras A-F da tela 2.1 do RI — ver `/aft-diario` e a
@@ -658,6 +708,11 @@ fica na seção 'Pendências por auditoria' do painel."*
 ## Passo 8 — Resumo final
 
 Apresente:
+
+> **No Codex**, tire do resumo as linhas de agentes, proteção e sessões por empresa
+> (não foram instaladas) e troque a linha do perfil por: `👤 Perfil do auditor:
+> ~/.claude/CLAUDE.md (o Codex lê pelo atalho ~/.codex/AGENTS.md)`. Acrescente uma linha
+> só: `🔗 Atalhos do Codex: ~/.agents/skills e ~/.codex/AGENTS.md [ok]`.
 
 ```
 ✅ AFT Toolkit configurado!

--- a/arquitetura/arquitetura-simples.html
+++ b/arquitetura/arquitetura-simples.html
@@ -91,7 +91,8 @@
 
   <div class="oque">
     <p><b>O que é.</b> O AFT Toolkit é um conjunto de <b>skills</b> (roteiros especializados)
-    para o <b>Claude Code</b>, o assistente de IA da Anthropic que roda no seu computador.
+    para o <b>Claude Code</b>, o assistente de IA da Anthropic que roda no seu computador —
+    e também para o <b>Codex</b>, o assistente da OpenAI: as mesmas skills servem aos dois.
     Cada skill ensina a IA a executar uma tarefa da fiscalização do trabalho do jeito certo:
     registrar o relato da inspeção, enquadrar a irregularidade na NR e na ementa, redigir o
     auto de infração, gerar o TXT que o Sistema Auditor importa, analisar PGR, validar ponto
@@ -116,7 +117,9 @@
       <h3>Instale uma vez</h3>
       <div class="txt">Cria sua pasta de trabalho (<b>~/Documents/AFT</b>), grava seus dados
       de auditor (CIF, UORG), instala o seu perfil no Claude, as proteções de privacidade e
-      deixa o <b>painel</b> sempre ligado na sua máquina. Guiado, do início ao fim.</div>
+      deixa o <b>painel</b> sempre ligado na sua máquina. Guiado, do início ao fim.
+      Se você usa o <b>Codex</b>, ele cria também os dois atalhos que fazem o Codex enxergar
+      as mesmas skills e o mesmo perfil — nada é duplicado.</div>
       <div class="fala">"instala o AFT Toolkit para mim"</div>
       <div class="chips"><span class="chip c-laranja">/aft-setup</span></div>
     </div>

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -132,15 +132,15 @@
 
 <script>
 const ARCH = {
-  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code (Windows)",
+  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
   "repo": "github.com/ryckardo42/aft-toolkit",
-  "data": "2026-08-10",
-  "resumo": "Repositório de distribuição que transforma o Claude Code (app desktop, Windows) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega: 45 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+  "data": "2026-08-14",
+  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
   "stats": {
-    "skills": 45,
-    "scripts": 35,
+    "skills": 46,
+    "scripts": 40,
     "dados": 6,
-    "commit": "ver `git log -1` — atualizado em 10/08/2026"
+    "commit": "ver `git log -1` — atualizado em 14/08/2026"
   },
   "atores": [
     {
@@ -231,6 +231,10 @@ const ARCH = {
     {
       "who": "/aft-setup",
       "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
+    },
+    {
+      "who": "Codex: dois atalhos (opcional)",
+      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
     }
   ],
   "camadas": [
@@ -240,12 +244,12 @@ const ARCH = {
       "skills": [
         {
           "nome": "/aft-setup",
-          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det).",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
           "tech": "winget · pipx · uorgs.csv · model: sonnet"
         },
         {
           "nome": "/aft-doctor",
-          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada.",
+          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
           "tech": "aft_doctor.py · model: sonnet"
         },
         {
@@ -737,6 +741,10 @@ const ARCH = {
   ],
   "decisoes": [
     {
+      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+    },
+    {
       "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
       "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
     },
@@ -926,7 +934,8 @@ const ARCH = {
     "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
     "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
     "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real."
+    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
   ]
 };
 

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -1,13 +1,13 @@
 {
-  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code (Windows)",
+  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
   "repo": "github.com/ryckardo42/aft-toolkit",
-  "data": "2026-08-10",
-  "resumo": "Repositório de distribuição que transforma o Claude Code (app desktop, Windows) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega: 45 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+  "data": "2026-08-14",
+  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
   "stats": {
-    "skills": 45,
-    "scripts": 35,
+    "skills": 46,
+    "scripts": 40,
     "dados": 6,
-    "commit": "ver `git log -1` — atualizado em 10/08/2026"
+    "commit": "ver `git log -1` — atualizado em 14/08/2026"
   },
   "atores": [
     {
@@ -98,6 +98,10 @@
     {
       "who": "/aft-setup",
       "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
+    },
+    {
+      "who": "Codex: dois atalhos (opcional)",
+      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
     }
   ],
   "camadas": [
@@ -107,12 +111,12 @@
       "skills": [
         {
           "nome": "/aft-setup",
-          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det).",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
           "tech": "winget · pipx · uorgs.csv · model: sonnet"
         },
         {
           "nome": "/aft-doctor",
-          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada.",
+          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
           "tech": "aft_doctor.py · model: sonnet"
         },
         {
@@ -604,6 +608,10 @@
   ],
   "decisoes": [
     {
+      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+    },
+    {
       "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
       "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
     },
@@ -793,6 +801,7 @@
     "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
     "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
     "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real."
+    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
   ]
 }


### PR DESCRIPTION
O toolkit deixa de pressupor o Claude Code. A pasta física das skills continua sendo `~/.claude/skills` — é o caminho escrito dentro de 45 `SKILL.md` e 8 scripts — e o Codex enxerga a mesma pasta por dois atalhos:

| Atalho | Alvo | Sem ele |
|---|---|---|
| `~/.agents/skills` | `~/.claude/skills` | o Codex não encontra skill nenhuma |
| `~/.codex/AGENTS.md` | `~/.claude/CLAUDE.md` | o Codex acha as skills mas trata o AFT como programador |

**Atalho, nunca cópia:** o `sync_perfil.py` reescreve o `CLAUDE.md` por dentro (`open(caminho, "w")`), então o link se mantém em dia sozinho. Verificado numa `HOME` de mentira, com os dois links e a reescrita do perfil.

## O que entra

- **`COMO-INSTALAR.md`** — seção "Usando o toolkit no Codex" com os dois caminhos (quem já usa o Claude e quer os dois; quem começa do zero no Codex), a tabela "O que muda no dia a dia" e três linhas em "Problemas comuns".
- **`aft-setup`** — Passo 0 (descobre o assistente, cria os atalhos) e notas nos passos 2b, 5b, 5c, 7e, 7e-bis e no resumo final.
- **`aft-atualizar`** — pula 2f/2f-bis/2g no Codex e confere os atalhos.
- **`aft_doctor.py`** — deduz o assistente pelos rastros que o app deixa em `~/.claude` (`projects`, `.claude.json`, `statsig`, `history.jsonl`); acrescenta a checagem "Atalhos do Codex" (`os.path.samefile`, que enxerga symlink, junction e hardlink) e rebaixa a informativo agentes, deny-list e vigia de sessões quando não há sinal de uso do Claude Code. Quem usa os dois continua vendo os avisos.
- **`AGENTS.md`**, **`NOVIDADES.md`** e **`arquitetura/`** (json + as duas páginas HTML).

## Testes

`/aft-doctor` rodado em três `HOME` de mentira — só Codex (4 OK), os dois assistentes (4 avisos), só Claude (3 avisos, sem menção a Codex). O teste pegou um bug: os rastros eram lidos de `SKILLS_DIR.parent` e, num clone fora do lugar, o doutor concluía "só Codex" para quem usa os dois. Corrigido: rastros sempre de `HOME`.

## O que este PR não resolve

- O `model:` por skill continua ignorado no Codex (o AFT troca com `/model`).
- PDF anexado ao chat: 12 skills pressupõem leitura nativa; nenhuma foi adaptada.
- O `Artifact` do `/aft-painel` (publicar a página) não existe lá; o painel local continua.
- Nada foi testado numa instalação de Codex que não seja a do mantenedor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)