### PR TITLE
fix(relatorio-acidentes): gravidade real no modo economico e obs. da CAT legiveis

### DIFF
--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -7,6 +7,37 @@ rever tudo, basta abrir este arquivo.
 ---
 
 ## 15/08/2026
+<!-- commit: relatorio-acidentes-gravidade-e-obs -->
+
+**O "relatório econômico" de acidentes agora traz mesmo os mais graves.** Quando a
+empresa tem muitas CATs, o relatório lista só os 25 acidentes mais graves. O critério
+de gravidade era a duração do tratamento declarada na CAT — só que o empregador
+preenche `0` na esmagadora maioria delas (numa usina com 266 CATs, 265 vieram com
+zero). Com todo mundo empatado em zero, "os 25 mais graves" acabava sendo "os 25 mais
+recentes": saíam cortes e escoriações da última safra, e ficavam de fora amputação,
+fraturas e queimaduras com internação de anos anteriores. Agora a ordem é a que
+importa na fiscalização: **óbito, depois internação, depois a natureza da lesão**
+(amputação, fratura, queimadura, corte, luxação) e só então a duração do tratamento.
+No mesmo caso real, 19 dos 25 acidentes listados mudaram — passaram a aparecer as 19
+CATs com internação hospitalar.
+
+**Duas informações novas em cada acidente e no resumo.** A CAT informa se houve
+internação, e isso não aparecia em lugar nenhum: agora o acidente com internação vem
+marcado, e o resumo diz quantas CATs tiveram internação. E onde o relatório dizia
+"Tratamento: Não informado", agora diz **"0 dias (assim declarado na CAT)"** — a
+diferença importa, porque o campo foi preenchido, com zero. O resumo também mostra em
+quantas CATs esse zero foi declarado: é um retrato de como a empresa preenche as
+comunicações de acidente.
+
+**O relato do acidente escrito pela empresa ficou legível.** As "Observações da CAT" —
+onde a empresa costuma narrar como o acidente ocorreu — vêm quase sempre em CAIXA ALTA
+do eSocial. O relatório passa a convertê-las para minúsculas; o texto digitado em
+caixa normal fica como está. A coluna existe nas planilhas de 2022 em diante (a de
+2021 não tem esse campo).
+
+---
+
+## 15/08/2026
 <!-- commit: nr24-saida-enxuta-e-vinculos-milhar -->
 
 **A NR-24 na preparação ficou direta: só o que é devido.** Ao planejar a ação fiscal, o

--- a/aft-relatorio-acidentes/SKILL.md
+++ b/aft-relatorio-acidentes/SKILL.md
@@ -169,8 +169,11 @@ Sai `CONTAGEM {"total": ..., "obitos": ..., "por_ano": {...}, ...}`.
 - **Total > 25** → mostre ao AFT os números (total, óbitos, distribuição por
   ano) e pergunte, **uma única vez**, como ele quer o relatório:
   1. **Completo** — todos os acidentes;
-  2. **Econômico** — só os **25 mais graves** (óbitos sempre entram; depois,
-     maior tempo de afastamento; empate vai para o mais recente). O resumo
+  2. **Econômico** — só os **25 mais graves**, nesta ordem: óbito; internação;
+     natureza da lesão (amputação, fratura, queimadura, corte,
+     luxação/distensão); maior duração de tratamento declarada; empate vai para
+     o mais recente. A duração do tratamento sozinha não ordena nada — o
+     empregador declara `0` na maior parte das CATs. O resumo
      estatístico continua cobrindo todos;
   3. **Recorte temporal** — só os acidentes a partir de um ano que ele escolher
      (a distribuição por ano ajuda: "desde 2024 são 18"). Pode combinar com o

