### PR TITLE
Seção II do auto: conclusão após o enquadramento e exemplo de trabalhador no dano coletivo

### DIFF
--- a/aft-NR01/SKILL.md
+++ b/aft-NR01/SKILL.md
@@ -132,12 +132,13 @@ Para cada ementa confirmada, redija o **bloco 2)** que será colado dentro do au
 2. **Personalize com os fatos da narrativa**: documentos solicitados e datas, notificação/DET, setor, eventos. Não enxerte fatos que o AFT não relatou.
 3. **Cite ao menos 1 ou 2 empregados como exemplo** quando a infração tocar trabalhadores identificáveis (capacitação, certificado, acidente, retorno em GIR). **Use os tokens `[[TRAB_NN]]` (e `[[CPF_NN]]` se citar CPF)** no lugar do nome/CPF real, registrando o par no `.depara_[CNPJ].json` da OS — política de anonimização do toolkit; o `/aft-gera-ai` re-hidrata no TXT final. Se o AFT não forneceu nomes, use o placeholder `[NOME DO EMPREGADO 1 — FUNÇÃO]` e sinalize no fechamento. Em infração puramente documental (ex.: PGR inexistente), a citação nominal é dispensável — o parágrafo de dano coletivo cobre a caracterização.
 4. **Cite o dispositivo legal violado** ao final do parágrafo factual (itens da NR-01 conforme a capitulação da ementa).
-5. **Escreva em parágrafos separados** — nunca um bloco único: um parágrafo para o enquadramento/constatação principal, um por grupo de fatos relacionados, um para o dano coletivo, um para a conclusão. As linhas em branco viram quebras reais no TXT do Sistema Auditor.
-6. **Inclua o parágrafo de dano coletivo** (texto fixo abaixo) — toda infração de NR-01 é SST:
+5. **Escreva em parágrafos separados** — nunca um bloco único: um parágrafo para o enquadramento/constatação principal, um por grupo de fatos relacionados, um para a conclusão jurídica (logo após o enquadramento) e um para o dano coletivo (fechando o bloco). As linhas em branco viram quebras reais no TXT do Sistema Auditor.
+6. **Conclusão jurídica logo após o enquadramento normativo** (parágrafo próprio): `Sendo assim, incorreu o empregador na infração ementada supracitada.`
+7. **Feche o bloco II com o parágrafo de dano coletivo** (texto canônico abaixo) — toda infração de NR-01 é SST:
 
-   > Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a citação do empregado em situação irregular faz-se necessária apenas quando imprescindível à caracterização da infração e quando a lei fixar a multa com base no quantitativo de trabalhadores diretamente prejudicados. Ademais, nas infrações que atingem a coletividade dos trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho (SST), dispensa-se a individualização do sujeito, pois o bem jurídico tutelado tem natureza difusa ou coletiva. (Orientação técnica SIT/n.2/2022).
+   > Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como exemplo de trabalhador prejudicado [[TRAB_01]], [função].
 
-7. **Feche com a conclusão jurídica**: `Sendo assim, incorreu o empregador na infração ementada supracitada.`
+   A frase final ("Contudo, cita-se...") é a regra, não o enfeite: se o contexto (narrativa do AFT, inspeção física, análise documental) identificar trabalhador prejudicado/exposto, cite esse(s), com a função se conhecida; senão, use a relação de vínculos ativos da pasta da OS (ex.: `ImprimirVinculosAtivos*.pdf`) e cite **pelo menos dois** empregados com função compatível com a exposição, no plural ("Contudo, citam-se como exemplos de trabalhadores prejudicados [[TRAB_01]], [função], e [[TRAB_02]], [função]."). Nome em capitalização normal, podendo abreviar (primeiro nome + um sobrenome); função em minúsculas; **nunca cite CPF neste parágrafo**. Vale a anonimização por tokens `[[TRAB_NN]]` (registre a forma abreviada no `.depara_[CNPJ].json`). Sem nenhum nome disponível (exceção), encerre em "...(Orientação Técnica SIT nº 2/2022).", sem a frase final.
 8. **Tom**: sóbrio, formal, impessoal, terceira pessoa. Acentuação portuguesa completa preservada (o encoding latin-1 é responsabilidade do `/aft-gera-ai`). Sem travessões.
 
 ---
@@ -162,17 +163,16 @@ II - IRREGULARIDADE:
 
 <texto redigido conforme regras da Fase 4, em parágrafos separados>
 
-Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a
-citação do empregado em situação irregular faz-se necessária apenas
-quando imprescindível à caracterização da infração e quando a lei fixar
-a multa com base no quantitativo de trabalhadores diretamente
-prejudicados. Ademais, nas infrações que atingem a coletividade dos
-trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho
-(SST), dispensa-se a individualização do sujeito, pois o bem jurídico
-tutelado tem natureza difusa ou coletiva. (Orientação técnica
-SIT/n.2/2022).
-
 Sendo assim, incorreu o empregador na infração ementada supracitada.
