### PR TITLE
fix(painel): UnicodeEncodeError no gerar_painel.py em console cp1252 (Windows)

### DIFF
--- a/_scripts/gerar_painel.py
+++ b/_scripts/gerar_painel.py
@@ -77,6 +77,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Console do Windows é cp1252: sem isto, o JSON final (nomes de empregador com
+# acento) estoura em UnicodeEncodeError antes de terminar de imprimir.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 try:
     import pdfplumber  # opcional: detecção pelo conteúdo da 1ª página
 except ImportError:

--- a/novidades/2026-08-20-05-painel-acento-windows.md
+++ b/novidades/2026-08-20-05-painel-acento-windows.md
@@ -1,0 +1,13 @@
+## 20/08/2026
+<!-- commit: painel-acento-windows -->
+
+**Conserto: o painel não quebra mais com acento no nome da empresa (Windows).** Em
+algumas máquinas Windows, o `gerar_painel.py` era interrompido por um erro de
+codificação na hora de imprimir o resumo final, quando o nome de um empregador
+tinha acento gravado de um jeito específico (o "ã" ou "ç" desmontado em duas
+partes, coisa que acontece ao colar o nome de outro sistema). O sintoma era a
+sincronização do Google Agenda (/aft-agenda-det) ou o /aft-painel pararem no
+meio com um ticket de erro. Agora o script se protege sozinho, como os demais
+scripts do toolkit já faziam, e imprime o resumo completo em qualquer console.
+
+---


### PR DESCRIPTION
## O problema

Ticket de campo `ticket-2026-08-20-0719`: na maquina de um colega AFT, a tarefa agendada da /aft-agenda-det chamava o `gerar_painel.py` e ele morria em `UnicodeEncodeError` no `print` final do resumo JSON, antes de terminar de imprimir o campo `vencimentos`.

Causa: o console do Windows e cp1252 e o JSON sai com `ensure_ascii=False`. A pegadinha e que cp1252 ate aceita "a" com til normal — o caractere que estourou foi o **til combinante** (\u0303): o nome do empregador estava em forma decomposta (NFD), tipico de nome colado de outro sistema.

## O conserto

O mesmo bloco de `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` que praticamente todos os outros `_scripts/*.py` ja usam — o `gerar_painel.py` era a excecao.

## Verificacao

Reproduzido em pasta de teste (nome ficticio em NFD + `PYTHONIOENCODING=cp1252`): sem o conserto, o mesmo `UnicodeEncodeError` do ticket; com o conserto, exit 0 e JSON completo com o nome acentuado.

Nota tecnica nova no cofre: `robustez-encoding-windows.md` (inclui um limite conhecido: memory.md inteiro em NFD faz o titulo de secao nao casar e a secao sumir em silencio — nao corrigido aqui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)