--- a/aft-relatorio-acidentes/scripts/relatorio_acidentes.py
+++ b/aft-relatorio-acidentes/scripts/relatorio_acidentes.py
@@ -364,6 +364,7 @@ COLS_B = {  # campo do relatorio -> nome exato da coluna nas planilhas
     "municipio_a": "Município do local do acidente",
     "municipio_b": "UF do local do acidente",
     "tratamento": "Duração estimada do tratamento, em dias",
+    "internacao": "Indicativo de internação",
     "obs": "Observações da CAT",
     "obito": "Indicativo de óbito",
     "dt_obito": "Data do óbito",
@@ -614,6 +615,40 @@ def _dias_tratamento(r):
     return int(t) if t and so_digitos(t) == t else 0
 
 
+# A duracao do tratamento e declarada pelo empregador e vem 0 na maior parte das
+# CATs - sozinha nao ordena nada. Estes dois criterios vem da propria CAT e sao
+# preenchidos sempre: houve internacao, e qual a natureza da lesao.
+NATUREZA_GRAVIDADE = (
+    (r"amputa|enuclea", 5),
+    (r"fratura", 4),
+    (r"queimadura|escaldadura", 3),
+    (r"corte|lacera|punctura", 2),
+    (r"luxa|distens|tor[çc]", 1),
+)
+
+
+def _peso_natureza(r):
+    natureza = (r.get("lesao") or "").lower()
+    for padrao, peso in NATUREZA_GRAVIDADE:
+        if re.search(padrao, natureza):
+            return peso
+    return 0
+
+
+def _houve_internacao(r):
+    return (r.get("internacao") or "").strip().upper().startswith("S")
+
+
+def _obs_legivel(txt):
+    """As Observacoes da CAT quase sempre vem em CAIXA ALTA do eSocial, o que
+    cansa a leitura no meio do relatorio. Converte para minusculas quando as
+    maiusculas dominam; texto ja digitado em caixa mista fica como esta."""
+    letras = [c for c in txt if c.isalpha()]
+    if letras and sum(1 for c in letras if c.isupper()) / len(letras) >= 0.7:
+        return txt.lower()
+    return txt
+
+
 def _recorte_desde(registros, ano):
     """So acidentes com data valida >= 01/01/<ano>. Registro sem data nao tem
     como pertencer ao recorte - fica fora e e contado para o aviso."""
@@ -624,14 +659,14 @@ def _recorte_desde(registros, ano):
 
 
 def _selecao_economica(registros, n):
-    """Os n mais graves: obito sempre entra (e o acidente mais grave que
-    existe, mesmo sem dias de afastamento declarados); depois, maior tempo de
-    tratamento; empate decidido pelo mais recente. A lista escolhida volta em
-    ordem cronologica, como o resto do relatorio."""
+    """Os n mais graves, nesta ordem: obito; internacao; natureza da lesao
+    (amputacao > fratura > queimadura > corte > luxacao/distensao); maior tempo
+    de tratamento declarado; empate decidido pelo mais recente. A lista
+    escolhida volta em ordem cronologica, como o resto do relatorio."""
     def chave(r):
         d = _data(r.get("dt"))
-        return (not _eh_obito(r), -_dias_tratamento(r),
-                -(d.toordinal() if d else 0))
+        return (not _eh_obito(r), not _houve_internacao(r), -_peso_natureza(r),
+                -_dias_tratamento(r), -(d.toordinal() if d else 0))
     return _ordenar(sorted(registros, key=chave)[:n])
 
 
@@ -659,9 +694,13 @@ def _linhas_acidente(r):
     lesao += f" — CID: {_ou_ni(r.get('cid'))}"
     if r.get("complesao"):
         lesao += f' - "{r["complesao"]}"'
-    trat = r.get("tratamento")
-    trat = f"{trat} dias" if trat and so_digitos(trat) == trat and trat != "0" \
-        else _ou_ni("" if trat in ("", "0") else trat)
+    trat = (r.get("tratamento") or "").strip()
+    if trat == "0":
+        trat = "0 dias (assim declarado na CAT)"
+    elif trat and so_digitos(trat) == trat:
+        trat = f"{trat} dias"
+    else:
+        trat = _ou_ni(trat)
     pares = [
         ("Dia", _data_fmt(r.get("dt"))),
         ("Trabalhador", _ou_ni(r.get("trab"))),
@@ -674,10 +713,12 @@ def _linhas_acidente(r):
          (f"Município: {r['municipio']}" if r.get("municipio") else NAO_INFORMADO)),
         ("Tratamento", trat),
     ]