+
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação
+nominal do empregado só é necessária quando imprescindível à
+caracterização da infração ou quando a multa se baseia no quantitativo
+de trabalhadores prejudicados. Nas infrações que atingem a coletividade,
+tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a
+individualização, dado o caráter difuso ou coletivo do bem jurídico
+tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como
+exemplo de trabalhador prejudicado [[TRAB_01]], [função].
 
 ===
 ```

--- a/aft-NR12/SKILL.md
+++ b/aft-NR12/SKILL.md
@@ -118,11 +118,12 @@ Para cada ementa confirmada, redija o **bloco 2)** que será colado dentro do au
 2. **Personalize com os fatos da narrativa**: máquinas atingidas, setor, marca/modelo se houver. Não enxerte fatos que o AFT não relatou.
 3. **Cite ao menos 1 ou 2 empregados como exemplo** (mesmo em infração coletiva — necessário para defesa). **Use os tokens `[[TRAB_NN]]` (e `[[CPF_NN]]` se citar CPF)** no lugar do nome/CPF real, registrando o par no `.depara_[CNPJ].json` da OS — política de anonimização do toolkit; o `/aft-gera-ai` re-hidrata no TXT final. Se o AFT não forneceu nomes, use o placeholder `[NOME DO EMPREGADO 1 — FUNÇÃO]` e sinalize no fechamento.
 4. **Cite o dispositivo legal violado** ao final do parágrafo factual (itens da NR-12 conforme a capitulação da ementa).
-5. **Inclua o parágrafo de dano coletivo** (texto fixo abaixo) — toda infração de NR-12 é SST:
+5. **Conclusão jurídica logo após o enquadramento normativo** (parágrafo próprio): `Sendo assim, incorreu o empregador na infração ementada supracitada.`
+6. **Feche o bloco II com o parágrafo de dano coletivo** (texto canônico abaixo) — toda infração de NR-12 é SST:
 
-   > Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a citação do empregado em situação irregular faz-se necessária apenas quando imprescindível à caracterização da infração e quando a lei fixar a multa com base no quantitativo de trabalhadores diretamente prejudicados. Ademais, nas infrações que atingem a coletividade dos trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho (SST), dispensa-se a individualização do sujeito, pois o bem jurídico tutelado tem natureza difusa ou coletiva. (Orientação técnica SIT/n.2/2022).
+   > Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como exemplo de trabalhador prejudicado [[TRAB_01]], [função].
 
-6. **Feche com a conclusão jurídica**: `Sendo assim, incorreu o empregador na infração ementada supracitada.`
+   A frase final ("Contudo, cita-se...") é a regra, não o enfeite: se a narrativa identificar o operador da máquina ou outro trabalhador exposto, cite esse(s), com a função se conhecida; senão, use a relação de vínculos ativos da pasta da OS (ex.: `ImprimirVinculosAtivos*.pdf`) e cite **pelo menos dois** empregados com função compatível com a exposição, no plural ("Contudo, citam-se como exemplos de trabalhadores prejudicados [[TRAB_01]], [função], e [[TRAB_02]], [função]."). Nome em capitalização normal, podendo abreviar (primeiro nome + um sobrenome); função em minúsculas; **nunca cite CPF neste parágrafo**. Vale a anonimização por tokens `[[TRAB_NN]]` (registre a forma abreviada no `.depara_[CNPJ].json`). Sem nenhum nome disponível (exceção), encerre em "...(Orientação Técnica SIT nº 2/2022).", sem a frase final.
 7. **Tom**: sóbrio, formal, impessoal, terceira pessoa. Acentuação portuguesa completa preservada (o encoding latin-1 é responsabilidade do `/aft-gera-ai`). Sem travessões.
 8. **Risco grave e iminente**: se a ementa está marcada como aplicável a Termo de Interdição em `references/ementas-comuns.md` E a narrativa indica máquina em operação ou exposição atual, sinalize internamente `[RISCO_GRAVE = true]` para mostrar no encerramento.
 
@@ -149,17 +150,16 @@ II - IRREGULARIDADE:
 
 <texto redigido conforme regras da Fase 4>
 
-Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a
-citação do empregado em situação irregular faz-se necessária apenas
-quando imprescindível à caracterização da infração e quando a lei fixar
-a multa com base no quantitativo de trabalhadores diretamente
-prejudicados. Ademais, nas infrações que atingem a coletividade dos
-trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho
-(SST), dispensa-se a individualização do sujeito, pois o bem jurídico
-tutelado tem natureza difusa ou coletiva. (Orientação técnica
-SIT/n.2/2022).
-
 Sendo assim, incorreu o empregador na infração ementada supracitada.
+
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação
+nominal do empregado só é necessária quando imprescindível à
+caracterização da infração ou quando a multa se baseia no quantitativo
+de trabalhadores prejudicados. Nas infrações que atingem a coletividade,
+tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a
+individualização, dado o caráter difuso ou coletivo do bem jurídico
+tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como
+exemplo de trabalhador prejudicado [[TRAB_01]], [função].
 
 ----- LINHA PARA A SEÇÃO 4 DO RT (consumido por /aft-embargo-interdicao) -----
 

--- a/aft-PGR-analise/SKILL.md
+++ b/aft-PGR-analise/SKILL.md
@@ -555,8 +555,9 @@ estabelecimento. CNPJ: capa do PGR ou memory.md.
 - **Estruture em parágrafos temáticos — nunca em um bloco único.** Separe com linha em
   branco: um parágrafo para o enquadramento normativo (conduta + item da NR-01 violado),
   um parágrafo por **grupo temático de constatações relacionadas** (ex.: um por
-  trecho/seção do PGR sobre o mesmo tema, um por GHE/setor), e o parágrafo de dano
-  coletivo e a conclusão jurídica sempre isolados, cada um no seu próprio parágrafo. A
+  trecho/seção do PGR sobre o mesmo tema, um por GHE/setor), e a conclusão jurídica e o
+  parágrafo de dano coletivo sempre isolados, cada um no seu próprio parágrafo, nesta
+  ordem: conclusão jurídica logo após o enquadramento; dano coletivo fechando o bloco. A
   linha em branco no `autos.md` é o que o `/aft-gera-ai` converte em quebra de linha real
   (`#13#10`) no Sistema Auditor — um bloco II sem nenhuma quebra interna sai como um
   único parágrafo gigante e ilegível. Alvo prático: 3 a 6 parágrafos.
