### PR TITLE
NR-24: saída enxuta na preparação e correção do efetivo com ponto de milhar

### DIFF
--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -7,6 +7,16 @@ rever tudo, basta abrir este arquivo.
 ---
 
 ## 15/08/2026
+<!-- commit: diario-auditoria-geral-DE -->
+
+**Diário de atividades: a `/aft-auditoria-geral` agora registra D e E juntos.**
+Quando ela roda, você analisou documentos/achados do empregador (letra D, análise fora
+do estabelecimento) e redigiu autos (letra E, elaboração de documentos) — o diário
+passa a anotar as duas de uma vez, como na tela do RI. As demais classificações
+continuam iguais: NAD, TN, gera-ai, e-mail e afins registram E; PGR, AET, laudo NR-12,
+jornada, acidente e dimensionamentos registram D.
+
+## 15/08/2026
 <!-- commit: analise-acidente-arvore-de-causas -->
 
 **A `/aft-analise-acidente` foi reescrita: agora ela segue de ponta a ponta o método da

--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -7,6 +7,36 @@ rever tudo, basta abrir este arquivo.
 ---
 
 ## 15/08/2026
+<!-- commit: nr24-saida-enxuta-e-vinculos-milhar -->
+
+**A NR-24 na preparação ficou direta: só o que é devido.** Ao planejar a ação fiscal, o
+dimensionamento das instalações sanitárias vinha com meia página de cenários hipotéticos
+("se houver poeira...", "se houver calor...") e uma lista de conferência de vestiário que
+empurrava os números para longe da vista. Agora, tanto na conversa quanto no
+`preparacao.docx` que você leva impresso:
+
+- **O quadro do que é devido vem primeiro e sozinho**: bacias, lavatórios, mictórios,
+  chuveiros e bebedouros, com o item da norma ao lado — a régua para contar no percurso
+  pelo estabelecimento. A memória de cálculo do mictório continua, porque é a conta que
+  ninguém faz de cabeça.
+- **Os quatro cenários de exposição viraram uma linha.** Antes da visita eles eram só
+  hipótese; confirmando em campo poeira, agente químico, esforço ou calor, é só pedir o
+  dimensionamento de novo com aquele cenário e o número sai exato, em vez de você
+  escolher numa tabela.
+- **O bloco de vestiário ficou nas medidas mínimas dos armários e na regra do
+  trancamento.** As três dispensas que a empresa costuma invocar (higienização diária,
+  guarda-volumes, escaninho) continuam na `/aft-nr24-dimensionamento`, que é onde se
+  decide o enquadramento.
+
+**Correção: empresa com mais de mil empregados ficava sem efetivo.** Ao ler a Relação de
+Vínculos Ativos do SFIT, o toolkit ignorava o total quando ele vinha com ponto de milhar
+("1.151") — justamente nas empresas grandes, onde o dimensionamento de SESMT e CIPA mais
+pesa, o número aparecia vazio. Corrigido: agora o efetivo é lido normalmente. Se a lista
+nominal vier truncada pelo SFIT ("listagem limitada aos primeiros 200 trabalhadores"), o
+aviso continua aparecendo para você confirmar em campo.
+
+
+## 15/08/2026
 <!-- commit: diario-auditoria-geral-DE -->
 
 **Diário de atividades: a `/aft-auditoria-geral` agora registra D e E juntos.**

--- a/aft-auditoria-geral/SKILL.md
+++ b/aft-auditoria-geral/SKILL.md
@@ -562,8 +562,10 @@ Para autos CLT art. 41 + art. 29:
 ## Diário de atividades (automático)
 
 Ao concluir o trabalho desta skill numa OS, registre o dia trabalhado no diário —
-sem perguntar nada ao AFT (o script deduplica por data+letra; repetir é inofensivo):
+sem perguntar nada ao AFT (o script deduplica por data+letra; repetir é inofensivo).
+São duas letras: **D** porque a skill analisa documentos/achados do empregador, **E**
+porque redige os autos:
 
 ```bash
-python ~/.claude/skills/_scripts/diario_registrar.py "<pasta da OS>" --tipos E --detalhe "via /aft-auditoria-geral"
+python ~/.claude/skills/_scripts/diario_registrar.py "<pasta da OS>" --tipos DE --detalhe "via /aft-auditoria-geral"
 ```

