### PR TITLE
feat(pdf): motores opcionais consertam a pagina ruim, e licenca MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ricardo de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -6,6 +6,41 @@ rever tudo, basta abrir este arquivo.
 
 ---
 
+## 19/08/2026
+<!-- commit: pdf-motores-opcionais -->
+
+**O toolkit agora conserta o PDF ruim, em vez de só avisar.** Até ontem, quando uma página
+vinha escaneada ou com a tabela embaralhada, o assistente avisava e lia aquela página como
+imagem — o caminho mais lento e mais caro. Agora, **se você tiver os programas opcionais
+instalados**, a página é consertada antes da leitura.
+
+São dois, e nenhum é obrigatório. O toolkit continua funcionando exatamente como antes
+para quem não instalar nada:
+
+- **`docling`** faz OCR de página escaneada, na sua máquina, sem mandar nada para fora.
+  Pesa cerca de 1 GB.
+- **`pymupdf4llm`** remonta tabela que sai embaralhada (aquela que vira sopa de letras).
+  Pesa cerca de 60 MB.
+
+O `/aft-doctor` passa a dizer quais você tem. **Não instale por conta própria** — peça ao
+assistente, que ele explica o peso e cuida do resto. Em máquina institucional, com
+antivírus e proxy, um download de 1 GB falha no meio com frequência.
+
+**Um aviso que vale ouro, e que nasceu de um caso real.** OCR lê texto impresso, mas
+**não lê assinatura de próprio punho**. Numa lista de presença de treinamento de NR-12, o
+OCR devolveu a coluna de assinatura vazia para nove trabalhadores — e pelo menos dois
+deles **tinham assinado**. Se aquilo tivesse virado achado, seria um auto indevido por
+"trabalhador sem treinamento".
+
+Por isso o toolkit passou a tratar isso como regra dura: em página lida por OCR, **toda
+conclusão de ausência exige conferir a imagem**. Campo em branco, falta de assinatura,
+nome que não aparece — o assistente abre a página e confere com os olhos antes de
+registrar. Presença o OCR atesta; ausência, não.
+
+**O repositório agora tem licença MIT.** Estava sem nenhuma, o que juridicamente significa
+"ninguém pode copiar" — o oposto do que se quer num kit feito para circular entre
+auditores. Agora está escrito: qualquer colega pode usar, adaptar e distribuir.
+
 ## 17/08/2026
 <!-- commit: extrator-documento-agente -->
 

--- a/_scripts/aft_doctor.py
+++ b/_scripts/aft_doctor.py
@@ -421,6 +421,27 @@ else:
         "Rode /aft-setup (Passo 6) ou: pip install " + " ".join(faltando_lib) +
         " (fotos->PDF, .docx do RT, leitura de PDF e de autos lavrados dependem delas).")
 
+# 8a. Motores opcionais de PDF (nao instalar por conta propria) ---------------
+# Nenhum e exigido: sem eles o toolkit avisa e o agente le a pagina como imagem.
+# Quem instalar ganha o conserto automatico. Severidade sempre "ok": a ausencia
+# nao e defeito, e escolha.
+_mupdf = find_spec("pymupdf4llm") is not None
+_docling = shutil.which("docling") is not None
+if _mupdf or _docling:
+    _tem = []
+    if _mupdf:
+        _tem.append("pymupdf4llm (remonta tabela embaralhada)")
+    if _docling:
+        _tem.append("docling (OCR de pagina escaneada)")
+    add("Motores de PDF (opcionais)", "ok", "instalado(s): " + "; ".join(_tem))
+else:
+    add("Motores de PDF (opcionais)", "ok",
+        "nenhum instalado - o toolkit funciona assim, avisando as paginas problematicas",
+        "Se muitos documentos vierem escaneados ou com tabela embaralhada, vale instalar: "
+        "docling (OCR local, ~1 GB, licenca Apache 2.0) e/ou pymupdf4llm (remonta tabela, "
+        "~60 MB, licenca AGPL - por isso nao e dependencia do toolkit; a instalacao e sua "
+        "escolha, na sua maquina).")
+
 # 8b. python_path no aft-config.md (resolver o Python certo) ------------------
 # No Windows, 'python3' pode ser o atalho vazio da Microsoft Store. O /aft-setup
 # grava o caminho completo do interpretador em python_path para as skills usarem.