@@ -564,22 +565,32 @@ estabelecimento. CNPJ: capa do PGR ou memory.md.
 - Cite o **dispositivo da NR-01** violado (item exato, ex: 1.5.4.3.1).
 - **Incorpore as citações de página** geradas na análise (`pág. X` ou `págs. X a Y`).
   Não economize palavras: a empresa precisa localizar cada evidência citada.
-- Inclua o **parágrafo de dano coletivo** (PGR é SST):
+- **Conclusão jurídica logo após o enquadramento normativo** (parágrafo próprio):
+  *"Sendo assim, incorreu o empregador na infração ementada supracitada."*
+- Feche o bloco II com o **parágrafo de dano coletivo** (PGR é SST), último parágrafo
+  antes de ELEMENTOS DE CONVICÇÃO. Texto canônico:
 
 ```
-Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a
-citação do empregado em situação irregular faz-se necessária apenas
-quando imprescindível à caracterização da infração e quando a lei fixar
-a multa com base no quantitativo de trabalhadores diretamente
-prejudicados. Ademais, nas infrações que atingem a coletividade dos
-trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho
-(SST), dispensa-se a individualização do sujeito, pois o bem jurídico
-tutelado tem natureza difusa ou coletiva. (Orientação técnica
-SIT/n.2/2022).
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação
+nominal do empregado só é necessária quando imprescindível à
+caracterização da infração ou quando a multa se baseia no quantitativo
+de trabalhadores prejudicados. Nas infrações que atingem a coletividade,
+tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a
+individualização, dado o caráter difuso ou coletivo do bem jurídico
+tutelado (Orientação Técnica SIT nº 2/2022). Contudo, citam-se como
+exemplos de trabalhadores prejudicados [NOME 1], [função], e [NOME 2],
+[função].
 ```
 
-- Finalize com a conclusão jurídica: *"Sendo assim, incorreu o empregador na infração
-  ementada supracitada."*
+  **Exemplo de trabalhador prejudicado (frase final "Contudo, ..."):** se o contexto da
+  fiscalização (inspeção física, narrativa do AFT) identificar trabalhador exposto, cite
+  esse(s). Senão, procure na pasta da OS uma relação de vínculos ativos (ex.:
+  `ImprimirVinculosAtivos*.pdf`) e cite **pelo menos dois** empregados com função
+  compatível com a exposição. Nome em capitalização normal, podendo abreviar (primeiro
+  nome + um sobrenome); função em minúsculas; **nunca cite CPF**. Com um só nome, use o
+  singular ("cita-se como exemplo de trabalhador prejudicado..."). Sem nenhum nome
+  disponível (exceção), encerre em "...(Orientação Técnica SIT nº 2/2022).", sem a frase
+  final.
 - Tom: sóbrio, formal, impessoal, terceira pessoa. Sem travessões.
 - **Acentuação completa e obrigatória.** Escreva o subtítulo 2 em português com TODOS os
   acentos (ç ã õ á é í ó ú â ê ô à). O TXT final do Sistema Auditor é gravado em
