### PR TITLE
Correcoes achadas ao validar o fluxo de NAD: NCO, AET e exemplo do gera-ai

### DIFF
--- a/_scripts/notebooklm_reauth.py
+++ b/_scripts/notebooklm_reauth.py
@@ -78,6 +78,8 @@ def _python_do_notebooklm() -> Path | None:
     raizes: list[Path] = []
     if os.environ.get("PIPX_HOME"):
         raizes.append(Path(os.environ["PIPX_HOME"]) / "venvs")
+    if os.environ.get("LOCALAPPDATA"):
+        raizes.append(Path(os.environ["LOCALAPPDATA"]) / "pipx" / "pipx" / "venvs")  # pipx padrao atual no Windows
     raizes += [
         Path.home() / "pipx" / "venvs",            # pipx novo no Windows
         Path.home() / ".local" / "pipx" / "venvs",  # pipx clássico

--- a/_scripts/validar_txt.py
+++ b/_scripts/validar_txt.py
@@ -43,6 +43,22 @@ except Exception:
 
 TOKEN = re.compile(r"\[\[[A-Z0-9_]+\]\]")
 
+# Subtitulos obrigatorios do texto_autuacao (campo 18) - com acento correto.
+# O latin-1 final suporta acentuacao normalmente; nao ha motivo para tirar acento
+# aqui. Ja aconteceu de um script de montagem escrever "FISCALIZACAO"/"OBSERVACOES"
+# sem acento, ou descartar o subtitulo III inteiro por erro de regex na extracao -
+# nenhum dos dois quebra o TXT (o Sistema Auditor aceita e importa normalmente),
+# entao so aparece quando o AFT confere o auto ja importado. Pegamos aqui antes.
+SUBTITULOS_OK = ["I - DA FISCALIZAÇÃO:", "II - IRREGULARIDADE:", "III - OBSERVAÇÕES:"]
+# "IRREGULARIDADE" nao tem acento em portugues - so FISCALIZACAO e OBSERVACOES
+# denunciam perda de acento (deveriam ser FISCALIZAÇÃO e OBSERVAÇÕES).
+SUBTITULOS_SEM_ACENTO = re.compile(r"\b(FISCALIZACAO|OBSERVACOES)\s*:", re.IGNORECASE)
+# "#13#10" que precede texto real (nao o marcador de linha em branco " . ") deve
+# vir seguido de exatamente 8 espacos - e o recuo de paragrafo que indenta_quebras.py
+# aplica. Sem ele, o Sistema Auditor mostra o subtitulo "I" com recuo (automatico,
+# so na primeira linha do campo) e todo o resto colado na margem.
+QUEBRA_SEM_RECUO = re.compile(r"#13#10(?! \. )(?!        )")
+
 # O Sistema Auditor limita os anexos a 10 MB por AUTO DE INFRACAO, somando os
 # anexos daquele auto — nao por arquivo. Estourou num auto, a importacao e recusada.
 # O mesmo PDF anexado a varios autos e permitido: pesa 1 vez no orcamento de cada um.
@@ -227,6 +243,27 @@ def main():
             # Texto do auto (campo 18): subtitulo/linha duplicados.
             if len(campos) > 17:
                 checar_texto_autuacao(campos[17], rotulo, erros)
+
+            # texto_autuacao (campo 18): subtitulos I/II/III presentes e acentuados,
+            # e recuo de paragrafo aplicado (indenta_quebras.py ja rodado).
+            if len(campos) > 17:
+                texto = campos[17]
+                faltando = [s for s in SUBTITULOS_OK if s not in texto]
+                if faltando:
+                    erros.append(f"{rotulo} -> Erro: subtitulo(s) ausente(s) ou sem acento "
+                                 f"correto no texto_autuacao: {', '.join(faltando)}. Confira "
+                                 f"se a extracao do bloco III do autos.md descartou o "
+                                 f"cabecalho, ou se o script de montagem escreveu o rotulo "
+                                 f"sem acento.")
+                sem_acento = SUBTITULOS_SEM_ACENTO.findall(texto)
+                if sem_acento:
+                    erros.append(f"{rotulo} -> Erro: subtitulo(s) sem acento no texto_autuacao: "
+                                 f"{', '.join(sorted(set(sem_acento)))}. O latin-1 aceita "
+                                 f"acento normalmente - corrija o script de montagem.")
+                if QUEBRA_SEM_RECUO.search(texto):
+                    avisos.append(f"{rotulo} -> recuo de paragrafo nao aplicado no "
+                                  f"texto_autuacao (rode indenta_quebras.py sobre o "
+                                  f"tokenized.txt antes de re-hidratar).")
 
         elif tipo == "2":
             rotulo = (f"AI CNPJ/CPF:{bloco_atual[0]} Ementa:{bloco_atual[1]}"

--- a/aft-aet-auditoria/SKILL.md
+++ b/aft-aet-auditoria/SKILL.md
@@ -426,13 +426,16 @@ econômica** do estabelecimento, **CNPJ** (apenas dígitos).
 
 **Regras de redação do subtítulo 2:**
 
-- Estruture as evidências em **lista numérica** (`1)`, `1.1)`, `2)`...), cada item ligando o
-  fato à exigência da NR-17. Esta é a forma de tornar a análise rastreável no auto.
-  **Separe cada item por linha em branco** no `autos.md` — é o que o `/aft-gera-ai` converte
-  em quebra de linha real no Sistema Auditor; uma lista numérica sem quebra entre os itens
-  sai como um único parágrafo corrido. A conclusão jurídica e o parágrafo de dano coletivo
-  (abaixo) também ficam isolados, cada um no seu próprio parágrafo, nesta ordem: conclusão
-  jurídica logo após a última evidência/enquadramento; dano coletivo fechando o bloco II.
+- Estruture as evidências em **parágrafos corridos, nunca em lista numérica** (nada de
+  `1)`, `1.1)`, `2)`...): um parágrafo por evidência, ligando o fato à exigência da NR-17,
+  separado do seguinte por linha em branco. **Separe cada parágrafo por linha em branco**
+  no `autos.md` — é o que o `/aft-gera-ai` converte em quebra de linha real no Sistema
+  Auditor; um bloco sem quebra entre os parágrafos sai como um único parágrafo corrido
+  ilegível. Quando um ponto elabora o parágrafo anterior (ex.: um exemplo específico de um
+  achado geral), funda as duas frases no mesmo parágrafo em vez de abrir um item novo. A
+  conclusão jurídica e o parágrafo de dano coletivo (abaixo) também ficam isolados, cada um
+  no seu próprio parágrafo, nesta ordem: conclusão jurídica logo após a última
+  evidência/enquadramento; dano coletivo fechando o bloco II.
 - Descreva os **fatos concretos** com precisão técnica e tom oficial.
 - Cite o **dispositivo da NR-17** violado (item exato, ex: 17.3.3, 17.3.8, 17.4.1(d),
   17.4.2, 17.4.3).

--- a/aft-auditoria-geral/SKILL.md
+++ b/aft-auditoria-geral/SKILL.md
@@ -300,6 +300,10 @@ do Decreto nº 4.552/2002, iniciada em [data_inspecao] e ainda em curso
 na presente data no empregador acima qualificado.
 ```
 
+> Este subtítulo (I - DA FISCALIZAÇÃO) é sempre este texto fixo, independente da
+> fonte da irregularidade (campo ou documental) — não varie. A **fonte** do auto
+> (campo vs. documental) se reflete na abertura do **Subtítulo 2**, não neste.
+
 **Enriquecimento contextual** — acrescente, na sequência, apenas os itens que o relato fornecer:
 
 | Informação no relato | Como inserir |
@@ -334,6 +338,24 @@ O texto deve conectar o **fato empírico** (o que foi constatado no local) com o
 | **Como** | Como a irregularidade se manifesta? | ✅ Necessário — fato empírico observado + descrição técnica da falha e do risco gerado. |
 | **Por Quê** | O que a norma exigia? | ✅ Necessário — conduta devida conforme a lei + conexão com o item normativo violado (fato típico). |
 
+**Frase de abertura do Subtítulo 2 — uma por fonte, idêntica em todos os autos daquela fonte.**
+
+O primeiro parágrafo do Subtítulo 2 varia conforme a **fonte da irregularidade** (Fase 1),
+mas deve ser **textualmente idêntico** em todos os autos que compartilham a mesma fonte
+nesta OS — nunca deixe alguns autos com data e outros sem, ou frases parecidas mas não
+iguais. Duas fórmulas fixas, escolha uma por auto conforme a origem do achado:
+
+- **Fonte A (campo, `inspecao-fisica.md`):**
+  `"Em [data_inspecao], durante inspeção física no estabelecimento do empregador, no setor [SETOR], constatou-se que..."`
+- **Fonte B (documental, análise de resposta a notificação/PGR/PCMSO/AEP etc.):**
+  `"Mediante análise da documentação apresentada em resposta à Notificação nº [NUM_NAD], constatou-se que..."`
+- **Auto que combina achado de campo confirmado por documento** (ex.: interdição
+  seguida de Relatório Técnico): use a fórmula de campo (Fonte A) — o documento entra
+  como elemento de convicção, não como abertura.
+
+Ao redigir a leva de autos de uma mesma OS, **releia o primeiro parágrafo de todos antes
+de apresentar** e corrija qualquer divergência: mesma fonte → mesma frase, literal.
+
 **Lógica de redação (3 movimentos)** — conecta o empírico ao típico nesta ordem, **cada
 movimento em seu próprio parágrafo** (separado por linha em branco no `autos.md` — é o
 que o `/aft-gera-ai` converte em quebra de linha real no Sistema Auditor; um bloco II sem
@@ -358,7 +380,39 @@ parágrafo, **nesta ordem**: a conclusão jurídica vem logo após o enquadramen
 **Regras de redação:**
 
 - Descreva os **fatos concretos** constatados, com precisão técnica e tom oficial.
+- **Identifique a máquina/equipamento explicitamente em CADA auto**, por nome/tipo (e
+  marca/modelo se houver) — nunca "a máquina" genérico quando a OS tem mais de um
+  equipamento envolvido. Cada auto é uma peça autônoma e precisa fazer sentido sozinho
+  para a defesa do autuado, mesmo que outro auto da mesma leva já tenha citado o
+  mesmo equipamento.
+- **Confira o equipamento contra a fonte primária antes de redigir**, nunca por
+  inferência ou memória do relato: se houver Relatório Técnico de interdição/embargo,
+  laudo ou outro documento técnico que descreva o objeto, releia-o e confirme qual
+  objeto (ex.: "Objeto 1"/"Objeto 2") corresponde à ementa antes de atribuir a máquina
+  ao auto. Atribuição errada de máquina é o erro mais caro de corrigir depois.
 - Cite o **dispositivo legal infringido** (artigo da CLT, item da NR, portaria).
+- **Fechamento do Subtítulo 2** — antes do parágrafo de dano coletivo, feche com uma
+  frase padronizada de enquadramento normativo, igual em estrutura para todos os autos
+  da leva: `"A conduta contraria o disposto no item [X.X.X] da [norma], que exige/impõe [síntese da exigência]."`
+  Se o auto decorreu de interdição/embargo, acrescente ao final desse mesmo parágrafo (não
+  em parágrafo à parte) a menção ao Termo, ex.: `"A gravidade da situação determinou a
+  lavratura do Termo de Interdição nº [...], com paralisação total da máquina [...], na
+  mesma data."` — releia todos os autos da leva juntos e confira que a estrutura do
+  fechamento é a mesma antes de apresentar.
+- **Exceção de padronização — Regra Especial:** ementas com corpo de texto fixado em lei
+  ou norma interna do toolkit (ex.: 101060-3, quando a interdição está confirmada) têm
+  texto **literal e imutável** — não aplique a padronização de abertura/fechamento acima
+  a esse subtítulo; reproduza o texto fixo tal como definido na skill/normativo de origem.
+- **Bis in idem entre ementa geral e específica da mesma NR:** quando duas ementas da
+  mesma NR podem, em tese, cobrir o mesmo ponto físico de risco — uma de zona de perigo
+  geral (ex.: NR-12 item 12.5.1) e outra específica para o tipo de risco (ex.: NR-12 item
+  12.4.1 dispositivos de partida, ou 12.8.1 transportadores contínuos) — **não autue as
+  duas para o mesmo ponto/zona**. Aplique o princípio da especialidade (norma específica
+  prevalece sobre a geral) e, se ambas forem cabíveis por a máquina ter mais de uma zona
+  de perigo distinta, delimite explicitamente no texto de cada auto **qual zona física**
+  cada ementa cobre (ex.: "área de prensagem" num auto, "área dos roletes" no outro), de
+  modo que nenhum auto autue duas vezes o mesmo fato. Na dúvida sobre qual ementa é a
+  específica para o caso, confirme via NotebookLM (Fase 2, Camada 1) antes de redigir.
 - **Sempre cite ao menos 1 ou 2 empregados** como exemplos de prejudicados, mesmo em infrações de natureza coletiva. O nome do empregado é necessário para permitir a defesa do autuado. **Na redação e nos ecos do chat, use os tokens `[[TRAB_NN]]` (e `[[CPF_NN]]` se citar CPF)**, registrando o par real no `.depara_[CNPJ].json` da OS — o `/aft-gera-ai` re-hidrata no TXT final. Se o auditor não forneceu nomes, use `[NOME DO EMPREGADO 1 - FUNÇÃO]` como placeholder e peça os dados.
 - Se houver consulta ao eSocial, mencione a data e os eventos verificados (S-2190, S-2200, etc.).
 - **Conclusão jurídica logo após o enquadramento normativo** (parágrafo próprio, imediatamente depois do movimento 3): "Sendo assim, incorreu o empregador na infração ementada supracitada."
@@ -427,6 +481,13 @@ Ao redigir os autos, avalie se alguma irregularidade constitui **risco grave e i
 Se detectar: marque internamente `[RISCO_GRAVE = true]` para usar na Fase 5.
 
 ### Apresentação
+
+Antes de apresentar, **releia os autos da leva lado a lado** e confira: (1) mesma fonte
+→ mesma frase de abertura do Subtítulo 2, literal; (2) fechamento normativo com a mesma
+estrutura em todos; (3) toda máquina/equipamento nomeada explicitamente em cada auto que
+a envolve; (4) nenhum par de ementas geral/específica autuando o mesmo ponto físico sem
+delimitação de zona. Corrija divergências antes de mostrar ao AFT — pedir para ele
+apontar inconsistências depois custa uma rodada de revisão inteira.
 
 Apresente cada auto numerado:
 

--- a/aft-autos-lavrados/SKILL.md
+++ b/aft-autos-lavrados/SKILL.md
@@ -148,6 +148,7 @@ Capture o JSON do stdout. Estrutura:
       "ementa_num": "001839-2", "ementa_descricao": "Deixar de controlar...",
       "historico_raw": "Trata-se de fiscalização...", "data_lavratura": "13/03/2026",
       "cnpj_autuado": "...", "razao_social_autuado": "...",
+      "porte_economico": "Outros", "nro_trabalhadores": 53,
       "status_duplicidade": "unico", "warnings": [] }
   ],
   "errors": []