--- a/aft-nr24-dimensionamento/SKILL.md
+++ b/aft-nr24-dimensionamento/SKILL.md
@@ -64,10 +64,11 @@ python ~/.claude/skills/aft-nr24-dimensionamento/scripts/dimensionar_nr24.py \
 | `--frente-trabalho` | **frente de trabalho** da construção | aplica o item 18.5.7 da NR-18 |
 | `--json` | integração | saída só em JSON |
 
-**Sem os flags de exposição, o script devolve o cenário base E o que cada hipótese
-mudaria.** É esse o formato certo **antes da visita**, quando o AFT ainda não sabe
-o que vai encontrar: ele leva impresso o "se houver poeira, os lavatórios passam de
-7 para 14".
+**Sem os flags de exposição, o script entrega o cenário base** e uma linha de aviso
+lembrando que poeira, agente químico, esforço ou calor fazem subir lavatórios e
+chuveiros. É o formato certo **antes da visita**, quando ainda não se sabe o que se
+vai encontrar; confirmada a exposição em campo, roda-se de novo com o flag e o
+número sai exato — melhor do que carregar quatro cenários hipotéticos.
 
 ## Regra de ouro nº 2 — a base é o TURNO COM MAIOR CONTINGENTE
 
@@ -200,7 +201,7 @@ contagem de armários e devolve a obrigação do 24.4.8 no lugar.
 2. **Pergunte só o que muda o cálculo**, numa rodada só, e apenas quando o AFT
    estiver conferindo o que existe (uso fiscal): data de construção, exposição a
    agentes ou poeira, esforço/calor, uniforme, alojamento. **Antes da visita, não
-   pergunte nada disso** — rode sem os flags e entregue os cenários.
+   pergunte nada disso** — rode sem os flags e entregue o cenário base.
 3. **Execute o script.**
 4. **Apresente o resultado** no formato padrão abaixo, com a memória de cálculo.
 5. **Verificação fiscal** (o AFT conta o que existe no local): confronte item a
@@ -250,8 +251,9 @@ exatamente a divisão por sexo que a NR-24 exige, e ela já vem pronta do SFIT.
 
 Nesse uso:
 
-- rode **sem os flags de exposição** e entregue o cenário base + os cenários
-  condicionais: antes da visita ninguém sabe se há poeira ou troca de uniforme;
+- rode **sem os flags de exposição** e entregue o cenário base: antes da visita
+  ninguém sabe se há poeira ou troca de uniforme, e o script já avisa numa linha o
+  que a exposição mudaria;
 - deixe explícito que o número da Relação é o **efetivo total**, não o maior turno;
 - o resultado vai para o `preparacao.docx`, que o AFT leva impresso — o documento
   vira a régua para contar bacias, mictórios e bebedouros no percurso pelo

--- a/aft-nr24-dimensionamento/scripts/dimensionar_nr24.py
+++ b/aft-nr24-dimensionamento/scripts/dimensionar_nr24.py
@@ -662,21 +662,31 @@ def imprime_obra(r, aloj):
           "base exata — confirme o maior turno em campo.")
 
 
+def medida_curta(medida: str) -> str:
+    """De "0,40 m (altura) x 0,30 m (largura) x 0,40 m (profundidade)" para
+    "0,40x0,30x0,40 m" — a medida por extenso só cabe no .docx."""
+    n = [t for t in medida.replace("x", " ").split()
+         if "," in t and t[0].isdigit()]
+    return "x".join(n[:3]) + " m"
+
+
 def imprime_vestiario(v):
+    """Vestiário em três linhas: se é devido, quanto, e a medida do armário.
+
+    A checklist de campo (trancamento, uso rotativo, dispensas do 24.4) vive no
+    .docx que o AFT leva na visita — aqui ela só afasta o número da vista."""
     rotulo = {True: "SIM", False: "NÃO", None: "A VERIFICAR"}[v["exigido"]]
     print(f"VESTIÁRIO — exigido: {rotulo} ({v['motivo']})")
     if v["exigido"] is not False:
-        print(f"  Área mínima: {dec(v['area_minima_m2']['feminino'])} m² (feminino) · "
-              f"{dec(v['area_minima_m2']['masculino'])} m² (masculino)")
-    print(f"  Armários: {v['armarios']['feminino']} (feminino) · "
-          f"{v['armarios']['masculino']} (masculino)")
-    print(f"  Tipo: {v['tipo_armario']}")
-    print("  Dimensões mínimas (item 24.4.6 e 24.4.6.1):")
-    for nome, medida, item in v["dimensoes_minimas"]:
-        print(f"    · {nome}: {medida} [{item}]")
-    print("  A conferir em campo:")
-    for chk in v["verificacoes"]:
-        print(f"    · {chk}")
+        print(f"  Sendo devido: {dec(v['area_minima_m2']['feminino'])} m² (F) e "
+              f"{dec(v['area_minima_m2']['masculino'])} m² (M) · "
+              f"{v['armarios']['feminino']} armários (F) e "
+              f"{v['armarios']['masculino']} (M), individuais e com trancamento "
+              '(24.4.3 "e")')
+    medidas = " · ".join(
+        f"{' '.join(nome.replace('—', ' ').replace('divisão', ' ').split()).lower()}"        f" {medida_curta(medida)}"
+        for nome, medida, _ in v["dimensoes_minimas"])
+    print(f"  Armário (24.4.6 e 24.4.6.1): {medidas}")
     print()
 
 
@@ -695,52 +705,45 @@ def imprime_alojamento(aloj):
     print()
 
 
+def linha_quadro(rotulo, fem, masc, item):
+    print(f"  {rotulo:<38}{fem:>9}{masc:>11}   {item}")
+
+
 def imprime(r, aloj, cen):
+    """Quadro do que e devido, e so.
+
+    O AFT le isto para contar bacia, mictorio e bebedouro no percurso: o numero
+    tem de estar visivel de relance. Memoria de calculo so onde a conta nao e
+    obvia (mictorio progressivo); cenarios de exposicao viram uma linha, porque
+    antes da visita sao hipotese — confirmada alguma, roda-se de novo com o flag."""
     e = r["entrada"]
     construida = ("a partir de 24/09/2019" if e["construcao"] == "apos-24-09-2019"
                   else "até 23/09/2019")
-    print(f"NR-24 — dimensionamento para {e['total']} trabalhadores "
-          f"({e['homens']} homens, {e['mulheres']} mulheres)")
-    print(f"Base: turno com maior contingente (item 24.1.1) · estabelecimento "
-          f"construído {construida}")
-    print()
+    ins, lav, mic = r["instalacoes_sanitarias"], r["lavatorios"], r["mictorios"]
+    chu = r["chuveiros"]
 
-    ins = r["instalacoes_sanitarias"]
-    print("INSTALAÇÕES SANITÁRIAS (bacia sifonada com assento e tampo + lavatório)")
-    for linha in ins["memoria"]:
-        print(f"  · {linha}")
-    print(f"  Feminino: {ins['feminino']} bacia(s) sanitária(s)")
-    print(f"  Masculino: {ins['masculino']} bacia(s) sanitária(s)")
+    print(f"NR-24 — {e['total']} trabalhadores ({e['homens']} homens, "
+          f"{e['mulheres']} mulheres) · construído {construida}")
+    print("Base: turno com maior contingente (item 24.1.1)")
     print()
-
-    lav = r["lavatorios"]
-    print(f"LAVATÓRIOS — {lav['regra']}")
-    print(f"  Feminino: {lav['feminino']}   ·   Masculino: {lav['masculino']}")
+    print(f"  {'':<38}{'Feminino':>9}{'Masculino':>11}   Item")
+    linha_quadro("Bacias sanitárias (assento e tampo)", ins["feminino"],
+                 ins["masculino"], "24.2.1 e 24.2.2")
+    linha_quadro("Lavatórios", lav["feminino"], lav["masculino"], "24.2.1")
+    linha_quadro("Mictórios",
+                 "—", mic["exigidos"] if mic["exigidos"] is not None else "existir",
+                 "24.2.1.1")
+    linha_quadro("Chuveiros", chu["feminino"], chu["masculino"], "24.3.5")
+    linha_quadro("Bebedouros (total do turno)", "", r["bebedouros"]["quantidade"],
+                 "24.9.1.1")
     print()
-
-    mic = r["mictorios"]
-    print(f"MICTÓRIOS (instalação sanitária masculina) — {mic['regra']}")
     for linha in mic["memoria"]:
-        print(f"  · {linha}")
-    if mic["exigidos"] is not None:
-        print(f"  Masculino: {mic['exigidos']} mictório(s)")
-    else:
-        print("  Masculino: sem quantidade a apurar — exige-se a EXISTÊNCIA de "
-              "mictório, não uma proporção")
+        print(f"  {linha}")
     if mic["alerta"]:
         print(f"  !! {mic['alerta']}")
     print()
 
-    chu = r["chuveiros"]
-    print(f"CHUVEIROS — {chu['regra']}")
-    print(f"  Feminino: {chu['feminino']}   ·   Masculino: {chu['masculino']}")
-    print()
-
     imprime_vestiario(r["vestiario"])
-
-    print(f"BEBEDOUROS — {r['bebedouros']['regra']}")
-    print(f"  {r['bebedouros']['quantidade']} bebedouro(s) para o total de {e['total']}")
-    print()
 
     ref = r["local_refeicoes"]
     print(f"LOCAL PARA REFEIÇÕES — {ref['regime']}")
@@ -751,25 +754,10 @@ def imprime(r, aloj, cen):
         imprime_alojamento(aloj)
 
     if cen:
-        print("SE HOUVER EXPOSIÇÃO (o que muda) — confirmar em campo:")
-        for chave, d in cen.items():
-            if chave == "vestiario":
-                continue
-            lv = d["lavatorios"]
-            lv_txt = (f"lavatórios {lv['feminino']}F/{lv['masculino']}M"
-                      if isinstance(lv, dict) else "lavatórios sem alteração")
-            cv = d["chuveiros"]
-            print(f"  · {d['hipotese']}")
-            print(f"      {lv_txt} · chuveiros {cv['feminino']}F/{cv['masculino']}M "
-                  f"· armários: {d['armarios']}")
-        vv = cen["vestiario"]
-        print(f"  · {vv['hipotese']}")
-        print(f"      área mínima {dec(vv['area_minima_m2']['feminino'])} m² (F) e "
-              f"{dec(vv['area_minima_m2']['masculino'])} m² (M) · "
-              f"{vv['armarios']['feminino']} armários (F) e "
-              f"{vv['armarios']['masculino']} (M)")
-        print()
-
+        print("  !! Havendo exposição a agente infectante/químico, poeira que impregne "
+              "pele e roupas, esforço físico ou calor intenso, sobem os lavatórios e "
+              "passam a ser exigidos chuveiros (24.2.2.1 e 24.3.5). Confirmado em "
+              "campo, rode de novo com --agentes, --poeira ou --esforco-calor.")
     for a in r["avisos"]:
         print(f"  !! {a}")
     print("  !! O dimensionamento é do TURNO COM MAIOR CONTINGENTE (24.1.1). Se o "
@@ -827,8 +815,6 @@ def main():
             print(json.dumps(r, ensure_ascii=False, indent=2))
             return
         imprime_obra(r, aloj)
-        print()
-        print(json.dumps(r, ensure_ascii=False))
         return
 
     r = dimensionar(a.homens, a.mulheres, a.construcao, a.agentes, a.poeira,
@@ -846,8 +832,6 @@ def main():
         print(json.dumps(r, ensure_ascii=False, indent=2))
         return
     imprime(r, aloj, cen)
-    print()
-    print(json.dumps(r, ensure_ascii=False))
 
 
 if __name__ == "__main__":

--- a/aft-preparacao-acao-fiscal/SKILL.md
+++ b/aft-preparacao-acao-fiscal/SKILL.md
@@ -317,9 +317,10 @@ quantos bebedouros aquele local deve ter, e contar no percurso.
 
 1. **Chame a `/aft-nr24-dimensionamento`** com os homens e mulheres da Relação de Vínculos
    (ou informados pelo AFT). **Rode sem os flags de exposição**: antes da visita não se
-   sabe se há poeira, agente químico ou troca de uniforme, e a skill devolve, além do
-   cenário base, o que cada hipótese mudaria — é essa tabela condicional que serve em
-   campo. Não pergunte ao AFT sobre exposição, uniforme ou alojamento nesta fase.
+   sabe se há poeira, agente químico ou troca de uniforme. A skill devolve o cenário
+   base e uma linha lembrando o que a exposição mudaria; confirmada alguma em campo, o
+   dimensionamento se refaz com o flag e sai exato. Não pergunte ao AFT sobre
+   exposição, uniforme ou alojamento nesta fase.
 1b. **Sendo obra, é NR-18, não NR-24.** Em canteiro de obras a norma setorial prevalece e
    os números mudam bastante (chuveiro 1:10 em vez de 1:20, bebedouro 1:25 em vez de
    1:50, vestiário sempre obrigatório). Trate como obra quando o **CNAE for da seção F**
@@ -341,11 +342,11 @@ quantos bebedouros aquele local deve ter, e contar no percurso.
    vestiário) e alojamento (item 24.7, dimensionamento próprio).
 5. **Vestiário e armários entram como lembrete, não como pergunta.** O `.docx` traz um
    bloco "Vestiário e armários — o que conferir" com as medidas mínimas dos três tipos
-   de armário (item 24.4.6 e 24.4.6.1), a regra do uso rotativo e do trancamento, e as
-   três dispensas que a empresa costuma invocar (higienização diária, guarda-volumes e
-   escaninho do 24.4.8). **Não pergunte ao AFT** se há higienização diária ou
-   guarda-volumes na preparação: são fatos de campo. Os flags `--higienizacao-diaria` e
-   `--guarda-volumes` servem depois da visita, quando ele já sabe.
+   de armário (item 24.4.6 e 24.4.6.1) e a regra do trancamento. **Não pergunte ao AFT**
+   se há higienização diária ou guarda-volumes na preparação: são fatos de campo. Os
+   flags `--higienizacao-diaria` e `--guarda-volumes` servem depois da visita, quando
+   ele já sabe; as dispensas do 24.4.5.1, 24.4.7 e 24.4.8 estão detalhadas na
+   `/aft-nr24-dimensionamento`, que é onde se decide o enquadramento.
 
 Sem a divisão por sexo (o AFT deu só o total, sem Relação de Vínculos), **peça-a uma vez**;
 se ele não tiver, pule a fase e registre em `## Pendências` "Levantar homens e mulheres do
@@ -618,7 +619,7 @@ Próximos passos:
 
 - Chama `/aft-nova-auditoria` (FASE 1) para resolver/criar a OS — não duplica essa lógica.
 - Chama `/aft-cnae-grau-risco-nr04`, `/aft-dimensionamento-sesmt-nr04` e `/aft-cipa-nr05-dimensionamento` (FASE 3.5) para o grau de risco, o SESMT e a CIPA devidos — os cálculos são dos scripts delas, nunca de cabeça.
-- Chama `/aft-nr24-dimensionamento` (FASE 3.6) para as instalações sanitárias, mictórios, lavatórios e bebedouros devidos, a partir dos homens e mulheres da Relação de Vínculos — sem os flags de exposição, para que o documento de campo traga também os cenários condicionais. Sendo canteiro de obras (CNAE 41/42/43 ou "SPE" no nome), a mesma skill aplica a NR-18 no lugar da NR-24, e o `.docx` diz em que sinal se baseou.
+- Chama `/aft-nr24-dimensionamento` (FASE 3.6) para as instalações sanitárias, mictórios, lavatórios e bebedouros devidos, a partir dos homens e mulheres da Relação de Vínculos — sem os flags de exposição, com uma linha no documento sobre o que a exposição mudaria. Sendo canteiro de obras (CNAE 41/42/43 ou "SPE" no nome), a mesma skill aplica a NR-18 no lugar da NR-24, e o `.docx` diz em que sinal se baseou.
 - Trata a Relação de Vínculos Ativos do SFIT com o próprio `vinculos_ativos.py` (FASE 3.1), inteiramente local: nem o PDF nem a lista nominal entram no contexto do modelo.
 - Chama `/aft-relatorio-acidentes` (FASE 4.5) para o histórico de CATs do CNPJ — o script dela processa tudo localmente e grava em `Acidentes/`; a preparação usa só os agregados.
 - Usa a biblioteca `modelo_docx.py` (`/aft-modelo-docx`) para o `preparacao.docx` (FASE 7) — o padrão visual do toolkit, com o cabeçalho institucional da lotação do AFT.

--- a/aft-preparacao-acao-fiscal/scripts/preparacao_docx.py
+++ b/aft-preparacao-acao-fiscal/scripts/preparacao_docx.py
@@ -461,17 +461,11 @@ def bloco_vestiario(doc, vest, sempre_exigido=False):
     for nome, medida, item in vest["dimensoes_minimas"]:
         m.linha_dados(t, [nome, medida, item])
 
-    for chk in vest["verificacoes"]:
-        m.marcador(doc, chk)
-
     m.paragrafo(doc,
-                "Três dispensas que a empresa costuma invocar — e o que exigir de cada "
-                "uma: higienização diária das vestimentas ou vestimenta descartável "
-                "dispensa o armário DUPLO, mas não o simples (24.4.5.1); serviço de "
-                "guarda-volumes dispensa os armários (24.4.7); e estabelecimento "
-                "desobrigado de vestiário ainda deve garantir escaninho, gaveta com "
-                "tranca ou similar (24.4.8). Nenhuma delas se prova por declaração "
-                "verbal.")
+                "Todos os armários são individuais e com sistema de trancamento "
+                "(item 24.4.3 \"e\"): armário sem tranca não atende, ainda que "
+                "individual. Meça um de cada tipo — a irregularidade de dimensão é "
+                "frequente e só aparece com trena.")
 
 
 def secao_nr18(doc, n, nr18, vinc, motivo):
