### PR TITLE
Validador do TXT: pega subtítulo e linha repetidos no texto do auto

### DIFF
--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -7,6 +7,29 @@ rever tudo, basta abrir este arquivo.
 ---
 
 ## 17/08/2026
+<!-- commit: validar-txt-subtitulo-duplicado -->
+
+**A conferência do TXT agora pega subtítulo repetido no texto do auto.** Apareceu num
+arquivo real: o texto do auto saiu com o subtítulo escrito **duas vezes seguidas** —
+"I - DA FISCALIZAÇÃO:" e, logo abaixo, "I - DA FISCALIZAÇÃO:" outra vez, e o mesmo com
+"II - IRREGULARIDADE:". Erro de forma bem visível no auto impresso, e a conferência
+automática deixou passar: dizia APROVADO, porque o Sistema Auditor de fato importa o
+arquivo assim mesmo.
+
+**O que muda.** A conferência que roda antes de entregar o TXT (a do `/aft-gera-ai`)
+passou a olhar o texto do auto e a **reprovar** quando: (a) qualquer um dos subtítulos
+— I - DA FISCALIZAÇÃO, II - IRREGULARIDADE, III - OBSERVAÇÕES, com ou sem acento —
+aparece mais de uma vez no mesmo auto; ou (b) uma linha qualquer se repete idêntica
+logo em seguida, que é o formato genérico desse mesmo defeito. Reprovado, o assistente
+é obrigado a corrigir e refazer o arquivo antes de te entregar.
+
+**E a causa.** A repetição nascia na hora em que o assistente copiava o auto já
+redigido para dentro do arquivo do Sistema Auditor: ele reescrevia o subtítulo que já
+estava no texto. A instrução do `/aft-gera-ai` ficou explícita nesse ponto — o
+subtítulo vem do texto de origem e não deve ser digitado de novo. A conferência
+continua como rede de segurança, para o caso de escapar.
+
+## 17/08/2026
 <!-- commit: cat-trabalhador-skill -->
 
 **Nova habilidade: o dossiê de CATs de um trabalhador (`/aft-cat-trabalhador`).** Até

--- a/_scripts/validar_txt.py
+++ b/_scripts/validar_txt.py
@@ -48,6 +48,63 @@ TOKEN = re.compile(r"\[\[[A-Z0-9_]+\]\]")
 # O mesmo PDF anexado a varios autos e permitido: pesa 1 vez no orcamento de cada um.
 LIMITE_ANEXOS_MB = 10.0
 
+# Subtitulos fixos do texto de autuacao (campo 18), no formato romano da /aft-gera-ai.
+# Defeito ja observado: o subtitulo sai DUPLICADO ("I - DA FISCALIZACAO:#13#10 . #13#10
+# I - DA FISCALIZACAO:"), porque foi digitado de novo ao transcrever o autos.md. E erro
+# de forma que aparece no auto impresso, entao reprova.
+SUBTITULO = re.compile(
+    r"\bI{1,3}\s*-\s*(?:DA\s+FISCALIZA[CÇ][AÃ]O|IRREGULARIDADE|"
+    r"OBSERVA[CÇ][OÕ]ES)\s*:")
+
+# Comprimento minimo para tratar linha repetida como defeito (evita alarme com "a)",
+# numeros soltos e outras linhas curtas que podem legitimamente se repetir).
+MIN_LINHA_REPETIDA = 10
+
+
+def sem_acento(v):
+    tab = str.maketrans("ÁÀÂÃÉÊÍÓÔÕÚÇ", "AAAAEEIOOOUC")
+    return (v or "").translate(tab)
+
+
+def chave_subtitulo(v):
+    """Normaliza o subtitulo para comparacao: sem acento, espacos colapsados."""
+    return re.sub(r"\s+", " ", sem_acento(v).upper()).strip()
+
+
+def checar_texto_autuacao(texto, rotulo, erros):
+    """Campo 18: subtitulo repetido e linha repetida logo em seguida."""
+    contagem = {}
+    for m in SUBTITULO.finditer(texto):
+        k = chave_subtitulo(m.group(0))
+        contagem[k] = contagem.get(k, 0) + 1
+    for k, n in sorted(contagem.items()):
+        if n > 1:
+            erros.append(f"{rotulo} -> Erro: o subtitulo '{k}' aparece {n} vezes no texto "
+                         f"do auto (campo 18); deve aparecer UMA unica vez. Duplicado, ele "
+                         f"sai repetido no auto impresso. Apague a repeticao no "
+                         f".tokenized.txt e rode indenta_quebras.py + rehydrate.py de novo.")
+
+    # Padrao generico do mesmo erro: a linha volta identica logo depois, seja colada,
+    # seja separada so pelo marcador de linha em branco `#13#10 . #13#10`.
+    seg = [s.strip() for s in texto.split("#13#10")]
+    ja_visto = set()
+    for i, a in enumerate(seg[:-1]):
+        if len(a) < MIN_LINHA_REPETIDA or a == "." or a in ja_visto:
+            continue
+        if seg[i + 1] == a:
+            sep = "coladas"
+        elif i + 2 < len(seg) and seg[i + 1] == "." and seg[i + 2] == a:
+            sep = "separadas so por `#13#10 . #13#10`"
+        else:
+            continue
+        ja_visto.add(a)
+        if SUBTITULO.fullmatch(a):
+            continue  # ja reportado como subtitulo duplicado
+        trecho = a if len(a) <= 60 else a[:60] + "..."
+        erros.append(f"{rotulo} -> Erro: linha repetida duas vezes seguidas no texto do "
+                     f"auto (campo 18), {sep}: \"{trecho}\". Apague a repeticao no "
+                     f".tokenized.txt e rode indenta_quebras.py + rehydrate.py de novo.")
+
 
 def is_filled(v):
     """Campo preenchido: nao-vazio ou contendo token (sera re-hidratado)."""