@@ -155,6 +156,8 @@ Capture o JSON do stdout. Estrutura:
 ```
 
 Cada auto traz `status_duplicidade` (`unico` · `mantido_ultimo` · `cancelado_presumido` · `manter_todos` · `revisar`) e, quando cancelado, `substituido_por` com o AI do válido — o script já resolve isso; a interpretação está no Passo 2.5.
+
+`porte_economico` e `nro_trabalhadores` só vêm preenchidos em auto **efetivamente lavrado** — o Sistema Auditor exige os dois campos antes da lavratura, mas em rascunho/"Em elaboração" saem em branco (porte) ou com o placeholder `-1` (trabalhadores); o script já filtra isso e devolve `null` nesse caso. Uso no Passo 6.5.
 
 **Tratamento de casos:**
 - `pasta_auditor: null` + `match_estrategia: nao_encontrado` + `candidatos_alternativos: []` → OS sem autos transmitidos. Siga ao Passo 4 com lista vazia.
@@ -331,6 +334,34 @@ Depois, adicione 1 linha em `## Registro de atividades` (append na tabela; não 
 
 > O `memory.md` do toolkit é um markdown simples (sem schema rígido nem limite de linhas) — basta editar as duas seções com a tool `Edit`, sem validador externo.
 
+### Passo 6.5 — Aproveitar Porte/Nº de trabalhadores do primeiro auto lavrado
+
+Várias skills do toolkit perguntam ao AFT o porte da empresa (regra de dupla visita,
+pares de ementa ME/EPP × geral) e o número de trabalhadores (CIPA, SESMT, NR-24) — dado
+que, uma vez que exista ao menos **um** auto efetivamente lavrado, já está preenchido no
+próprio PDF (campos `porte_economico`/`nro_trabalhadores` do scan, Passo 2). Poupe essa
+pergunta nas próximas skills que abrirem esta OS:
+
+1. Entre os autos **válidos** desta rodada (Passo 2.5), pegue o primeiro (ordem
+   cronológica) que tiver `porte_economico` e/ou `nro_trabalhadores` não-nulos. Como os
+   dois campos são do cadastro do empregador, não da ementa, o valor é o mesmo em todos
+   os autos da mesma OS — um único auto com o dado já basta.
+2. **Só grave o que ainda não está no `memory.md`.** Verifique se já existe uma linha
+   `**Porte:**` e/ou `**Nº de trabalhadores:**` no corpo (geralmente logo abaixo do
+   `**CNPJ:**`/`**CPF:**`). Se já existir, **não sobrescreva** — pode ter sido escrita ou
+   corrigida à mão pelo AFT, e o dado do PDF nunca prevalece sobre isso. Só complete o
+   que estiver faltando.
+3. Formato da linha (mesma linha para os dois campos, se ambos faltarem; separe com
+   `·` se só um faltar e o outro já existir e precisar ficar ao lado):
+   ```markdown
+   **Porte:** <porte_economico> (<"não ME/EPP" se "Outros", "ME/EPP" se "ME" ou "EPP">) · **Nº de trabalhadores:** <nro_trabalhadores>   <!-- extraído do AI <numero_ai> lavrado, <data_lavratura> -->
+   ```
+   Use Edit cirúrgico, inserindo a linha logo após `**CNPJ:**`/`**CPF:**` do cabeçalho —
+   não crie seção nova para isso.
+4. Nenhum auto válido desta rodada trouxe os campos (todos `null`) → não toque nessa
+   parte do `memory.md`; segue tudo igual, sem pendência a registrar (não é erro, só
+   significa que os autos ainda são rascunho ou o texto do PDF não bateu com o padrão).
+
 ### Passo 7 — Reportar ao AFT
 
 **Modo OS única:**