@@ -587,34 +581,19 @@ def secao_nr24(doc, n, nr24, vinc):
 
     cen = nr24.get("cenarios")
     if cen:
-        m.subtitulo(doc, "Se houver exposição — o que muda")
+        # Antes da visita a exposição é hipótese. A tabela dos quatro cenários
+        # ocupava meia página com números que só valem se confirmados em campo —
+        # confirmado algum, o dimensionamento se refaz com o flag correspondente.
         m.paragrafo(doc,
-                    "As proporções acima são o piso, sem exposição. Confirmado em campo "
-                    "qualquer dos cenários abaixo, o número sobe:")
-        tc = m.nova_tabela(doc, ["Se houver", "Lavatórios", "Chuveiros", "Armários"],
-                           larguras_cm=(6.4, 3.0, 3.0, 4.1))
-        rotulos = {
-            "exposicao_agentes": "Material infectante, substância tóxica, irritante "
-                                 "ou aerodispersóide que impregne pele e roupas",
-            "deposicao_de_poeiras": "Poeiras que impregnem pele e roupas",
-            "esforco_fisico_ou_calor_intenso": "Esforço físico ou calor intenso",
-        }
-        for chave, rotulo in rotulos.items():
-            d = cen[chave]
-            lv = d["lavatorios"]
-            lv_txt = (f"{lv['feminino']}F / {lv['masculino']}M"
-                      if isinstance(lv, dict) else "sem alteração")
-            cv = d["chuveiros"]
-            arm = ("duplos" if "dupl" in str(d["armarios"]) else "sem alteração")
-            m.linha_dados(tc, [rotulo, [lv_txt],
-                               [f"{cv['feminino']}F / {cv['masculino']}M"], [arm]])
-        v = cen["vestiario"]
-        m.paragrafo(doc,
-                    "Vestiário (item 24.4.1): obrigatório se houver troca de vestimenta "
-                    "ou uniforme trocado no local, ou se o estabelecimento tiver de "
-                    "disponibilizar chuveiro. Nesse caso, área mínima de "
-                    f"{m2(v['area_minima_m2']['feminino'])} m² (feminino) e "
-                    f"{m2(v['area_minima_m2']['masculino'])} m² (masculino).")
+                    "As proporções acima são o piso, sem exposição. Havendo agente "
+                    "infectante ou químico, poeira que impregne pele e roupas, esforço "
+                    "físico ou calor intenso, os lavatórios sobem e passam a ser "
+                    "exigidos chuveiros (24.2.2.1 e 24.3.5); e a troca de vestimenta ou "
+                    "uniforme no local obriga o vestiário (24.4.1), com área mínima de "
+                    f"{m2(cen['vestiario']['area_minima_m2']['feminino'])} m² (feminino) "
+                    f"e {m2(cen['vestiario']['area_minima_m2']['masculino'])} m² "
+                    "(masculino). Confirmado qualquer deles, refaça o dimensionamento "
+                    "pela /aft-nr24-dimensionamento com o cenário real.")
     else:
         m.paragrafo(doc,
                     f"Chuveiros: {chu['feminino']} (feminino) e {chu['masculino']} "

--- a/aft-preparacao-acao-fiscal/scripts/vinculos_ativos.py
+++ b/aft-preparacao-acao-fiscal/scripts/vinculos_ativos.py
@@ -63,9 +63,10 @@ ESPACO = 1.5        # lacuna (pt) que separa palavras — no PDF não há glifo 
 LINHA = 2.5         # tolerância vertical (pt) para agrupar caracteres na mesma linha
 
 RE_DATA = re.compile(r"^\d{2}/\d{2}/\d{4}$")
+# Numeros do quadro-resumo vem com ponto de milhar a partir de 1.000 ("1.151").
 RE_RESUMO = re.compile(
     r"^(A\s*partir\s*de\s*18|Abaixo\s*de\s*18|Total)\s+"
-    r"(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*$", re.I)
+    + r"\s+".join([r"([\d.]+)"] * 5) + r"\s*$", re.I)
 RE_CNPJ = re.compile(r"CNPJ/CPF:\s*([\d./-]{11,20})")
 RE_RAZAO = re.compile(r"Raz[ãa]o\s*Social:\s*(.+?)\s*$")
 RE_EMISSAO = re.compile(r"Data\s*de\s*Emiss[ãa]o:\s*(\d{2}/\d{2}/\d{4})")