+    if _houve_internacao(r):
+        pares.append(("Internação", "Sim"))
     if _data(r.get("dt_obito")):
         pares.append(("Data do óbito", _data_fmt(r["dt_obito"])))
     if r.get("obs"):
-        pares.append(("Obs. CAT", r["obs"]))
+        pares.append(("Obs. CAT", _obs_legivel(r["obs"])))
     return pares
 
 
@@ -695,6 +736,9 @@ def _estatisticas(registros):
             if v:
                 cont[v] = cont.get(v, 0) + 1
         e[chave] = cont
+    e["internacoes"] = sum(1 for r in registros if _houve_internacao(r))
+    e["trat_zero"] = sum(1 for r in registros
+                         if (r.get("tratamento") or "").strip() == "0")
     if set(e["cats"]) <= {"Inicial"}:  # so vale a pena mostrar se ha reabertura etc.
         e["cats"] = {}
     return e
@@ -720,6 +764,11 @@ def gerar_md(caminho, empresa, cnpj14, registros, fonte, est):
           f"- Total de CATs: {est['total']}",
           f"- CATs com óbito: {est['obitos']}",
           f"- Período dos acidentes: {est['periodo']}"]
+    if est.get("internacoes"):
+        L.append(f"- CATs com internação: {est['internacoes']}")
+    if est.get("trat_zero"):
+        L.append(f"- Duração do tratamento declarada como 0 dia: "
+                 f"{est['trat_zero']} de {est['total']} CATs")
     if est["tipos"]:
         L.append("- Por tipo: " + " · ".join(f"{k}: {v}" for k, v in
                                              sorted(est["tipos"].items())))
@@ -762,6 +811,11 @@ def gerar_docx(caminho, empresa, cnpj14, registros, fonte, est):
     linhas = [("Total de CATs", str(est["total"])),
               ("CATs com óbito", str(est["obitos"])),
               ("Período dos acidentes", est["periodo"])]
+    if est.get("internacoes"):
+        linhas.append(("CATs com internação", str(est["internacoes"])))
+    if est.get("trat_zero"):
+        linhas.append(("Duração do tratamento declarada como 0 dia",
+                       f"{est['trat_zero']} de {est['total']} CATs"))
     if est["tipos"]:
         linhas.append(("Por tipo de acidente", " · ".join(
             f"{k}: {v}" for k, v in sorted(est["tipos"].items()))))