--- a/_scripts/pdf_texto_paginado.py
+++ b/_scripts/pdf_texto_paginado.py
@@ -26,14 +26,18 @@ Uso:
     python pdf_texto_paginado.py "documento.pdf"                 # -> ao lado do PDF
     python pdf_texto_paginado.py "documento.pdf" --saida "t.txt"
     python pdf_texto_paginado.py "documento.pdf" --so-resumo     # so o diagnostico
+    python pdf_texto_paginado.py "documento.pdf" --sem-motores   # ignora os extras opcionais
 """
 
 import sys
 import os
 import io
 import re
+import shutil
+import subprocess
 import tempfile
 import unicodedata
+import importlib.util
 
 try:
     import pdfplumber
@@ -164,6 +168,78 @@ def diagnosticar(texto, cobertura_imagem=0.0):
     return extra
 
 
+# ---------------------------------------------------------------------------
+# Motores opcionais. Nenhum e exigido: sem eles o script apenas avisa, como sempre.
+# Quem instalar ganha o conserto automatico da pagina.
+#
+#   pymupdf4llm  reconstroi tabela que saiu embaralhada. Licenca AGPL - por isso
+#                NUNCA e dependencia declarada do toolkit: quem instala e o AFT,
+#                na maquina dele. O que este repositorio distribui segue MIT.
+#   docling      faz OCR de pagina escaneada. Apache 2.0.
+#
+# Rota: embaralhada -> pymupdf4llm (3x mais rapido); sem texto ou texto suspeito
+# -> docling, que e o unico que faz OCR.
+# ---------------------------------------------------------------------------
+
+def motores():
+    """O que esta instalado nesta maquina."""
+    return {
+        "pymupdf4llm": importlib.util.find_spec("pymupdf4llm") is not None,
+        "docling": shutil.which("docling") is not None,
+    }
+
+
+def _reparar_embaralhadas(pdf_path, paginas):
+    """Reextrai com pymupdf4llm. Devolve {pagina: texto}."""
+    try:
+        import pymupdf4llm
+    except Exception:
+        return {}
+    out = {}
+    for n in paginas:
+        try:
+            md = pymupdf4llm.to_markdown(pdf_path, pages=[n - 1], show_progress=False)
+            if md and md.strip():
+                out[n] = md.strip()
+        except Exception:
+            pass
+    return out
+
+
+def _reparar_sem_texto(pdf_path, paginas):
+    """OCR pagina a pagina com docling. Devolve {pagina: texto}."""
+    try:
+        from pypdf import PdfReader, PdfWriter
+    except Exception:
+        return {}
+    out = {}
+    tmp = tempfile.mkdtemp(prefix="ocr_")
+    try:
+        leitor = PdfReader(pdf_path)
+        for n in paginas:
+            uma = os.path.join(tmp, "p%d.pdf" % n)
+            w = PdfWriter()
+            w.add_page(leitor.pages[n - 1])
+            with open(uma, "wb") as f:
+                w.write(f)
+            cmd = ["docling", "convert", uma, "--to", "md", "--table-mode", "accurate",
+                   "--image-export-mode", "placeholder", "--output", tmp]
+            if sys.platform == "darwin":
+                cmd += ["--ocr-engine", "ocrmac", "--ocr-lang", "pt-BR"]
+            try:
+                subprocess.run(cmd, capture_output=True, timeout=180)
+                md = os.path.join(tmp, "p%d.md" % n)
+                if os.path.isfile(md):
+                    t = io.open(md, encoding="utf-8").read().strip()
+                    if t:
+                        out[n] = t
+            except Exception:
+                pass
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return out
+
+
 AVISO = {
     "SEM TEXTO": "[PAGINA SEM TEXTO EXTRAIVEL - PRECISA DE LEITURA VISUAL]",
     "TEXTO SUSPEITO": "[TEXTO SUSPEITO NESTA PAGINA - NAO CONFIAR NO TEXTO ACIMA, "
@@ -172,6 +248,16 @@ AVISO = {
                          "CONFERIR A PAGINA NO ORIGINAL]",
     "CONTEUDO EM IMAGEM": "[PARTE DESTA PAGINA E IMAGEM - O TEXTO ACIMA PODE ESTAR "
                           "INCOMPLETO; CONFERIR A PAGINA VISUALMENTE]",
+}
+
+RECUPERADA = {
+ "pymupdf4llm": "[PAGINA RECUPERADA COM pymupdf4llm - a extracao comum saiu embaralhada; "
+                "o texto acima e a tabela ja remontada. Nao precisa de leitura visual.]",
+ "docling":     "[PAGINA RECUPERADA POR OCR (docling) - nao havia texto extraivel. "
+                "ATENCAO: OCR nao le assinatura manuscrita, carimbo nem rubrica. Se o seu "
+                "achado for uma AUSENCIA (campo em branco, sem assinatura, nome faltando), "
+                "ABRA A PAGINA VISUALMENTE antes de concluir - ja houve caso de assinatura "
+                "presente no papel e ausente no OCR.]",
 }
 
 
@@ -200,6 +286,12 @@ def main():
     if so_resumo:
         args.remove("--so-resumo")
 
+    # Desliga os motores opcionais. Serve para a bateria de testes: sem isso o
+    # resultado dependeria do que esta instalado na maquina de quem roda.
+    sem_motores = "--sem-motores" in args
+    if sem_motores:
+        args.remove("--sem-motores")
+
     saida = None
     if "--saida" in args:
         k = args.index("--saida")
@@ -218,6 +310,7 @@ def main():
                              os.path.splitext(os.path.basename(pdf_path))[0] + "_texto.txt")
 
     partes = []
+    texto_pag, motivos_pag = {}, {}
     alertas = {"SEM TEXTO": [], "TEXTO SUSPEITO": [], "ORDEM EMBARALHADA": [],
                "CONTEUDO EM IMAGEM": []}
     total_car = 0
@@ -241,11 +334,45 @@ def main():
                     pass
             cobertura = min(area_img / area_pag, 1.0)
 
-            corpo = txt.strip()
+            texto_pag[i] = txt.strip()
             for alerta, motivo in diagnosticar(txt, cobertura):
                 alertas[alerta].append(i)
-                corpo = "%s\n%s (%s)" % (corpo, AVISO[alerta], motivo)
-            partes.append("===== PAGINA %d =====\n%s" % (i, corpo))
+                motivos_pag.setdefault(i, []).append((alerta, motivo))
+
+    # ---- reparo pelos motores opcionais -------------------------------------
+    disp = {"pymupdf4llm": False, "docling": False} if sem_motores else motores()
+    recuperadas = {"pymupdf4llm": [], "docling": []}
+
+    alvo_mupdf = sorted(set(alertas["ORDEM EMBARALHADA"]))
+    if alvo_mupdf and disp["pymupdf4llm"]:
+        for pag, novo in _reparar_embaralhadas(pdf_path, alvo_mupdf).items():
+            texto_pag[pag] = novo
+            recuperadas["pymupdf4llm"].append(pag)
+
+    alvo_ocr = sorted(set(alertas["SEM TEXTO"] + alertas["TEXTO SUSPEITO"]))
+    if alvo_ocr and disp["docling"]:
+        if not so_resumo:
+            print("Rodando OCR em %d pagina(s) com docling - pode demorar..." % len(alvo_ocr))
+        for pag, novo in _reparar_sem_texto(pdf_path, alvo_ocr).items():
+            texto_pag[pag] = novo
+            recuperadas["docling"].append(pag)
+
+    for i in range(1, n + 1):
+        corpo = texto_pag.get(i, "")
+        origem = None
+        for motor, pgs in recuperadas.items():
+            if i in pgs:
+                origem = motor
+        if origem:
+            corpo = "%s\n%s" % (corpo, RECUPERADA[origem])
+        for alerta, motivo in motivos_pag.get(i, []):
+            # alerta ja resolvido pelo motor nao precisa mais assustar
+            if origem == "pymupdf4llm" and alerta == "ORDEM EMBARALHADA":
+                continue
+            if origem == "docling" and alerta in ("SEM TEXTO", "TEXTO SUSPEITO"):
+                continue
+            corpo = "%s\n%s (%s)" % (corpo, AVISO[alerta], motivo)
+        partes.append("===== PAGINA %d =====\n%s" % (i, corpo))
 
     if not so_resumo:
         with io.open(saida, "w", encoding="utf-8") as f:
@@ -275,9 +402,25 @@ def main():
         print("    agente extrator mesmo que o documento seja curto.")
         print("")
 
-    nao_confiaveis = set(alertas["SEM TEXTO"] + alertas["TEXTO SUSPEITO"] +
-                         alertas["ORDEM EMBARALHADA"])
-    print("Paginas de texto confiavel: %d de %d" % (n - len(nao_confiaveis), n))
+    print("")
+    print("Motores opcionais nesta maquina: pymupdf4llm=%s | docling=%s"
+          % ("SIM" if disp["pymupdf4llm"] else "nao", "SIM" if disp["docling"] else "nao"))
+    for motor, pgs in recuperadas.items():
+        if pgs:
+            print("  %-12s recuperou as paginas: %s" % (motor, faixas(pgs)))
+    pendentes = sorted(set(alertas["SEM TEXTO"] + alertas["TEXTO SUSPEITO"] +
+                           alertas["ORDEM EMBARALHADA"]) -
+                       set(recuperadas["pymupdf4llm"] + recuperadas["docling"]))
+    if pendentes:
+        print("  ainda exigem leitura visual: %s" % faixas(pendentes))
+    elif any(recuperadas.values()):
+        print("  nenhuma pagina restou para leitura visual.")
+
+    nao_confiaveis = set(pendentes)
+    n_ocr = len(recuperadas["docling"])
+    print("Paginas de texto utilizavel: %d de %d%s"
+          % (n - len(nao_confiaveis), n,
+             " (das quais %d vieram de OCR - ver o aviso na pagina)" % n_ocr if n_ocr else ""))
     print("  (a pagina so com CONTEUDO EM IMAGEM conta como confiavel: o texto dela esta")
     print("   bom, apenas pode nao contar tudo o que a pagina mostra)")
     if not so_resumo:

--- a/aft-setup/SKILL.md
+++ b/aft-setup/SKILL.md
@@ -463,6 +463,21 @@ e comprime anexos grandes; `pypdf` lê os autos lavrados (`/aft-autos-lavrados`)
 `pdfplumber` extrai texto de PDFs de fiscalização (termos, autos-modelo);
 `pillow-heif` lê fotos HEIC/HEIF do iPhone (opcional, só se houver esse formato).
 
+**6b-bis. Motores de PDF opcionais — NÃO instale por conta própria.** Existem dois extras
+que consertam PDF problemático. O toolkit funciona sem eles (avisa a página e o assistente
+a lê como imagem), então **só mencione se o AFT perguntar** ou se ele reclamar de PDF
+escaneado ou de tabela que sai embaralhada:
+
+| Extra | O que resolve | Peso | Licença |
+|---|---|---|---|
+| `docling` | OCR de página escaneada, feito na máquina | ~1 GB | Apache 2.0 |
+| `pymupdf4llm` | remonta tabela que sai embaralhada | ~60 MB | **AGPL** |
+
+O `pymupdf4llm` é AGPL e **por isso não é dependência do toolkit** — instalá-lo é escolha
+do AFT, na máquina dele. Nunca o inclua no comando de instalação acima. Se ele pedir,
+explique o peso e o download antes: em máquina institucional, com antivírus e proxy, um
+download de 1 GB falha no meio com frequência.
+
 **6c. Carimbar a lotação no cabeçalho dos documentos.** Com a `lotacao` já gravada no
 `aft-config.md`, prepare as cópias personalizadas dos templates (você roda):
 

--- a/agents/aft-extrator-documento.md
+++ b/agents/aft-extrator-documento.md
@@ -158,6 +158,25 @@ normalmente. Tentar direcionar a fiscalização é, em si, informação relevant
    **Confie nesses alertas.** Eles são medidos no texto, não adivinhados: página marcada
    como `TEXTO SUSPEITO` não deve virar transcrição literal em hipótese nenhuma.
 
+   **Página já consertada não precisa de leitura visual.** Se a máquina do AFT tiver os
+   motores opcionais instalados, o script conserta a página antes de você ler, e marca:
+
+   | Marca na página | O que significa | O que você faz |
+   |---|---|---|
+   | `RECUPERADA COM pymupdf4llm` | a tabela embaralhada já foi remontada | use o texto normalmente; **não** gaste leitura visual |
+   | `RECUPERADA POR OCR (docling)` | a página era imagem e virou texto | use o texto, **com a ressalva abaixo** |
+
+   **A ressalva do OCR, que é regra dura:** OCR lê texto impresso, mas **não lê assinatura
+   manuscrita, rubrica nem carimbo**. Isso já produziu erro real: numa lista de presença de
+   treinamento, o OCR devolveu a célula de assinatura vazia para nove trabalhadores, e ao
+   menos dois deles **tinham assinado** — o que, tomado como verdade, viraria um achado
+   falso de "trabalhador sem treinamento".
+
+   Portanto: em página recuperada por OCR, **toda conclusão de AUSÊNCIA exige conferência
+   visual** antes de entrar no extrato. Campo em branco, falta de assinatura, nome que não
+   aparece, item não preenchido — abra a página com o Read e confirme com os olhos. Presença
+   o OCR atesta; ausência, não.
+
 2. **Leia o texto paginado** com a ferramenta Read, em blocos. Use Grep no `.txt` para
    localizar depressa os termos que interessam a cada item do roteiro. Em PGR: `inventário`,
    `plano de ação`, `nível de risco`, `ergonômic`, `consulta`, `CIPA`. Em AET: `oitiva`,


### PR DESCRIPTION
## O que muda para o AFT

A triagem de PDF deixa de só **avisar** e passa a **consertar** a página, quando a máquina
tiver os motores opcionais instalados. Sem eles, o comportamento é exatamente o de antes.

Rota decidida por medição contra a bateria de 10 casos:

| Situação da página | Motor | Resultado medido |
|---|---|---|
| tabela embaralhada | `pymupdf4llm` | 48,7% de letras soltas → **0%**, 3x mais rápido que o docling |
| escaneada / texto suspeito | `docling` | 4 páginas de OCR em 10,4 s |
| nenhum instalado | — | comportamento anterior, sem regressão |

## Licença

O repositório **não tinha licença nenhuma** — juridicamente, "ninguém pode copiar".
Passou a ter **MIT**.

Isso decide o desenho: um toolkit MIT não pode *exigir* uma peça AGPL, e o `pymupdf4llm`
é AGPL. Por isso a detecção é em tempo de execução e o `/aft-setup` nunca o instala —
quem monta a combinação é o AFT, na máquina dele. O que este repositório distribui segue
100% MIT.

## Regra nova, nascida de caso real

Numa lista de presença de treinamento de NR-12 escaneada, o OCR devolveu a coluna de
assinatura **vazia para nove trabalhadores** — e pelo menos dois tinham assinado. Tomado
como verdade, seria um auto por "trabalhador sem treinamento" contra quem fez o treinamento.

O manual do agente passou a exigir: **em página lida por OCR, toda conclusão de AUSÊNCIA
exige conferência visual.** Presença o OCR atesta; ausência, não.

## Detalhes de implementação

- OCR roda **página a página** (sub-PDF temporário) para o número da página continuar
  exato — sem isso a citação do auto se perde.
- `--sem-motores` para a bateria rodar de forma determinística, independente do que esteja
  instalado na máquina de quem testa.
- `/aft-doctor` informa o que está instalado, sempre com severidade "ok": a ausência dos
  extras não é defeito, é escolha.

## Verificação

- 10/10 casos da bateria rodam; regressão bate com o gabarito
- `/aft-doctor` executa as 23 checagens
- sintaxe dos dois scripts validada
- testado nos documentos reais: PGR de 163 e 425 páginas, laudo de NR-12, AET mista e AET
  100% escaneada

🤖 Generated with [Claude Code](https://claude.com/claude-code)