@@ -167,6 +224,9 @@ def main():
                 if not re.fullmatch(r"\d{7}", cod3):
                     erros.append(f"{rotulo} -> Erro: codigo de ementa '{cod3}' invalido "
                                  f"(esperado 7 digitos, ementa sem hifen).")
+            # Texto do auto (campo 18): subtitulo/linha duplicados.
+            if len(campos) > 17:
+                checar_texto_autuacao(campos[17], rotulo, erros)
 
         elif tipo == "2":
             rotulo = (f"AI CNPJ/CPF:{bloco_atual[0]} Ementa:{bloco_atual[1]}"
@@ -260,7 +320,8 @@ def main():
         for a in avisos:
             print("  - " + a)
     if erros:
-        print(f"\nERROS ({len(erros)}) - o Sistema Auditor recusaria a importacao:")
+        print(f"\nERROS ({len(erros)}) - o Sistema Auditor recusaria a importacao "
+              f"ou o auto sairia com defeito de forma:")
         for e in erros:
             print("  X " + e)
         print("\nRESULTADO: REPROVADO. Corrija os erros acima antes de importar.")

--- a/aft-gera-ai/SKILL.md
+++ b/aft-gera-ai/SKILL.md
@@ -404,6 +404,11 @@ Linhas separadas por `\n`.
 - `[TAB]` = caractere literal `\t`.
 - `[texto_autuacao]` é uma **única linha contínua** (sem `\n` reais). Use `#13#10` como comando de quebra de linha:
   - **Subtítulos em algarismos romanos com hífen**: `I - DA FISCALIZAÇÃO:`, `II - IRREGULARIDADE:`, `III - OBSERVAÇÕES:`.
+  - **Cada subtítulo aparece UMA única vez.** Ao transcrever o `autos.md` para o
+    `[texto_autuacao]`, o subtítulo **já vem no texto de origem**: copie-o como está e
+    **não o escreva de novo** antes do corpo da seção. Subtítulo digitado duas vezes sai
+    duplicado no auto impresso (`I - DA FISCALIZAÇÃO:#13#10 . #13#10I - DA FISCALIZAÇÃO:`)
+    — defeito de forma que o `validar_txt.py` reprova no Passo 6.
   - **Após CADA subtítulo**: `#13#10 . #13#10` (o subtítulo fica sozinho na linha; a linha com `.` é o "espaço em branco" — o Sistema Auditor não entende linha vazia).
   - **Separador de seção** (entre o fim de uma seção e o subtítulo seguinte): `#13#10 . #13#10`
   - **Separador de parágrafo** (dentro de um subtítulo): `#13#10`
@@ -461,7 +466,7 @@ linha 6 (CIF)
      "$DIR/AI_[NUM_AUTOS]_[CNPJ].txt"
    ```
    O script aborta (sem gerar o TXT) se faltar valor no de-para, se algum CPF não tiver 11 dígitos, se sobrar token órfão `[[...]]`, ou se houver caractere fora do latin-1. Se abortar, corrija a causa e rode de novo — **não** preencha o TXT à mão.
-6. **VALIDAÇÃO PRÉ-IMPORTAÇÃO (obrigatória).** Antes de entregar o arquivo ao AFT, rode o validador sobre o TXT real — ele pega em segundos os erros que, de outro modo, só apareceriam como "AI RECUSADO" dentro do Sistema Auditor (CEP vazio, nº de campos errado, ementa malformada, identificador com dígitos errados, anexo inexistente, **anexos de um auto somando mais de 10 MB**, caractere fora do latin-1):
+6. **VALIDAÇÃO PRÉ-IMPORTAÇÃO (obrigatória).** Antes de entregar o arquivo ao AFT, rode o validador sobre o TXT real — ele pega em segundos os erros que, de outro modo, só apareceriam como "AI RECUSADO" dentro do Sistema Auditor (CEP vazio, nº de campos errado, ementa malformada, identificador com dígitos errados, anexo inexistente, **anexos de um auto somando mais de 10 MB**, caractere fora do latin-1) — e também o **subtítulo ou a linha repetidos** no texto do auto (campo 18), que o Sistema Auditor aceitaria mas sairiam duplicados no auto impresso:
    ```bash
    python ~/.claude/skills/_scripts/validar_txt.py "$DIR/AI_[NUM_AUTOS]_[CNPJ].txt"
    ```


### PR DESCRIPTION
## Problema

Apareceu em arquivo real: o texto de autuação (campo 18) saiu com o subtítulo escrito **duas vezes seguidas** — `I - DA FISCALIZAÇÃO:#13#10 . #13#10I - DA FISCALIZAÇÃO:` —, porque foi digitado de novo ao transcrever o `autos.md`, quando o subtítulo **já vem no texto de origem**.

O Sistema Auditor aceita o arquivo. O defeito só aparece no **auto impresso**, quando já é tarde.

## Solução

O `validar_txt.py` passa a reprovar, no campo 18:

- **subtítulo romano repetido** (`I - DA FISCALIZAÇÃO`, `II - IRREGULARIDADE`, `III - OBSERVAÇÕES`), comparado sem acento e com espaços normalizados;
- **qualquer linha repetida duas vezes seguidas**, coladas ou separadas só pelo marcador de linha em branco `#13#10 . #13#10`. Linhas com menos de 10 caracteres ficam de fora, para não dar alarme com `a)` e números soltos.

A `/aft-gera-ai` passa a avisar na origem: ao transcrever o `autos.md`, copiar o subtítulo como está e não escrevê-lo de novo antes do corpo da seção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)