@@ -593,7 +604,9 @@ SIT/n.2/2022).
   Regra Especial D.A como conteúdo do subtítulo 2 e acrescente aos elementos de
   convicção: `; termo de interdição lavrado, em anexo`.
 - O subtítulo 3 é **fixo e literal** (bloco acima) — não altere.
-- Não há trabalhadores nominados em autos de PGR (infração coletiva — sem linhas tipo 4).
+- Autos de PGR não levam trabalhadores nominados nas **linhas tipo 4** do TXT (infração
+  coletiva) — o exemplo de trabalhador prejudicado do parágrafo de dano coletivo é só
+  texto do bloco II, não gera linha tipo 4.
 
 **Códigos das sete ementas** (formato com hífen, para a linha `Ementa:` — o `/aft-gera-ai`
 remove o hífen no cod_3):

--- a/aft-aet-auditoria/SKILL.md
+++ b/aft-aet-auditoria/SKILL.md
@@ -430,31 +430,43 @@ econômica** do estabelecimento, **CNPJ** (apenas dígitos).
   fato à exigência da NR-17. Esta é a forma de tornar a análise rastreável no auto.
   **Separe cada item por linha em branco** no `autos.md` — é o que o `/aft-gera-ai` converte
   em quebra de linha real no Sistema Auditor; uma lista numérica sem quebra entre os itens
-  sai como um único parágrafo corrido. O parágrafo de dano coletivo e a conclusão jurídica
-  (abaixo) também ficam isolados, cada um no seu próprio parágrafo.
+  sai como um único parágrafo corrido. A conclusão jurídica e o parágrafo de dano coletivo
+  (abaixo) também ficam isolados, cada um no seu próprio parágrafo, nesta ordem: conclusão
+  jurídica logo após a última evidência/enquadramento; dano coletivo fechando o bloco II.
 - Descreva os **fatos concretos** com precisão técnica e tom oficial.
 - Cite o **dispositivo da NR-17** violado (item exato, ex: 17.3.3, 17.3.8, 17.4.1(d),
   17.4.2, 17.4.3).
 - **Incorpore as citações de página/folha** geradas na análise. Não economize palavras: a
   empresa precisa localizar cada evidência.
-- Inclua o **parágrafo de dano coletivo** (AET é SST):
+- **Conclusão jurídica logo após a última evidência/enquadramento** (parágrafo próprio):
+  *"Sendo assim, incorreu o empregador na infração ementada supracitada."*
+- Feche o bloco II com o **parágrafo de dano coletivo** (AET é SST), último parágrafo
+  antes de ELEMENTOS DE CONVICÇÃO. Texto canônico:
 
 ```
-Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a
-citação do empregado em situação irregular faz-se necessária apenas
-quando imprescindível à caracterização da infração e quando a lei fixar
-a multa com base no quantitativo de trabalhadores diretamente
-prejudicados. Ademais, nas infrações que atingem a coletividade dos
-trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho
-(SST), dispensa-se a individualização do sujeito, pois o bem jurídico
-tutelado tem natureza difusa ou coletiva. (Orientação técnica
-SIT/n.2/2022).
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação
+nominal do empregado só é necessária quando imprescindível à
+caracterização da infração ou quando a multa se baseia no quantitativo
+de trabalhadores prejudicados. Nas infrações que atingem a coletividade,
+tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a
+individualização, dado o caráter difuso ou coletivo do bem jurídico
+tutelado (Orientação Técnica SIT nº 2/2022). Contudo, citam-se como
+exemplos de trabalhadores prejudicados [NOME 1], [função], e [NOME 2],
+[função].
 ```
 
-- Finalize com a conclusão jurídica: *"Sendo assim, incorreu o empregador na infração
-  ementada supracitada."*
+  **Exemplo de trabalhador prejudicado (frase final "Contudo, ..."):** se o contexto da
+  fiscalização (inspeção física, narrativa do AFT, a própria AET) identificar trabalhador
+  exposto ao risco ergonômico, cite esse(s), com a função se conhecida. Senão, procure na
+  pasta da OS uma relação de vínculos ativos (ex.: `ImprimirVinculosAtivos*.pdf`) e cite
+  **pelo menos dois** empregados com função compatível com a exposição. Nome em
+  capitalização normal, podendo abreviar (primeiro nome + um sobrenome); função em
+  minúsculas; **nunca cite CPF**. Com um só nome, use o singular ("cita-se como exemplo
+  de trabalhador prejudicado..."). Sem nenhum nome disponível (exceção), encerre em
+  "...(Orientação Técnica SIT nº 2/2022).", sem a frase final.
 - Tom: sóbrio, formal, impessoal, terceira pessoa. **Sem travessões.**
-- Não há trabalhadores nominados em autos de AET (infração coletiva — sem linhas tipo 4).
+- Autos de AET não levam trabalhadores nominados nas **linhas tipo 4** do TXT (infração
+  coletiva) — o exemplo do parágrafo de dano coletivo é só texto do bloco II.
 
 **Códigos das cinco ementas** (já no formato com hífen para a linha `Ementa:` — o `/aft-gera-ai`
 remove o hífen no cod_3):

--- a/aft-auditoria-geral/SKILL.md
+++ b/aft-auditoria-geral/SKILL.md
@@ -344,8 +344,10 @@ nenhuma quebra interna sai como um único parágrafo gigante e ilegível):
 3. **Enquadramento normativo** (Por quê): vincular o fato constatado à exigência normativa descumprida, fechando o nexo entre o empírico e o típico.
 
 Se houver mais de uma irregularidade/constatação dentro da mesma ementa, use um parágrafo
