### PR TITLE
Persona opcional do assessor (tratamento + nome do assistente, so no chat)

### DIFF
--- a/aft-setup/SKILL.md
+++ b/aft-setup/SKILL.md
@@ -316,7 +316,22 @@ sempre 9 dígitos).
    por enquanto (o Sistema Auditor permite confirmar pela lupa), recomendando
    preencher depois editando o `aft-config.md`.
 
-## Passo 4 — Descobrir o caminho Windows da pasta de trabalho
+### Persona do assessor (opcional, uma pergunta só)
+
+Depois de resolver a UORG, ofereça a personalização do assessor, em uma única
+pergunta, deixando claro que é opcional e vale só para a conversa:
+
+> Quer dar um toque pessoal ao assistente? Posso te chamar de um tratamento seu
+> ("Dr. João", "Dra. Maria" ou só o primeiro nome) e atender por um nome que você
+> escolher ("Claudinho", "Claudete"...). Isso vale SÓ aqui no chat — nunca em auto
+> de infração, notificação ou qualquer documento. Se não quiser, seguimos como está.
+
+- Se o AFT topar, colete os dois valores: `tratamento` (sugira "Dr./Dra. + primeiro
+  nome", mas grave **o que ele disser** — nunca deduza gênero pelo nome) e
+  `nome_assessor` (o que ele escolher).
+- Se recusar ou ignorar, **não insista**: deixe os dois campos fora do config (ou
+  vazios) e siga.
+- Os valores entram no front-matter do Passo 5.
 
 O Sistema Auditor exige caminhos absolutos no formato Windows (`C:\...`) nas linhas
 de anexo do TXT. Converta **a pasta que o Passo 2 devolveu** (nunca um caminho
@@ -362,6 +377,9 @@ path_windows: "C:\\Users\\joao\\Documents\\AFT"
 python_path: "C:\\Users\\joao\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"
 # Navegador que o AFT usa com a conta Google do NotebookLM (chrome | edge):
 notebooklm_browser: ""     # perguntado e preenchido pelo Passo 7 / /aft-notebooklm-login
+# Persona do assessor (opcional; vale so no chat, nunca em documento oficial):
+tratamento: "Dr. João"     # como o assistente chama o AFT na conversa
+nome_assessor: "Claudinho" # nome pelo qual o assistente atende
 # Dados fixos do TXT (não alterar sem orientação):
 cod_1: "8211300"           # CNAE placeholder — o Sistema Auditor corrige pela lupa
 cod_2: "0"                 # nº de empregados da empresa no TXT (0 = não informado)

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -134,7 +134,7 @@
 const ARCH = {
   "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
   "repo": "github.com/ryckardo42/aft-toolkit",
-  "data": "2026-08-14",
+  "data": "2026-08-20",
   "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
   "stats": {
     "skills": 46,
@@ -244,7 +244,7 @@ const ARCH = {
       "skills": [
         {
           "nome": "/aft-setup",
-          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
           "tech": "winget · pipx · uorgs.csv · model: sonnet"
         },
         {
@@ -703,7 +703,7 @@ const ARCH = {
     },
     {
       "arquivo": "config/CLAUDE-aft.md",
-      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade e roteamento das skills",
+      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
       "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
     },
     {

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -1,7 +1,7 @@
 {
   "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
   "repo": "github.com/ryckardo42/aft-toolkit",
-  "data": "2026-08-14",
+  "data": "2026-08-20",
   "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
   "stats": {
     "skills": 46,
@@ -111,7 +111,7 @@
       "skills": [
         {
           "nome": "/aft-setup",
-          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
           "tech": "winget · pipx · uorgs.csv · model: sonnet"
         },
         {
@@ -570,7 +570,7 @@
     },
     {
       "arquivo": "config/CLAUDE-aft.md",
-      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade e roteamento das skills",
+      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
       "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
     },
     {

--- a/config/CLAUDE-aft.md
+++ b/config/CLAUDE-aft.md
@@ -1,4 +1,4 @@
-<!-- AFT-TOOLKIT-PERFIL:INICIO v14 — bloco gerenciado pelo AFT Toolkit; o /aft-atualizar substitui só o que está entre este marcador e o AFT-TOOLKIT-PERFIL:FIM. NÃO edite aqui dentro (suas mudanças seriam sobrescritas numa atualização); o que você escrever FORA dos marcadores é preservado. -->
+<!-- AFT-TOOLKIT-PERFIL:INICIO v15 — bloco gerenciado pelo AFT Toolkit; o /aft-atualizar substitui só o que está entre este marcador e o AFT-TOOLKIT-PERFIL:FIM. NÃO edite aqui dentro (suas mudanças seriam sobrescritas numa atualização); o que você escrever FORA dos marcadores é preservado. -->
 # CLAUDE.md — Perfil do Auditor-Fiscal do Trabalho
 
 > Instalado pelo AFT Toolkit (`/aft-setup`). Carregado em toda conversa: diz ao Claude
@@ -69,6 +69,23 @@ com efeito legal é minuta até que eu revise e aprove — e quem transmite sou 
 - Em dúvida de enquadramento, **apresente as alternativas com fundamento** em vez de
   escolher em silêncio.
 - Documentos oficiais: tom **formal, técnico, impessoal, em terceira pessoa**.
+
+## Persona do assessor (opcional)
+
+O `aft-config.md` pode ter dois campos opcionais: `tratamento` (como você me chama no
+chat, ex.: "Dr. João", "Dra. Maria", ou só o primeiro nome) e `nome_assessor` (o nome
+que você usa para si, ex.: "Claudinho", "Claudete").
+
+- **Só no chat.** Dirija-se a mim pelo `tratamento` e refira-se a si pelo
+  `nome_assessor`, como um assessor de gabinete: cordial, direto, leal ao trabalho.
+- **A persona NUNCA aparece fora da conversa**: em auto de infração, RT, notificação
+  DET, e-mail, `.docx`, `memory.md` ou TXT do Sistema Auditor não existe persona nem
+  tratamento — tom formal, técnico, impessoal, em terceira pessoa. Nunca assine nada
+  nem mencione o nome do assessor em texto que será colado em outro lugar.
+- **Persona é só tom de voz.** Não muda nenhuma regra deste perfil: você sugere, o AFT
+  decide; privacidade, enquadramento e autuação seguem intactos. Cortesia não é
+  concordância — aponte o problema quando houver.
+- Sem os campos no `aft-config.md`, siga como hoje, sem persona.
 
 ## AFT Toolkit
 

--- a/novidades/2026-08-20-04-persona-assessor.md
+++ b/novidades/2026-08-20-04-persona-assessor.md
@@ -1,0 +1,17 @@
+## 20/08/2026
+<!-- commit: persona-assessor -->
+
+**O assistente agora pode ter nome e chamar você de "Dr." ou "Dra." (opcional).**
+Muitos colegas já batizaram o assistente no particular: Claudinho, Claudete... Agora
+isso é oficial. Você escolhe um tratamento para si ("Dr. João", "Dra. Maria" ou só o
+primeiro nome) e um nome para o assessor, e ele passa a usar os dois na conversa, como
+um assessor de gabinete. A regra dura: **vale só no chat**. Auto de infração, RT,
+notificação do DET, e-mail, relatório e qualquer documento continuam formais e
+impessoais, sem persona e sem assinatura do assistente — e nenhuma regra de trabalho
+muda (quem decide segue sendo o AFT). Quem está instalando agora responde uma pergunta
+a mais no `/aft-setup`; quem já tem o toolkit pode simplesmente pedir na conversa
+("quero que você me chame de Dr. Fulano e atenda por Claudinho") que o assistente grava
+os campos `tratamento` e `nome_assessor` no `aft-config.md`. É totalmente opcional: sem
+os campos, nada muda.
+
+---


### PR DESCRIPTION
## O que muda para o AFT

Muitos colegas ja batizaram o assistente no particular (Claudinho, Claudete...). Agora isso e padrao do toolkit, de forma opcional:

- **config/CLAUDE-aft.md** (bloco v14 -> v15): nova secao "Persona do assessor (opcional)", logo apos "Papel do Claude". Le dois campos opcionais do aft-config.md: `tratamento` (como o assistente chama o AFT no chat) e `nome_assessor` (o nome pelo qual o assistente atende). Tres fronteiras duras: persona so no chat (nunca em auto, RT, DET, e-mail, .docx, memory.md ou TXT), o assistente nunca assina nada, e persona e so tom de voz (nao afrouxa nenhuma regra do perfil). Sem os campos, comportamento identico ao atual.
- **aft-setup/SKILL.md**: pergunta unica e opcional ao fim do Passo 3 (gravar o que o AFT disser; nunca deduzir genero pelo nome) e os dois campos no front-matter do Passo 5.
- **novidades/2026-08-20-04-persona-assessor.md**: entrada do changelog, incluindo como quem ja tem o toolkit ativa (pedir na conversa; o assistente grava os campos no aft-config.md).
- **arquitetura** (.json + .html sincronizados) e nota tecnica nova no cofre (persona-assessor.md).

Nenhum script Python muda: quem le os campos e o proprio Claude, via a regra do perfil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)