@@ -169,10 +170,10 @@ def le_pdf(caminho: Path):
                 m = RE_RESUMO.match(texto)
                 if m:
                     faixa = sem_acento(m.group(1)).replace(" ", "_")
+                    n = [int(g.replace(".", "")) for g in m.groups()[1:]]
                     resumo[faixa] = {
-                        "homens": int(m.group(2)), "mulheres": int(m.group(3)),
-                        "pcd": int(m.group(4)), "aprendizes": int(m.group(5)),
-                        "aprendizes_pcd": int(m.group(6))}
+                        "homens": n[0], "mulheres": n[1], "pcd": n[2],
+                        "aprendizes": n[3], "aprendizes_pcd": n[4]}
                     continue
                 if RE_LIMITE.search(texto):
                     rodape.append(texto)


### PR DESCRIPTION
## O que muda para o AFT

**A NR-24 na preparação da ação fiscal ficou direta: só o que é devido.** O quadro de bacias, lavatórios, mictórios, chuveiros e bebedouros vem primeiro e sozinho — é a régua para contar no percurso pelo estabelecimento. Antes, meia página de cenários hipotéticos e uma checklist de vestiário empurravam o número para longe da vista.

- Os quatro cenários de exposição viraram **uma linha**. Confirmada em campo poeira, agente químico, esforço ou calor, refaz-se o dimensionamento com o flag correspondente e o número sai exato — melhor do que escolher numa tabela de hipóteses.
- O bloco de vestiário ficou nas **medidas mínimas dos armários e na regra do trancamento**. As três dispensas (24.4.5.1, 24.4.7 e 24.4.8) seguem na `/aft-nr24-dimensionamento`, que é onde se decide o enquadramento.
- A memória de cálculo do mictório permanece: é a conta que ninguém faz de cabeça.