-por grupo temático em vez de espremer tudo no movimento 2. O parágrafo de dano coletivo e
-a conclusão jurídica (abaixo) ficam sempre isolados, cada um no seu próprio parágrafo.
+por grupo temático em vez de espremer tudo no movimento 2. A conclusão jurídica e o
+parágrafo de dano coletivo (abaixo) ficam sempre isolados, cada um no seu próprio
+parágrafo, **nesta ordem**: a conclusão jurídica vem logo após o enquadramento normativo
+(movimento 3), e o parágrafo de dano coletivo fecha o bloco II.
 
 **Modelo de referência** (adaptar à NR/dispositivo do caso):
 
@@ -359,21 +361,38 @@ a conclusão jurídica (abaixo) ficam sempre isolados, cada um no seu próprio p
 - Cite o **dispositivo legal infringido** (artigo da CLT, item da NR, portaria).
 - **Sempre cite ao menos 1 ou 2 empregados** como exemplos de prejudicados, mesmo em infrações de natureza coletiva. O nome do empregado é necessário para permitir a defesa do autuado. **Na redação e nos ecos do chat, use os tokens `[[TRAB_NN]]` (e `[[CPF_NN]]` se citar CPF)**, registrando o par real no `.depara_[CNPJ].json` da OS — o `/aft-gera-ai` re-hidrata no TXT final. Se o auditor não forneceu nomes, use `[NOME DO EMPREGADO 1 - FUNÇÃO]` como placeholder e peça os dados.
 - Se houver consulta ao eSocial, mencione a data e os eventos verificados (S-2190, S-2200, etc.).
-- **Parágrafo de dano coletivo** — incluir APENAS em infrações de SST (NRs), NÃO em infrações puramente CLT (registro, jornada, CTPS):
+- **Conclusão jurídica logo após o enquadramento normativo** (parágrafo próprio, imediatamente depois do movimento 3): "Sendo assim, incorreu o empregador na infração ementada supracitada."
+- **Parágrafo de dano coletivo** — incluir APENAS em infrações de SST (NRs), NÃO em infrações puramente CLT (registro, jornada, CTPS). É o **último parágrafo do bloco II** (depois da conclusão jurídica, antes de ELEMENTOS DE CONVICÇÃO). Texto canônico:
 
 ```
-Dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a
-citação do empregado em situação irregular faz-se necessária apenas
-quando imprescindível à caracterização da infração e quando a lei fixar
-a multa com base no quantitativo de trabalhadores diretamente
-prejudicados. Ademais, nas infrações que atingem a coletividade dos
-trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho
-(SST), dispensa-se a individualização do sujeito, pois o bem jurídico
-tutelado tem natureza difusa ou coletiva. (Orientação técnica
-SIT/n.2/2022).
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação
+nominal do empregado só é necessária quando imprescindível à
+caracterização da infração ou quando a multa se baseia no quantitativo
+de trabalhadores prejudicados. Nas infrações que atingem a coletividade,
+tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a
+individualização, dado o caráter difuso ou coletivo do bem jurídico
+tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como
+exemplo de trabalhador prejudicado [[TRAB_01]], [função].
 ```
 
-- Finalize com conclusão jurídica: "Sendo assim, incorreu o empregador na infração ementada supracitada."
+  **A frase final ("Contudo, cita-se...") é a regra, não o enfeite** — as boas práticas
+  da inspeção recomendam exemplificar o trabalhador prejudicado. Como escolher o exemplo:
+  1. **Contexto primeiro:** se a inspeção física, a análise documental ou a narrativa do
+     AFT identificarem trabalhador prejudicado/exposto (ex.: o operador da máquina), cite
+     esse(s), com a função se conhecida.
+  2. **Senão, lista de vínculos da OS:** procure na pasta da OS uma relação de vínculos
+     ativos (ex.: `ImprimirVinculosAtivos*.pdf`, relação de vínculos do SFIT) e cite
+     **pelo menos dois** empregados com função compatível com a exposição (ex.: padeiros
+     para máquina da padaria). Plural: "Contudo, citam-se como exemplos de trabalhadores
+     prejudicados [[TRAB_01]], [função], e [[TRAB_02]], [função]."
+  3. **Sem nenhum nome disponível (exceção):** encerre o parágrafo em "...(Orientação
+     Técnica SIT nº 2/2022).", sem a frase final.
+
+  Nome do trabalhador em capitalização normal, podendo abreviar (primeiro nome + um
+  sobrenome: "Alessandro Martins", não "ALESSANDRO MARTINS DE OLIVEIRA"); função em
+  minúsculas. **Nunca cite CPF neste parágrafo.** Vale a política de anonimização: no
+  rascunho e no chat, tokens `[[TRAB_NN]]` com o par real no `.depara_[CNPJ].json`
+  (registre a forma abreviada) — o `/aft-gera-ai` re-hidrata no TXT final.
 - Tom: sóbrio, formal, impessoal, terceira pessoa.
 - Dados ausentes: sinalize como `[DADO NÃO INFORMADO]`.
 