@@ -363,6 +394,9 @@ Use `⚠` para linhas com pendentes > 0, com autos `revisar` não decididos, ou 
 - `memory.md` é editado por chave (número do AI nas linhas `[x]`/`(cancelado)`; ementa nas `[ ]` pendentes) — não duplica linhas.
 - Linha em "Registro de atividades" é append-only.
 - A extração é determinística — mesma entrada, mesma saída.
+- Porte/Nº de trabalhadores (Passo 6.5): só escreve se a linha ainda não existir no
+  `memory.md` — rodar de novo nunca sobrescreve um valor já gravado (do PDF ou digitado
+  pelo AFT).
 
 ## Erros comuns e tratamento
 

--- a/aft-autos-lavrados/scripts/scan_autos.py
+++ b/aft-autos-lavrados/scripts/scan_autos.py
@@ -65,6 +65,14 @@ RE_EMENTA_NUM = re.compile(r"(\d{6}-\d)")
 RE_DATA_LAVRATURA = re.compile(r"Data:\s*(\d{2}/\d{2}/\d{4})")
 RE_CNPJ_AUTUADO = re.compile(r"CNPJ\s*:\s*(\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2})")
 RE_RAZAO_SOCIAL = re.compile(r"Nome/Razão Social:\s*(.+?)\s*$", re.MULTILINE)
+# Campos só preenchidos pelo Sistema Auditor no momento da LAVRATURA — vêm
+# em branco (Porte) ou com o placeholder "-1" (Nº Trabalhadores) em autos
+# ainda em elaboração/rascunho. Regex tolerante a espaçamento: o pdftotext
+# -layout separa "Porte Econômico: X" de "Natureza Jurídica: Y" por vários
+# espaços, mas o fallback pypdf pode concatenar sem espaço nenhum — por
+# isso a captura usa lookahead no próximo rótulo em vez de contar espaços.
+RE_PORTE_ECONOMICO = re.compile(r"Porte\s*Econômico:\s*(.+?)(?=Natureza\s*Jurídica|\n|$)")
+RE_NRO_TRABALHADORES = re.compile(r"N[ºo°]\s*Trabalhadores\s*\(total\)\s*:\s*(-?\d+)")
 
 
 def numero_ai_do_nome(nome_arquivo: str):
@@ -189,6 +197,8 @@ def parse_auto(text: str, pdf_path: Path) -> dict:
         "data_lavratura": None,
         "cnpj_autuado": None,
         "razao_social_autuado": None,
+        "porte_economico": None,
+        "nro_trabalhadores": None,
         "warnings": warnings,
     }
 
@@ -210,6 +220,22 @@ def parse_auto(text: str, pdf_path: Path) -> dict:
     m_rs = RE_RAZAO_SOCIAL.search(text)
     if m_rs:
         out["razao_social_autuado"] = m_rs.group(1).strip()
+
+    # Porte Econômico e Nº de Trabalhadores: só existem preenchidos em auto já
+    # LAVRADO (o Sistema Auditor exige o preenchimento antes da lavratura). Em
+    # rascunho/"Em elaboração" vêm em branco ou como placeholder "-1" — nesse
+    # caso o campo sai None, para não gravar lixo no memory.md.
+    m_porte = RE_PORTE_ECONOMICO.search(text)
+    if m_porte:
+        porte = m_porte.group(1).strip()
+        if porte:
+            out["porte_economico"] = porte
+
+    m_trab = RE_NRO_TRABALHADORES.search(text)
+    if m_trab:
+        n = int(m_trab.group(1))
+        if n >= 0:
+            out["nro_trabalhadores"] = n
 
     ementa_idx = text.find("EMENTA (Nº/Descrição):")
     if ementa_idx == -1:

--- a/aft-gera-ai/SKILL.md
+++ b/aft-gera-ai/SKILL.md
@@ -417,7 +417,19 @@ Linhas separadas por `\n`.
     só os parágrafos que a `/aft-revisa-auto` (FASE 2.7) separou; um bloco II com vários
     parágrafos no `autos.md` deve sair com vários `#13#10` no meio, não um único parágrafo
     corrido.