Saída na tela: de ~60 para 24 linhas. Seção do `preparacao.docx`: de ~2 páginas para meia.

## Dois defeitos corrigidos

1. **Efetivo vazio em empresa grande.** O quadro-resumo da Relação de Vínculos Ativos traz ponto de milhar a partir de 1.000 (`1.151`), e a leitura só aceitava dígitos puros — justamente nas empresas onde o dimensionamento de SESMT e CIPA mais pesa, o efetivo não era lido. O aviso de lista truncada pelo SFIT continua.
2. **JSON repetido na saída legível.** O `dimensionar_nr24.py` imprimia todo o resultado em JSON ao fim da saída de texto, mesmo sem `--json` — metade do volume, sem uso. Quem precisa do dado estruturado (`preparacao_docx.py`) já invoca com a flag.

## Verificação

- Os 7 modos do `dimensionar_nr24.py` (base, obra, frente de trabalho, construção até 23/09/2019, exposição, alojamento, `--json`) rodam sem erro.
- `preparacao.docx` gerado de ponta a ponta em pasta de teste, a partir de uma Relação de Vínculos real de 1.306 empregados: seção da NR-24 renderiza correta e enxuta.
- Nenhum dado de empresa ou de trabalhador entra no repositório.
- As duas `SKILL.md` foram alinhadas: não sobrou promessa de tabela que não existe mais.
- `NOVIDADES.md` atualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)