--- a/aft-det-630/SKILL.md
+++ b/aft-det-630/SKILL.md
@@ -102,7 +102,7 @@ A recusa na apresentação dos documentos solicitados não apenas impede a verif
 
 Em anexo o Relatório de <ATEND_OU_NAO_ATEND> à notificação emitido pelo DET<COMPLEMENTO_RELATORIO>.
 
-Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022).
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022).<FRASE_EXEMPLO_TRABALHADOR>
 
 ELEMENTOS DE CONVICÇÃO:
 - Relatório de <ATEND_OU_NAO_ATEND> à notificação emitido pelo DET (ANEXO).
@@ -120,6 +120,16 @@ ELEMENTOS DE CONVICÇÃO:
 | `<PARAGRAFO_OMISSAO>` | (ver bloco A abaixo) | (ver bloco B abaixo) |
 | `<ATEND_OU_NAO_ATEND>` | `não atendimento` | `atendimento` |
 | `<COMPLEMENTO_RELATORIO>` | ` que cita todos os documentos notificados mas não apresentados` | (string vazia) |
+| `<FRASE_EXEMPLO_TRABALHADOR>` | (ver regra abaixo) | idem |
+
+**Regra do `<FRASE_EXEMPLO_TRABALHADOR>`** (exemplo de trabalhador prejudicado, boas
+práticas da inspeção): se a pasta da OS tiver uma relação de vínculos ativos (ex.:
+`ImprimirVinculosAtivos*.pdf`), acrescente ao final do parágrafo de dano coletivo a
+frase ` Contudo, citam-se como exemplos de trabalhadores prejudicados [NOME 1], [função],
+e [NOME 2], [função].` com **pelo menos dois** empregados da lista — nome em
+capitalização normal, podendo abreviar (primeiro nome + um sobrenome); função em
+minúsculas; **nunca cite CPF**. Sem lista de vínculos na pasta, substitua por string
+vazia (o parágrafo termina em "...(Orientação Técnica SIT nº 2/2022).").
 
 **Bloco A — Cenário 1 (omissão total):**
 ```

--- a/aft-embargo-interdicao/SKILL.md
+++ b/aft-embargo-interdicao/SKILL.md
@@ -673,7 +673,7 @@ DA INFRAÇÃO COMETIDA: Constatou-se que o empregador aqui autuado incorreu na e
 
 O quadro resultante dessa sistematização e análise de informações levou à caracterização da condição de RISCO GRAVE E IMINENTE à saúde e à integridade física dos trabalhadores expostos, na forma conceituada pelo subitem 3.2.1 da Norma Regulamentadora nº 3 do Ministério do Trabalho e Previdência, com atualização dada pela Portaria nº 1.068, de 23 de setembro de 2019: "Considera-se grave e iminente risco toda condição ou situação de trabalho que possa causar acidente ou doença com lesão grave ao trabalhador.", resultando na lavratura do termo de interdição/embargo em anexo.
 
-Exemplo de empregado prejudicado: dano de natureza coletiva. A Portaria MTP nº 667/2021 esclareceu que a citação do empregado em situação irregular faz-se necessária apenas quando imprescindível à caracterização da infração e quando a lei fixar a multa com base no quantitativo de trabalhadores diretamente prejudicados. Ademais, nas infrações que atingem a coletividade dos trabalhadores, tais como naquelas inerentes ao meio ambiente de trabalho (SST), dispensa-se a individualização do sujeito, pois o bem jurídico tutelado tem natureza difusa ou coletiva. (Orientação técnica SIT/n.2/2022).
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como exemplo de trabalhador prejudicado {exemplo_trabalhador}.
 
 ELEMENTOS DE CONVICÇÃO:
 Inspeção realizada no estabelecimento e relatório técnico do embargo/interdição em anexo.
@@ -683,6 +683,17 @@ Inspeção realizada no estabelecimento e relatório técnico do embargo/interdi
 > injetado pelo `/aft-gera-ai` (de `config/blocos_auto.md`) entre o Subtítulo 2 e os
 > ELEMENTOS DE CONVICÇÃO. O template acima termina, de propósito, no Subtítulo 2 +
 > ELEMENTOS DE CONVICÇÃO.
+
+> **`{exemplo_trabalhador}`** (frase final do parágrafo de dano coletivo, boas práticas
+> da inspeção): se o RT/`inspecao-fisica.md` identificar trabalhador exposto ao objeto
+> interditado (o operador da máquina, por exemplo), cite esse(s), com a função se
+> conhecida. Senão, use a relação de vínculos ativos da pasta da OS (ex.:
+> `ImprimirVinculosAtivos*.pdf`) e cite **pelo menos dois** empregados com função
+> compatível com a exposição, ajustando para o plural ("citam-se como exemplos de
+> trabalhadores prejudicados NOME 1, função, e NOME 2, função"). Nome em capitalização
+> normal, podendo abreviar (primeiro nome + um sobrenome); função em minúsculas;
+> **nunca cite CPF**. Sem nenhum nome disponível (exceção), encerre o parágrafo em
+> "...(Orientação Técnica SIT nº 2/2022).", sem a frase final.
 
 #### 7.2.1. Enriquecimento contextual do Subtítulo 1
 

--- a/aft-revisa-auto/SKILL.md
+++ b/aft-revisa-auto/SKILL.md
@@ -92,11 +92,25 @@ cada elemento:
 NR-17, NR-18, NR-35 e demais NRs. Autos **contratuais** (aft-informalidade/CTPS, jornada, FGTS,
 salário) **não são SST**.
 
-- **Auto de SST sem o parágrafo → insira-o** ao final do bloco 2 (IRREGULARIDADE),
-  antes de `ELEMENTOS DE CONVICÇÃO:`. Texto canônico (latin-1-safe, **sem travessões**):
+- **Auto de SST sem o parágrafo → insira-o** como **último parágrafo** do bloco 2
+  (IRREGULARIDADE), antes de `ELEMENTOS DE CONVICÇÃO:` e **depois** da conclusão
+  jurídica ("Sendo assim, incorreu o empregador..."). Texto canônico (latin-1-safe,
+  **sem travessões**):
 
-> Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022).
+> Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação nominal do empregado só é necessária quando imprescindível à caracterização da infração ou quando a multa se baseia no quantitativo de trabalhadores prejudicados. Nas infrações que atingem a coletividade, tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a individualização, dado o caráter difuso ou coletivo do bem jurídico tutelado (Orientação Técnica SIT nº 2/2022). Contudo, cita-se como exemplo de trabalhador prejudicado [NOME], [função].
 
+- **Frase final de exemplo ("Contudo, cita-se..."):** é a regra do padrão — as skills
+  redatoras devem citar trabalhador prejudicado identificado no contexto ou, na falta,
+  pelo menos dois nomes da relação de vínculos da OS (sem CPF, nunca). Você, revisor,
+  **não inventa nome**: se o parágrafo já vier com exemplo (nome real ou token
+  `[[TRAB_NN]]`), mantenha; se vier sem, insira/mantenha o canônico **sem** a frase
+  final (terminando em "...(Orientação Técnica SIT nº 2/2022).") e sinalize `⚠️ sem
+  exemplo de trabalhador prejudicado no parágrafo de dano coletivo` — pendência
+  factual, não bloqueia.
+- **Ordem trocada → corrija:** se a conclusão jurídica vier **depois** do parágrafo de
+  dano coletivo (padrão antigo), troque os dois parágrafos de lugar — a conclusão fica
+  logo após o enquadramento normativo e o dano coletivo fecha o bloco. Reordenação pura,
+  sem alterar uma palavra.
 - **Auto contratual → NÃO** insira o parágrafo.
 - **Compatibilidade ISO-8859-1 (latin-1):** o `rehydrate.py` grava o TXT final nesse
   encoding. O latin-1 **suporta todos os acentos do português** (ç ã õ á é í ó ú â ê ô à):
@@ -186,9 +200,10 @@ fixo de parágrafos):**
   analisado, um por item de norma, um por setor inspecionado) — não junte achados de
   assuntos diferentes num só parágrafo.
 - Confirmação por inspeção física, quando o texto trouxer essa frase — parágrafo próprio.
+- **Conclusão** ("Sendo assim, incorreu o empregador...") — parágrafo próprio, logo após
+  o enquadramento normativo.
 - **Parágrafo de dano coletivo** (FASE 2) — sempre no seu próprio parágrafo, nunca
-  fundido com o anterior ou o seguinte.
-- **Conclusão** ("Sendo assim, incorreu o empregador...") — parágrafo próprio, ao final.
+  fundido com o anterior ou o seguinte; é o último do bloco II.
 
 **Regras:**
 - Nunca quebre no meio de uma frase — só entre pontos finais.
@@ -209,7 +224,8 @@ paragrafado, não mexa.
 Política: **corrige o que puder e segue direto** (sem reapresentar para aprovação).
 
 1. **Correções determinísticas → aplique direto:** parágrafo de dano coletivo ausente em
-   auto de SST; travessões/aspas curvas → pontuação latin-1-safe; acentuação pt-br
+   auto de SST; conclusão jurídica e dano coletivo em ordem trocada → reordene (FASE 2);
+   travessões/aspas curvas → pontuação latin-1-safe; acentuação pt-br
    reposta nas palavras apontadas pelo `checar_acentos.py` (FASE 2.5); referência a
    arquivo/pasta interna reescrita como descrição da prova (FASE 2.6); bloco II monolítico
    dividido em parágrafos (FASE 2.7).

--- a/novidades/2026-08-20-03-secao-ii-conclusao-e-exemplo-trabalhador.md
+++ b/novidades/2026-08-20-03-secao-ii-conclusao-e-exemplo-trabalhador.md
@@ -1,7 +1,7 @@
 ## 20/08/2026
 <!-- commit: secao-ii-auto-infracao -->
 
-**Seção II do auto de infração: conclusão no lugar certo e exemplo de trabalhador prejudicado.** Duas mudanças no texto padrão que as skills redatoras produzem (/aft-auditoria-geral, /aft-PGR-analise, /aft-aet-auditoria, /aft-NR01, /aft-NR12, /aft-det-630) e que a /aft-revisa-auto garante na revisão:
+**Seção II do auto de infração: conclusão no lugar certo e exemplo de trabalhador prejudicado.** Duas mudanças no texto padrão que as skills redatoras produzem (/aft-auditoria-geral, /aft-PGR-analise, /aft-aet-auditoria, /aft-NR01, /aft-NR12, /aft-det-630, /aft-embargo-interdicao) e que a /aft-revisa-auto garante na revisão:
 
 1. A frase de conclusão ("Sendo assim, incorreu o empregador na infração ementada supracitada.") agora vem logo depois do enquadramento normativo — a parte que diz o que a norma exigia —, e não mais no fim do auto.
 

--- a/novidades/2026-08-20-03-secao-ii-conclusao-e-exemplo-trabalhador.md
+++ b/novidades/2026-08-20-03-secao-ii-conclusao-e-exemplo-trabalhador.md
@@ -1,0 +1,12 @@
+## 20/08/2026
+<!-- commit: secao-ii-auto-infracao -->
+
+**Seção II do auto de infração: conclusão no lugar certo e exemplo de trabalhador prejudicado.** Duas mudanças no texto padrão que as skills redatoras produzem (/aft-auditoria-geral, /aft-PGR-analise, /aft-aet-auditoria, /aft-NR01, /aft-NR12, /aft-det-630) e que a /aft-revisa-auto garante na revisão:
+
+1. A frase de conclusão ("Sendo assim, incorreu o empregador na infração ementada supracitada.") agora vem logo depois do enquadramento normativo — a parte que diz o que a norma exigia —, e não mais no fim do auto.
+
+2. O parágrafo de dano coletivo ficou mais curto, fecha o bloco II e, seguindo as boas práticas da inspeção, passa a citar exemplo de trabalhador prejudicado: primeiro quem aparecer no contexto da fiscalização (o operador da máquina, por exemplo); se ninguém aparecer, pelo menos dois nomes da relação de vínculos ativos da pasta da OS, com a função. Nome abreviado, sem CPF. Só quando não houver nome nenhum disponível o parágrafo sai genérico, como era antes — agora isso é a exceção, não a regra.
+
+A /aft-revisa-auto também corrige sozinha autos antigos que cheguem na ordem antiga (troca os dois parágrafos de lugar) e sinaliza quando o parágrafo estiver sem exemplo de trabalhador.
+
+---


### PR DESCRIPTION
Duas mudanças no texto padrão da seção II - IRREGULARIDADE, em todas as skills redatoras de auto (/aft-auditoria-geral, /aft-PGR-analise, /aft-aet-auditoria, /aft-NR01, /aft-NR12, /aft-det-630, /aft-embargo-interdicao) e no gate /aft-revisa-auto:

1. A conclusão jurídica ("Sendo assim, incorreu o empregador...") passa a vir logo após o enquadramento normativo, em parágrafo próprio; o parágrafo de dano coletivo fecha o bloco II.
2. Parágrafo de dano coletivo no canônico curto, complementado por exemplo nominal de trabalhador prejudicado: primeiro quem o contexto identificar; na falta, pelo menos dois nomes da relação de vínculos ativos da OS, com função; sem CPF, nunca. Genérico só quando não houver nome nenhum (exceção).

A /aft-revisa-auto reordena sozinha autos na ordem antiga e sinaliza parágrafo sem exemplo (o revisor isolado não inventa nome). Changelog em novidades/2026-08-20-03; nota técnica no cofre (pipeline-autos-revisa-auto-gera-ai.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)