-  - Exemplo: `I - DA FISCALIZACAO:#13#10 . #13#10Trata-se de acao fiscal...de X.#13#10 . #13#10II - IRREGULARIDADE:#13#10 . #13#10Na referida fiscalizacao...#13#10Dano de natureza coletiva...#13#10 . #13#10III - OBSERVACOES:#13#10 . #13#10a) ...#13#10b) ...`
+  - Exemplo: `I - DA FISCALIZAÇÃO:#13#10 . #13#10Trata-se de ação fiscal...de X.#13#10 . #13#10II - IRREGULARIDADE:#13#10 . #13#10Na referida fiscalização...#13#10Dano de natureza coletiva...#13#10 . #13#10III - OBSERVAÇÕES:#13#10 . #13#10a) ...#13#10b) ...`
+  - **Nunca escreva os subtítulos sem acento** (`FISCALIZACAO`, `OBSERVACOES`) — mesmo em rascunho
+    interno ou script auxiliar. O encoding final (latin-1) suporta acento normalmente; a única
+    razão para tirar acento seria confundir "ASCII-safe" com "exigência do sistema", o que é falso
+    aqui e já causou um auto real sair sem o cabeçalho `III - OBSERVAÇÕES:` corretamente acentuado
+    numa fiscalização (17/08/2026). Se montar o `[texto_autuacao]` por script (em vez de digitar
+    linha a linha), **teste a saída extraindo o campo 18 de uma linha tipo 1 e conferindo, à mão,
+    que os três subtítulos aparecem completos e acentuados** antes de rodar `indenta_quebras.py`.
+  - **Ao extrair um bloco III já existente do `autos.md`** (o texto fixo `III - OBSERVAÇÕES:...`
+    que a Fase 2 injeta), a extração deve **incluir o cabeçalho `III - OBSERVAÇÕES:` no resultado**,
+    não só o conteúdo depois dele — um erro de regex que capture só o que vem *depois* do
+    cabeçalho descarta o subtítulo inteiro do TXT final sem dar erro em lugar nenhum (o
+    `validar_txt.py` não pegava isso; ver checagem nova abaixo).
   - **Normalização do legado (obrigatória)**: rascunho antigo redigido com `1) DA FISCALIZAÇÃO:` / `2) IRREGULARIDADE:` / `3) OBSERVAÇÕES:` é convertido para o formato romano ao montar o `[texto_autuacao]` (troca determinística de subtítulo, sem tocar no resto do texto) — todo TXT sai no formato novo, mesmo de rascunho antigo.
   - **Recuo de primeira linha (aplicado por script na geração, ver "Geração e salvamento"):** monte o `[texto_autuacao]` com os `#13#10` puros, como acima. O recuo NÃO é digitado à mão — o passo `indenta_quebras.py` insere, de forma determinística, 8 espaços após cada `#13#10` que precede texto real (parágrafo, subtítulo, alínea), deixando os parágrafos com recuo no Sistema Auditor. Os marcadores de linha em branco `#13#10 . #13#10` são preservados (o ponto continua com 1 espaço de cada lado, sem recuo). Não escreva os 8 espaços você mesmo — apenas rode o script.
 - `[cod_3]` = código da ementa com o hífen removido, mantendo TODOS os dígitos. Ex: `312358-8` → `3123588`; `000361-0` → `0003610`. Nunca usar zero-padding de 7 dígitos — o dígito verificador faz parte do código.
@@ -452,11 +464,20 @@ linha 6 (CIF)
    ```
    <OS_ATIVAS>/[PASTA_EMPRESA]/[PASTA_LAVRATURA]/AI_[NUM_AUTOS]_[CNPJ].tokenized.txt
    ```
-4. **Recuo de primeira linha (obrigatório).** Rode o script do toolkit sobre o tokenizado — ele insere 8 espaços após cada `#13#10` que precede texto real (recuo de parágrafo no Sistema Auditor), preservando os marcadores de linha em branco `#13#10 . #13#10`. É idempotente (rodar de novo não duplica o recuo):
+4. **Recuo de primeira linha (obrigatório — NUNCA pule este passo).** Rode o script do toolkit sobre o tokenizado — ele insere 8 espaços após cada `#13#10` que precede texto real (recuo de parágrafo no Sistema Auditor), preservando os marcadores de linha em branco `#13#10 . #13#10`. É idempotente (rodar de novo não duplica o recuo):
    ```bash
    DIR="<OS_ATIVAS>"/"[PASTA_EMPRESA]"/"[PASTA_LAVRATURA]"
    python ~/.claude/skills/_scripts/indenta_quebras.py "$DIR/AI_[NUM_AUTOS]_[CNPJ].tokenized.txt"
    ```
+   > **Por que isso é fácil de esquecer:** o Sistema Auditor aplica recuo automático **só na
+   > primeiríssima linha** do campo (o subtítulo `I - DA FISCALIZAÇÃO:`, que fica sem espaço nenhum
+   > antes dele mesmo). Todas as outras quebras (`#13#10` que o Toolkit cria manualmente) **não**
+   > ganham recuo sozinhas — sem este script, o resultado visual é o subtítulo `I` com recuo e
+   > tudo o mais (parágrafos, `II`, `III`) grudado na margem, uma inconsistência visível na
+   > importação. Regenerar o TXT numa correção rápida e esquecer de rodar este passo de novo
+   > é o erro mais fácil de cometer — se você regenerar o `.tokenized.txt` do zero por qualquer
+   > motivo (nova correção de texto, novo script de montagem), rode este passo de novo **antes**
+   > de re-hidratar, mesmo que pareça repetição.
 5. **Re-hidrate** rodando o script do toolkit (gera o TXT real, já em latin-1, a partir do tokenizado + de-para):
    ```bash
    DIR="<OS_ATIVAS>"/"[PASTA_EMPRESA]"/"[PASTA_LAVRATURA]"

--- a/aft-gera-ai/SKILL.md
+++ b/aft-gera-ai/SKILL.md
@@ -417,7 +417,7 @@ Linhas separadas por `\n`.
     só os parágrafos que a `/aft-revisa-auto` (FASE 2.7) separou; um bloco II com vários
     parágrafos no `autos.md` deve sair com vários `#13#10` no meio, não um único parágrafo
     corrido.
-  - Exemplo: `I - DA FISCALIZAÇÃO:#13#10 . #13#10Trata-se de ação fiscal...de X.#13#10 . #13#10II - IRREGULARIDADE:#13#10 . #13#10Na referida fiscalização...#13#10Dano de natureza coletiva...#13#10 . #13#10III - OBSERVAÇÕES:#13#10 . #13#10a) ...#13#10b) ...`
+  - Exemplo: `I - DA FISCALIZAÇÃO:#13#10 . #13#10Trata-se de ação fiscal...de X.#13#10 . #13#10II - IRREGULARIDADE:#13#10 . #13#10Na referida fiscalização...#13#10Sendo assim, incorreu...#13#10Dano de natureza coletiva...#13#10 . #13#10III - OBSERVAÇÕES:#13#10 . #13#10a) ...#13#10b) ...`
   - **Nunca escreva os subtítulos sem acento** (`FISCALIZACAO`, `OBSERVACOES`) — mesmo em rascunho
     interno ou script auxiliar. O encoding final (latin-1) suporta acento normalmente; a única
     razão para tirar acento seria confundir "ASCII-safe" com "exigência do sistema", o que é falso