@@ -980,8 +1034,9 @@ def main():
     ap.add_argument("--desde", type=int, metavar="AAAA",
                     help="recorte temporal: so acidentes a partir de 01/01/AAAA")
     ap.add_argument("--limite", type=int, metavar="N",
-                    help="modo economico: lista so os N mais graves (obitos sempre; "
-                         "depois maior afastamento; empate = mais recente)")
+                    help="modo economico: lista so os N mais graves (obito, "
+                         "internacao, natureza da lesao, duracao do tratamento; "
+                         "empate = mais recente)")
     ap.add_argument("--auto-economico", action="store_true",
                     help=f"aplica --limite {LIMITE_ECONOMICO} sozinho quando ha mais que isso")
     ap.add_argument("--doencas", action="store_true",
@@ -1004,7 +1059,8 @@ def main():
         if base:
             origem = "aft-config.md" if cfg and cfg.is_dir() else "convenção <PASTA_AFT>/CATs"
             print(f"pasta_cats: {base}   [{origem}]")
-            print(f"planilhas: {len(list(base.glob('*.xlsx')))} .xlsx")
+            print("planilhas: %d .xlsx" % len(
+                [x for x in base.glob("*.xlsx") if not x.name.startswith("~$")]))
             if cfg and not cfg.is_dir():
                 print(f"AVISO: o aft-config.md aponta para uma pasta que não existe "
                       f"({cfg}) — ignorada em favor da convenção. Apague a linha "
@@ -1133,6 +1189,7 @@ def main():
         print("CONTAGEM " + json.dumps({
             "total": len(registros),
             "obitos": sum(1 for r in registros if _eh_obito(r)),
+            "internacoes": sum(1 for r in registros if _houve_internacao(r)),
             "por_ano": dict(sorted(anos.items())),
             "sem_data": sem_data,
             "limite_economico": LIMITE_ECONOMICO,
@@ -1170,9 +1227,10 @@ def main():
         listados = _selecao_economica(registros, limite)
         est["notas"].append(
             f"Modo econômico: a relação abaixo traz somente os {limite} acidentes "
-            f"mais graves (óbitos sempre incluídos; depois, maior tempo de "
-            f"afastamento; empate decidido pelo mais recente) de um total de "
-            f"{est['total']}. O resumo acima considera todos.")
+            f"mais graves de um total de {est['total']}, nesta ordem: óbito; "
+            f"internação; natureza da lesão (amputação, fratura, queimadura, "
+            f"corte, luxação/distensão); maior duração de tratamento declarada; "
+            f"empate decidido pelo mais recente. O resumo acima considera todos.")
 
     saida = Path(args.saida).expanduser()
     saida.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## O problema

O modo econômico do Relatório de Acidentes lista "os 25 mais graves". O critério de gravidade era a **duração do tratamento declarada na CAT** — só que o empregador preenche `0` na esmagadora maioria delas: num caso real (usina, 266 CATs), **265 vieram com zero**.

Com todos empatados em zero e sem óbitos, a ordenação caía no critério de desempate e **"os 25 mais graves" virava "os 25 mais recentes"**: entravam cortes e escoriações da última safra, e ficavam de fora a amputação, as fraturas e as 19 CATs com internação hospitalar.

## A correção

Nova ordem: **óbito → internação → natureza da lesão** (amputação, fratura, queimadura, corte, luxação/distensão) **→ duração do tratamento → mais recente**.

No mesmo caso real, **19 dos 25 acidentes listados mudaram** e a lista passou a cobrir 2022-2026 em vez de 2023/2025/2026.

## Também neste commit

- Mapeia a coluna **"Indicativo de internação"** (100% preenchida na base estadual, e até então ignorada): o acidente com internação vem marcado, e o resumo conta as internações.
- `Tratamento: Não informado` vira **`0 dias (assim declarado na CAT)`** quando a fonte traz 0 — o campo foi preenchido, com zero. O resumo mostra em quantas CATs isso ocorreu (sinal de qualidade do preenchimento do empregador).
- **"Observações da CAT"** — o relato de como o acidente ocorreu, escrito pela empresa — sai em minúsculas quando vem em CAIXA ALTA do eSocial; caixa mista é preservada. Medido em duas planilhas reais: **99,3% das 9.636 observações** são convertidas.
- `--mostrar-base` deixa de contar o arquivo de bloqueio do Excel (`~$*.xlsx`) como planilha.
- `SKILL.md` e `NOVIDADES.md` atualizados.

## Como foi testado

Base estadual de GO (6 planilhas, 2021-2026), CNPJ real de usina com 266 CATs:

| Verificação | Resultado |
|---|---|
| Seleção econômica antes × depois | 19 de 25 acidentes trocaram; as 19 internações entraram |
| Internação | 19 marcadas, batendo com a contagem na planilha |
| Tratamento declarado como 0 | 265 de 266 |
| Observações em minúsculas | 1/1 nesse CNPJ; 9.636 observações de 2023+2026: 99,3% convertidas, resto preservado em caixa mista |
| CPF nos relatórios gerados | 0 ocorrências (a skill não lê a coluna de CPF) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)