--- a/aft-organiza-os/SKILL.md
+++ b/aft-organiza-os/SKILL.md
@@ -73,6 +73,13 @@ for d in "<OS_ATIVAS>"/*/; do [ -f "$d/memory.md" ] || echo "$d"; done
    `python ~/.claude/skills/_scripts/backup_arquivo.py "<memory.md>"`). Se estiver em
    dia, não toque.
 
+   **Gatilho específico — Ordem de Serviço sem `## Ementas da OS`.** Se a pasta tiver um
+   PDF de Ordem de Serviço (root ou solto) e o `memory.md` **não** tiver a seção
+   `## Ementas da OS`, isso sozinho já qualifica a pasta como "atualização" — mesmo que
+   nada mais esteja fora do padrão. É o caso típico de OS organizada antes desta
+   extração existir na skill, ou de Ordem de Serviço salva depois do primeiro
+   `/aft-organiza-os`.
+
    **Layout antigo (anterior a 22/07/2026) → migração.** Antes, notificações e pastas
    de autos ficavam soltas na raiz. Detecte e inclua a migração no plano quando houver,
    na raiz: `notificacao-*.pdf`, `relatorio-atendimento-*.pdf`, `notificacao-*/`,
@@ -97,6 +104,7 @@ Classifique cada item pelas assinaturas (nome do arquivo + texto da 1ª página)
 | Tipo | Assinaturas típicas |
 |---|---|
 | **Notificação DET** | "NOTIFICAÇÃO Nº" + código alfanumérico 12–16 chars (ex.: `S8JHJEYM2OC4VE`); "NOTIFICAÇÃO PARA A APRESENTAÇÃO DE DOCUMENTOS"/"CORREÇÃO"; cabeçalho MTE/SIT |
+| **Ordem de Serviço do SFIT** | arquivo tipo `OrdemServico*.pdf` ou qualquer nome (ex.: "Ordem de Serviço.pdf"); cabeçalho "Ordem de Serviço", seções "1. Dados da OS" / "4. Ementas a Fiscalizar" / "6. Equipe AFT" — mesma assinatura que o `/aft-nova-auditoria` usa no Passo 0 |
 | **Relatório de atendimento do DET** | nome `relatorio-atendimento*<CODIGO>*.pdf` ou 1ª página "Relatório de Atendimento" + código — é **evidência de que o DET foi respondido** |
 | **Notificação emitida pelo AFT (TN/NCO ou NAD)** | nome `tn-nco-*` ou `nad-*` (saídas das skills `/aft-tn-nco` e `/aft-NAD`) — o `.docx` vai para `NOTIFICACOES/`, o `.md` **fica na raiz** |
 | **Relação de autos lavrados** | "Relação de Autos de Infração Lavrados" (relatório do Sistema Auditor); nome tipo `RR_*.PDF` |
@@ -123,6 +131,11 @@ Extraia, quando presentes:
 - Da relação de autos: para cada auto, **número do AI** (9 dígitos → formate
   `XX.XXX.XXX-X`), **data de lavratura**, **ementa** (7 dígitos → `XXXXXX-X`) e um resumo
   curtíssimo da descrição.
+- Da Ordem de Serviço: nº da OS, prazo limite para término da fiscalização (o
+  **vencimento da OS**), e a tabela inteira da seção "4. Ementas a Fiscalizar"
+  (Atributo/NR, código da ementa, descrição) — **código e descrição literais do PDF,
+  nunca resumidos ou parafraseados**. É a mesma extração que o `/aft-nova-auditoria`
+  faz no Passo 0; aqui ela vira a seção `## Ementas da OS` do `memory.md` (FASE 4).
 
 > Privacidade: **não abra nem ecoe** conteúdo de listas de empregados (ex.: "RELAÇÃO DE
 > EMPREGADOS.xlsx") nem documentos pessoais de trabalhador (CNH, RG, CAT, certidão de
@@ -151,10 +164,14 @@ Monte **um único plano** cobrindo todas as pastas (novas + atualizações) e pe
    Empregador: ACME LTDA · CNPJ 11.222.333/0001-44
    ⚠️ Sem o PDF da notificação DET na pasta → DET fica em branco no memory.md
    (preencher depois; sem pergunta)
+   Ordem de Serviço encontrada (OS 99887766-5) → 12 ementas extraídas para
+   "## Ementas da OS"; renomear "OrdemServico.pdf" → "OS 99887766-5.pdf" (fica na raiz)
 
 ── 3. ... ───────────────────────────────────────────────
 
 ── Atualização: "BETA LTDA 11222333000144" ──────────────
+   Ordem de Serviço presente na pasta, mas memory.md não tem "## Ementas da OS"
+   → acrescentar seção com as 8 ementas do PDF (backup do memory.md antes)
    2 arquivos novos soltos na raiz → mover para notificacao-XYZ.../
    (memory.md será editado com backup antes)
 
@@ -171,6 +188,7 @@ só com as fichas e os relatórios `.md`**:
 <EMPREGADOR> <CNPJ>/
 ├── memory.md                     ← ficha da OS
 ├── CLAUDE.md                     ← briefing da sessão (não mover)
+├── OS <nº da OS>.pdf             ← Ordem de Serviço do SFIT, se presente (fica na raiz)
 ├── autos-lavrados.md             ← RAIZ OBRIGATÓRIA (ver regra abaixo)
 ├── analise-preliminar-*.md       ← RAIZ OBRIGATÓRIA
 ├── jornada-analise-*.md          ← RAIZ OBRIGATÓRIA
@@ -185,8 +203,23 @@ só com as fichas e os relatórios `.md`**:
 │   ├── Autos <DD-MM>/            ← TXT + anexos gerados pelo /aft-gera-ai
 │   └── Relacao de autos/         ← relação .docx do /aft-autos-lavrados
 ├── interdicao-embargo/           ← termo, RT, laudos, juntados
+├── RELATÓRIOS DE FISCALIZAÇÃO/   ← todo relatório de fiscalização (ver regra abaixo)
+│   ├── Relatorio auditoria RI <ri>.docx/.md/.json   ← /aft-relatorio
+│   ├── RI <ri> - autos e anexos.pdf                 ← dossiê do /aft-autos-pdf-reunidos
+│   └── relatorio-sfitweb.docx                       ← /minha-risfitweb
 └── fotos/
 ```
+
+> **Pasta padrão para relatórios — `RELATÓRIOS DE FISCALIZAÇÃO/`.** Todo documento cujo
+> propósito é ser um **relatório** da fiscalização (não uma notificação, não um auto,
+> não uma minuta de trabalho em andamento) vai nessa subpasta — crie-a se não existir.
+> Referência: `/aft-relatorio` (Relatório Final Simplificado) e `/minha-risfitweb`
+> (relatório de avaliação de ementas para o SFITWEB) já gravam ali. Documento de
+> relatório avulso pedido fora de skill (ver `/aft-modelo-docx`) segue a mesma regra.
+> Isso é diferente da regra de `.md` na raiz abaixo: os `.md`/`.json` que acompanham um
+> relatório (fonte do `.docx`) ficam **dentro** desta subpasta, junto do `.docx` — não
+> na raiz — porque aqui o documento final é sempre o `.docx`, e manter os três juntos
+> importa mais do que a visibilidade no painel.
 
 > **Regra dura — `.md` fica na RAIZ.** Duas travas no painel, não é preferência de
 > arrumação:
@@ -231,6 +264,16 @@ Regras do plano:
   (`autos.md` + TXT do `/aft-gera-ai`). É a mesma pasta que o `/aft-embargo-interdicao` e o `/aft-embargo-interdicao-manutencao`
   escrevem. Se já existir uma pasta antiga `Autos TE-TI DD-MM/`, inclua no plano
   renomeá-la para `interdicao-embargo/` (ou mover o conteúdo dela para lá).
+- **Ordem de Serviço** → fica na raiz (mesma convenção do `/aft-nova-auditoria`), renomeada
+  para `OS <nº da OS>.pdf` quando o número for extraído; sem número legível, mantenha o
+  nome original e avise no plano. Nunca mova para `NOTIFICACOES/` nem `AUTOS/` — não é
+  nem notificação nem auto, é o documento de abertura da fiscalização.
+- **Relatórios de fiscalização** → subpasta `RELATÓRIOS DE FISCALIZAÇÃO/` (crie se não
+  existir): relatório final (`Relatorio auditoria RI <ri>.docx/.md/.json`), dossiê de
+  autos e anexos (`RI <ri> - autos e anexos.pdf`), relatório de ementas do SFITWEB
+  (`relatorio-sfitweb.docx`) e qualquer outro relatório avulso solto na raiz que não
+  seja notificação, auto ou minuta de trabalho em andamento (esses seguem as regras
+  próprias acima).
 - Fotos: subpasta `fotos/` (crie se estiverem soltas; renomeie `FOTO/` → `fotos/`).
 - Trabalho do AFT em andamento (.docx/.md de minutas e análises): **fica na raiz**,
   intocado, anotado no memory.md.
@@ -254,9 +297,15 @@ status: em_andamento
 # <EMPREGADOR>
 
 **CPF:** <formatado>   (ou **CNPJ:**, conforme o caso)
+**OS (SFIT):** <nº da OS>   <!-- só quando a Ordem de Serviço foi lida -->
+**Vencimento da OS:** <dd/mm/aaaa>   <!-- prazo limite para término; só quando lido -->
 
 ## Notificações DET
 - [ ] <CODIGO> — prazo <dd/mm/aaaa>
+
+## Ementas da OS
+_(OS SFIT nº <os> — ementas a fiscalizar; seção só existe quando uma Ordem de Serviço foi lida)_
+- [ ] <código> — <descrição oficial literal> (<NR ou atributo>)
 
 ## Autos de Infração
 _(vazio)_
@@ -284,6 +333,14 @@ _(vazio)_
      `- [ ] (código não localizado) — prazo (a preencher)` + observação; **não pergunte**.
    - Registre em observação os trabalhos já iniciados pelo AFT (minutas, análises,
      relatórios .docx encontrados na raiz).
+   - **`## Ementas da OS`**: só entra no `memory.md` quando uma Ordem de Serviço foi
+     lida (FASE 2). Código e descrição **literais** do PDF — nunca resuma nem
+     parafraseie a ementa. Numa pasta **nova**, a seção já nasce junto com o resto do
+     arquivo. Numa pasta em **atualização** (memory.md já existe e só falta essa
+     seção — gatilho da FASE 1), acrescente-a com Edit cirúrgico logo após
+     `## Notificações DET`, sem tocar em mais nada do arquivo (o backup já foi feito
+     no passo 2). As linhas `**OS (SFIT):**` e `**Vencimento da OS:**` seguem a mesma
+     regra: só entram/atualizam se a Ordem de Serviço foi lida.
 3. Rode o guarda de PII em cada memory.md escrito — **sempre com a saída em UTF-8**, para
    o console Windows (cp1252) não derrubar o script:
    ```bash
@@ -377,5 +434,7 @@ Próximos passos sugeridos: /analise-preliminar (respostas de DET) · /aft-det-6
 - Dados extraídos vêm **dos documentos** — não invente empregador, código, prazo ou
   número de AI que não estejam escritos neles. Campo não encontrado fica vazio.
 - Código de DET: **só** o que está na linha "NOTIFICAÇÃO Nº" do PDF da notificação.
+- Ementa da Ordem de Serviço: código e descrição **literais** da tabela "4. Ementas a
+  Fiscalizar" — nunca resumir, parafrasear ou completar de memória.
 - Nome/CPF de trabalhador: nunca no chat nem no memory.md (só quantitativos).
 - Encoding UTF-8; datas dd/mm/aaaa no corpo do memory.md.

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -5,15 +5,17 @@ effort: medium
 description: >
   Use quando o AFT quiser redigir uma Notificação para Correção de
   Irregularidades (TN-NCO) — o texto que vai no DET notificando a empresa a
-  corrigir irregularidades de SST. Dispare com /aft-tn-nco, "cria a
-  notificação para corrigir", "redige a TN de correção", "notifica a empresa
-  para sanar as irregularidades", "monta a notificação dessas
-  irregularidades", "notifica tudo o que foi autuado", "uma notificação para
-  cada auto lavrado". Puxa sozinha os autos já lavrados (/aft-autos-lavrados)
-  e oferece um checklist das ementas para o AFT escolher o que notificar.
-  Acione também PROATIVAMENTE logo após identificar
-  irregularidade + NR/item + ementa. NÃO é o auto de infração (/aft-
-  auditoria-geral → /aft-gera-ai).
+  corrigir irregularidades de SST que NÃO foram objeto de auto de infração
+  (o auto já é, por si, meio de coerção indireto). Dispare com /aft-tn-nco,
+  "cria a notificação para corrigir", "redige a TN de correção", "notifica a
+  empresa para sanar as irregularidades", "monta a notificação dessas
+  irregularidades", "monta a NCO da dupla visita". Puxa sozinha os autos já
+  lavrados (/aft-autos-lavrados) só para EXCLUIR da notificação o que já tem
+  auto, e oferece um checklist das demais irregularidades para o AFT
+  escolher o que notificar. Acione também PROATIVAMENTE em dupla visita,
+  logo após identificar irregularidade + NR/item + ementa que ensejaria auto
+  mas cuja autuação foi diferida para a segunda visita. NÃO é o auto de
+  infração (/aft-auditoria-geral → /aft-gera-ai).
 ---
 
 # tn-nco — Notificação para Correção de Irregularidades
@@ -64,11 +66,11 @@ Toda execução desta skill começa consultando o que **já foi autuado** naquel
 2. **Snapshot velho ou ausente → rode a varredura.** Invoque a tool `Agent` com `subagent_type: "aft-autos-lavrados"`, passando **só esta OS** (caminho absoluto da pasta + CNPJ/CPF, ou os 8 primeiros dígitos, conforme o Passo 1 daquela skill), o `python_path` do `aft-config.md` e o caminho do manual `~/.claude/skills/aft-autos-lavrados/SKILL.md`. Avise o AFT em uma linha ("conferindo no Sistema Auditor o que já foi lavrado…"). Ao voltar, leia o `autos-lavrados.md` gravado.
    - Se o tipo de agente não existir, execute a `/aft-autos-lavrados` inline (o fallback previsto nela).
 3. **Sistema Auditor inalcançável** (pasta `PRO` não encontrada, volume do Parallels não montado, erro no scan) → **não trave a notificação**. Diga ao AFT, em uma frase, que não deu para conferir o Sistema Auditor agora e que a lista vem do `memory.md`; use as linhas `- [x]` de `## Autos lavrados` do `memory.md` como fonte dos autos.
-4. **Nenhum auto lavrado** (OS ainda não autuada, ou snapshot vazio) → diga isso em uma linha e siga direto para a FASE 1 pelas fontes normais (contexto da sessão / lista colada / pendências). É o caso da notificação preventiva, dupla visita e ME/EPP — perfeitamente normal.
+4. **Nenhum auto lavrado** (OS ainda não autuada, ou snapshot vazio) → diga isso em uma linha e siga direto para a FASE 1 pelas fontes normais (contexto da sessão / lista colada / pendências). É o caso mais comum: a NCO tipicamente não depende de auto nenhum.
 
-> **Por que sempre:** o pedido típico é "notifica tudo o que foi autuado". Sem este passo, a skill dependia de o AFT ter rodado `/aft-autos-lavrados` antes e acabava notificando de memória — com risco de deixar auto de fora ou notificar o que não foi lavrado. O que vale é o que está no Sistema Auditor.
+> **Por que sempre:** a regra da FASE 1 é que **a NCO não notifica o que já tem auto de infração lavrado** — o auto em si já é meio de coerção indireto (a multa e o risco de reincidência/agravamento pressionam a correção). Sem consultar o Sistema Auditor antes, a skill não sabe o que excluir e corre o risco de notificar formalmente algo que já foi autuado — redundante, e capaz de confundir a empresa sobre o que ainda precisa corrigir e o que já foi punido.
 
-Guarde, de cada auto **válido** do snapshot: `numero_ai`, `ementa_num`, `ementa_descricao`, `constatação` e a base legal (NR/item), quando identificável. Autos das seções "Autos substituídos" e "Pendentes de transmissão" **não** entram no checklist (o primeiro foi cancelado; o segundo ainda não existe no mundo jurídico).
+Guarde, de cada auto **válido** do snapshot, a **ementa** (`ementa_num`) — é o que a FASE 1 usa para excluir candidatas. Autos das seções "Autos substituídos" e "Pendentes de transmissão" **não** contam para a exclusão (o primeiro foi cancelado; o segundo ainda não existe no mundo jurídico, então o item continua elegível para NCO).
 
 ### Autos vindos de interdição/embargo
 
@@ -87,14 +89,15 @@ Quem decide é o AFT: se ele marcar o item, gere normalmente.
 
 ## FASE 1 — Coletar as irregularidades a notificar
 
-Junte, numa lista única de candidatas:
+**Regra central: a NCO não notifica o que já tem auto de infração lavrado.** O auto já é, por si, meio de coerção indireto — a multa e o risco de reincidência/agravamento pressionam a correção; notificar de novo o mesmo fato é redundante e pode confundir a empresa sobre o que ainda precisa corrigir e o que já foi punido. É uma regra só, sem exceção separada: em dupla visita, a autuação é diferida para a segunda visita, então os itens que ensejariam auto ainda não têm um — e por isso já se qualificam normalmente, sem precisar de tratamento à parte.
 
-1. **Autos lavrados** (FASE 0.5) — um candidato por auto válido.
-2. **Contexto da sessão:** irregularidades já enquadradas na sessão (saída de `/aft-auditoria-geral`, `/aft-PGR-analise`, ou o `inspecao-fisica.md` da OS) que **ainda não viraram auto**.
-3. **Colada:** lista de irregularidades que o AFT colou no prompt.
-4. **`memory.md`:** `## Pendências` e `## Inspeção física`, quando as fontes acima não bastarem. Se nada disso existir, peça a lista ao AFT.
+Junte, numa lista única de candidatas, **excluindo qualquer item cuja ementa já tenha auto lavrado válido** (FASE 0.5):
 
-Elimine duplicatas pela ementa: se a irregularidade do contexto já tem auto lavrado, ela aparece **uma vez só**, como auto.
+1. **Contexto da sessão:** irregularidades já identificadas na sessão (saída de `/aft-auditoria-geral`, `/aft-PGR-analise`, ou o `inspecao-fisica.md` da OS) que **não têm auto** — seja porque o AFT decidiu não autuar, seja porque é dupla visita e a autuação está diferida.
+2. **Colada:** lista de irregularidades que o AFT colou no prompt.
+3. **`memory.md`:** `## Pendências` e `## Inspeção física`, quando as fontes acima não bastarem. Se nada disso existir, peça a lista ao AFT.
+
+Elimine duplicatas pela ementa. Se o AFT pedir para notificar algo que já tem auto (ex.: "notifica tudo o que foi autuado" — comportamento antigo desta skill), avise que a convenção mudou e confirme se ele realmente quer notificar de novo um item já autuado antes de incluir.
 
 ### Checklist de seleção (obrigatório quando houver 2+ candidatas)
 
@@ -102,19 +105,21 @@ Primeiro, mostre **a lista inteira numerada** na tela, para o AFT ver tudo de um
 
 ```
 Candidatas a notificar — <EMPREGADOR>
+(itens já autuados foram excluídos automaticamente — ver lista abaixo)
 
- #  Origem        Ementa      Irregularidade
- 1  AI 23.227.251-4  001839-2   papeletas "ponto britânico"
- 2  AI 23.284.209-4  312467-3   injetora sem proteção  ⚠ interdição
- 3  auditoria        —          extintores sem sinalização (sem auto)
+ #  Origem          Ementa      Irregularidade
+ 1  auditoria        —          extintores sem sinalização (sem auto)
+ 2  dupla visita     001839-2   papeletas "ponto britânico" (autuação diferida p/ 2ª visita)
+
+Excluídos por já terem auto: 312467-3 (AI 23.284.209-4)
 ```
 
 Depois, colete a seleção com `AskUserQuestion` em modo **`multiSelect: true`** — é o checklist na tela:
 
-- **No máximo 4 opções por pergunta e 4 perguntas por chamada** (limite da tool): agrupe as candidatas em blocos de 4 (`header`: "Autos 1-4", "Autos 5-8"…). Até 16 candidatas cabem em uma chamada; acima disso, faça rodadas sucessivas e avise quantos lotes vêm.
-- **`label`** = identificador curto (`AI 23.227.251-4` ou `Ementa 001839-2`); **`description`** = descrição da ementa + a constatação em meia linha, com o aviso `(interdição — ver rito próprio)` quando for o caso.
-- Itens de origem interdição/embargo vão sempre por último no bloco, com o aviso acima já apresentado no chat.
-- Se o AFT já disse no prompt o que quer ("faz para todos os autos", "só os de NR-12"), **não pergunte**: aplique e mostre a lista do que entrou.
+- **No máximo 4 opções por pergunta e 4 perguntas por chamada** (limite da tool): agrupe as candidatas em blocos de 4 (`header`: "Itens 1-4", "Itens 5-8"…). Até 16 candidatas cabem em uma chamada; acima disso, faça rodadas sucessivas e avise quantos lotes vêm.
+- **`label`** = identificador curto (`Ementa 001839-2` ou o assunto resumido, quando não houver ementa); **`description`** = descrição da ementa + a constatação em meia linha, com o aviso `(interdição — ver rito próprio)` quando for o caso.
+- Itens de origem interdição/embargo vão sempre por último no bloco, com o aviso abaixo já apresentado no chat.
+- Se o AFT já disse no prompt o que quer ("notifica os itens sem auto", "só os de NR-12"), **não pergunte**: aplique e mostre a lista do que entrou.
 
 Só uma candidata → não monte checklist; confirme em uma frase.
 
@@ -264,7 +269,7 @@ Não bloqueie o fluxo se o `memory.md` não existir. Não toque em outras seçõ
 ## Encadeamento
 
 - **Entrada automática:** esta skill sempre consulta antes a `/aft-autos-lavrados` (FASE 0.5) — o AFT não precisa rodá-la à mão.
-- **Origem natural:** logo após `/aft-auditoria-geral` ou `/aft-PGR-analise` identificarem irregularidades + ementas, ofereça rodar `/aft-tn-nco` para a empresa corrigir (especialmente em dupla visita / ME-EPP, onde a correção precede a autuação).
+- **Origem natural:** em dupla visita / ME-EPP, logo após `/aft-auditoria-geral` ou `/aft-PGR-analise` identificarem irregularidades que ensejariam auto mas cuja autuação for diferida para a segunda visita, ofereça rodar `/aft-tn-nco`. Fora da dupla visita, só ofereça NCO para irregularidades que o AFT decidiu **não** autuar — nunca para o que já vai virar auto (o auto já coage sozinho).
 - **Interdição/embargo:** para as irregularidades que motivaram a medida, o caminho é `/aft-auditoria-AR-NR12` (julgar o laudo/AR apresentado) e depois `/aft-embargo-interdicao-levantamento` (levantar) ou `/aft-embargo-interdicao-manutencao` (manter) — não a notificação NCO.
 - Depois de gerar, o AFT cola os blocos manualmente no DET (o toolkit não automatiza o preenchimento do DET).
 - **Depois de lavrada no DET:** ofereça `/aft-email` para redigir o e-mail que avisa a empresa (ou o advogado) da notificação nova.
@@ -275,7 +280,7 @@ Não bloqueie o fluxo se o `memory.md` não existir. Não toque em outras seçõ
 
 - **Nunca** altere o "X" de "alínea X do art. 18" nem reescreva a introdução/observações fixas — são texto canônico do AFT, copiados verbatim para o DET.
 - **Nunca** invente código de ementa, item de NR ou base legal. Ementa só entra quando confirmada (vinda do auto lavrado ou da Fase 2); na dúvida, item sem `[...]`.
-- **Nunca notifique auto que não existe:** só entram no checklist os autos **válidos** do snapshot. Substituídos (cancelados) e pendentes de transmissão ficam de fora.
+- **Nunca notifique item que já tem auto de infração lavrado válido** — é a regra central da FASE 1. Autos substituídos (cancelados) e pendentes de transmissão não contam como "já autuados": o item continua elegível para NCO.
 - **Nunca decida sozinho** incluir ou excluir irregularidade de interdição/embargo: apresente o rito próprio, deixe desmarcada e siga a escolha do AFT.
 - A consulta ao Sistema Auditor **não pode travar a notificação**: se falhar, avise em uma frase e siga pelo `memory.md`.
 - Redija cada item como **obrigação a cumprir** (verbo de ação no infinitivo), não como descrição da falha.

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -254,18 +254,36 @@ PATH_MD="$PASTA_OS/tn-nco-$(date +%Y-%m-%d).md"
 
 Confirme ao AFT: arquivo salvo + nº de itens. Se não houver pasta de OS resolvida, pergunte onde salvar (ou ofereça a Área de Trabalho).
 
-### Gere também um .docx em paralelo (sempre)
+### Gere também um .docx em paralelo (sempre), no modelo da Análise Preliminar de NAD
 
 Além do `.md` (para o AFT colar no DET) e dos blocos de texto puro no chat, gere **na
 mesma execução** um `.docx` com o mesmo teor, em `<PASTA_OS>/NOTIFICACOES/`, no padrão
 visual do toolkit (biblioteca `aft-modelo-docx`) — nome sugerido
 `NCO - <DD-MM-AAAA>.docx` (ou `NCO - <DD-MM-AAAA> (2).docx` se já existir um do mesmo
-dia). É o mesmo padrão "chat + docx sempre juntos" usado pela Análise Preliminar e pelo
-compilado final de achados no fluxo de resposta a NAD: o `.docx` é para leitura
-confortável e arquivo (capa, introdução, um bloco por item com título em negrito, base
-legal, exigência e ementa), **não substitui** os blocos de texto puro do chat — quem cola
-no DET continua sendo esses blocos, não o `.docx`. Crie a pasta `NOTIFICACOES/` se ainda
-não existir.
+dia). O `.docx` é para leitura confortável e arquivo, **não substitui** os blocos de
+texto puro do chat — quem cola no DET continua sendo esses blocos.
+
+**Use como referência estrutural o modelo da "Análise Preliminar da Resposta à
+Notificação DET"** (comando do AFT de 20/08/2026), adaptando as seções ao conteúdo de
+uma NCO em vez de a uma análise:
+
+1. Capa: título "NOTIFICAÇÃO PARA CORREÇÃO DE IRREGULARIDADES (NCO)"; subtítulo com a
+   quantidade de itens e, se houver, a notificação DET de origem; unidade (empregador +
+   CNPJ); data no formato "Município-UF, dd de mês de aaaa" usando a **lotação do
+   auditor** (`municipio`/`uf` do `aft-config.md`), nunca o município da fiscalizada.
+2. "1. Identificação" — tabela rótulo-valor: Empregador, CNPJ, RI, Data da notificação,
+   Quantidade de itens.
+3. "2. Itens notificados" — um bloco por item, título em negrito, seguido de Base
+   legal, Exigência e, quando houver, a ementa de referência — o mesmo conteúdo dos
+   blocos do chat, só que em prosa formatada em vez de blocos de código.
+4. "3. Tabela-resumo" — tabela `Item | Título | Base legal | Ementa`, para conferência
+   rápida (mesmo espírito da tabela item a item da Análise Preliminar).
+5. "4. Observações" — o texto fixo de comprovação de cumprimento/prorrogação e dúvidas
+   (o mesmo do bloco de Observações do chat).
+6. Fechamento com assinatura do auditor (sem "É o relatório." — isso é da Análise
+   Preliminar, não da NCO).
+
+Crie a pasta `NOTIFICACOES/` se ainda não existir.
 
 ---
 

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -210,7 +210,7 @@ Dúvidas:
 
 ---
 
-## FASE 4 — Apresentar no chat (bloco a bloco) + salvar .md
+## FASE 4 — Apresentar no chat (bloco a bloco) + salvar .md e .docx
 
 O AFT **copia cada parte individualmente** para os campos correspondentes do DET (Introdução · um Item Solicitado por irregularidade · Observações). Por isso, apresente cada parte em seu **próprio bloco de código copiável**, com rótulo claro.
 
@@ -253,6 +253,19 @@ PATH_MD="$PASTA_OS/tn-nco-$(date +%Y-%m-%d).md"
 ```
 
 Confirme ao AFT: arquivo salvo + nº de itens. Se não houver pasta de OS resolvida, pergunte onde salvar (ou ofereça a Área de Trabalho).
+
+### Gere também um .docx em paralelo (sempre)
+
+Além do `.md` (para o AFT colar no DET) e dos blocos de texto puro no chat, gere **na
+mesma execução** um `.docx` com o mesmo teor, em `<PASTA_OS>/NOTIFICACOES/`, no padrão
+visual do toolkit (biblioteca `aft-modelo-docx`) — nome sugerido
+`NCO - <DD-MM-AAAA>.docx` (ou `NCO - <DD-MM-AAAA> (2).docx` se já existir um do mesmo
+dia). É o mesmo padrão "chat + docx sempre juntos" usado pela Análise Preliminar e pelo
+compilado final de achados no fluxo de resposta a NAD: o `.docx` é para leitura
+confortável e arquivo (capa, introdução, um bloco por item com título em negrito, base
+legal, exigência e ementa), **não substitui** os blocos de texto puro do chat — quem cola
+no DET continua sendo esses blocos, não o `.docx`. Crie a pasta `NOTIFICACOES/` se ainda
+não existir.
 
 ---
 

--- a/agents/aft-autos-lavrados.md
+++ b/agents/aft-autos-lavrados.md
@@ -30,7 +30,7 @@ dezenas de PDFs não entulhe o contexto do AFT — de volta, só o relatório.
 
 1. **Leia o manual** (o SKILL.md recebido). Ignore o Passo 1 (resolução de alvos — já
    feito) e o Passo 1.5 (despacho — você É o agente). Execute os **Passos 2 → 2.5 →
-   3 → 4 → 4.5 → 5 → 5.5 → 6** para cada alvo, na ordem, exatamente como o manual
+   3 → 4 → 4.5 → 5 → 5.5 → 6 → 6.5** para cada alvo, na ordem, exatamente como o manual
    manda.
 2. **Você nunca pergunta nada** — não tem a tool AskUserQuestion, de propósito. Nos
    pontos em que o manual manda perguntar ao AFT, aplique a regra conservadora e


### PR DESCRIPTION
Conjunto de correcoes achadas durante uma sessao de validacao ponta a ponta do fluxo de analise de resposta a NAD (extracao -> autos -> gera-ai -> autos-lavrados -> tn-nco -> relatorio), reconciliadas com o commit secao-ii-auto-infracao ja no main.

- Traz de volta uma correcao real de acentuacao/recuo (Subtitulo III, indentacao no Sistema Auditor) que so existia local, nunca tinha sido enviada.
- aft-tn-nco: a NCO passa a notificar so o que NAO tem auto de infracao lavrado (o auto ja e, por si, meio de coercao indireto -- multa + risco de reincidencia). Antes ela notificava tudo o que ja tinha sido autuado, o que e redundante. Gera tambem um .docx em paralelo em NOTIFICACOES/, no mesmo modelo estrutural da Analise Preliminar de NAD.
- aft-aet-auditoria ainda instruia lista numerica (1), 1.1), 2)...) para as evidencias do bloco II -- inconsistente com o padrao de paragrafo corrido que as demais skills redatoras (e o proprio secao-ii-auto-infracao) ja usam. Corrigido.
- O exemplo ilustrativo de encoding em aft-gera-ai ainda mostrava a ordem antiga do dano coletivo (sem a conclusao juridica antes). Corrigido para refletir a ordem atual.

Testado nesta sessao: simulacao completa do ciclo gera-ai -> autos-lavrados -> tn-nco -> relatorio numa OS real, com numeros de AI ficticios (nenhum dado de fiscalizacao real trafegou).