### PR TITLE
fix(analise-documento): nao reextrai PGR/AET/laudo NR-12 quando o extrato ja existe

### DIFF
--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -99,6 +99,24 @@ scripts do toolkit já faziam, e imprime o resumo completo em qualquer console.
 
 ---
 
+## 20/08/2026
+<!-- commit: extrato-ja-existe -->
+
+**PGR, AET e laudo da NR-12 não são mais extraídos duas vezes.** As três skills de análise
+de documento longo (`/aft-PGR-analise`, `/aft-aet-auditoria`, `/aft-auditoria-AR-NR12`)
+mandam o documento para o agente extrator antes de analisar, justamente para não gastar a
+sua conversa lendo cem páginas. Só que elas não conferiam se aquele documento **já tinha
+sido extraído antes** — e, no silêncio, mandavam extrair de novo. Quem sentia isso era
+quem extraiu o PGR numa etapa anterior (numa triagem de vários documentos entregues pela
+empresa, por exemplo) e depois acionou a skill: o mesmo documento ia para o extrator pela
+segunda vez, dobrando a parte mais cara do trabalho, sem nenhum aviso na tela. Agora cada
+uma das três olha primeiro se o extrato correspondente (`pgr-extrato.md`, `aet-extrato.md`
+ou `laudo-extrato.md`) já está na pasta da OS: se estiver, confere se ele cobre o roteiro
+esperado e vai direto para a análise. Se o extrato estiver vazio, truncado ou fora do
+roteiro, ela refaz a extração e diz a você por quê.
+
+---
+
 ## 19/08/2026
 
 <!-- commit: det-cancelada-e-canal-comunicacao -->

--- a/aft-PGR-analise/SKILL.md
+++ b/aft-PGR-analise/SKILL.md
@@ -116,6 +116,16 @@ PGR costuma passar de cem páginas. Lido direto na conversa, ele consome o conte
 limite de uso do AFT, e é **recobrado a cada turno** da análise - o que estoura o plano no
 meio do trabalho. Por isso a leitura é feita fora da conversa, por um agente próprio.
 
+**Antes de medir, veja se o extrato já existe.** Se
+`<OS_ATIVAS>/[PASTA_EMPRESA]/pgr-extrato.md` já estiver na pasta, a extração já foi feita
+- por uma execução anterior deste skill, ou por um fluxo de trabalho que extraiu os
+documentos numa triagem inicial. Confira que ele cobre as sete ementas do roteiro abaixo
+e **siga direto para "Analise sobre o extrato"**: não meça o PDF nem delegue de novo.
+Extrair duas vezes o mesmo PGR é o desperdício mais caro deste skill - é justamente o
+custo que a delegação existe para evitar. Só refaça a extração se o extrato estiver
+vazio, truncado ou visivelmente fora do roteiro e, nesse caso, diga ao AFT em uma linha
+por que está refazendo.
+
 Descubra primeiro o tamanho do documento:
 
 ```bash

--- a/aft-aet-auditoria/SKILL.md
+++ b/aft-aet-auditoria/SKILL.md
@@ -96,6 +96,15 @@ AET costuma ser documento longo, com muita tabela de posto de trabalho. Lida dir
 conversa, ela consome o contexto e o limite de uso do AFT, e é **recobrada a cada turno** da
 análise. Por isso a leitura é feita fora da conversa, por um agente próprio.
 
+**Antes de medir, veja se o extrato já existe.** Se
+`<OS_ATIVAS>/[PASTA_EMPRESA]/aet-extrato.md` já estiver na pasta, a extração já foi feita
+- por uma execução anterior deste skill, ou por um fluxo de trabalho que extraiu os
+documentos numa triagem inicial. Confira que ele cobre as cinco ementas do roteiro abaixo
+e **analise sobre ele**: não meça o PDF nem delegue de novo. Extrair duas vezes a mesma
+AET é o desperdício mais caro deste skill - é justamente o custo que a delegação existe
+para evitar. Só refaça a extração se o extrato estiver vazio, truncado ou visivelmente
+fora do roteiro e, nesse caso, diga ao AFT em uma linha por que está refazendo.
+
 Descubra primeiro o tamanho do documento:
 
 ```bash

--- a/aft-auditoria-AR-NR12/SKILL.md
+++ b/aft-auditoria-AR-NR12/SKILL.md
@@ -102,6 +102,16 @@ Laudo de adequação costuma ser longo e cheio de tabela e foto de máquina. Lid
 conversa, ele consome o contexto e o limite de uso do AFT, e é **recobrado a cada turno** do
 julgamento. Por isso a leitura é feita fora da conversa, por um agente próprio.
 
+**Antes de medir, veja se o extrato já existe.** Se
+`<OS_ATIVAS>/[PASTA_EMPRESA]/laudo-extrato.md` já estiver na pasta, a extração já foi
+feita - por uma execução anterior deste skill, ou por um fluxo de trabalho que extraiu os
+documentos numa triagem inicial. Confira que ele cobre os seis blocos do roteiro abaixo
+(e cada máquina, quando o laudo cobrir mais de uma) e **julgue sobre ele**: não meça o
+PDF nem delegue de novo. Extrair duas vezes o mesmo laudo é o desperdício mais caro deste
+skill - é justamente o custo que a delegação existe para evitar. Só refaça a extração se
+o extrato estiver vazio, truncado ou visivelmente fora do roteiro e, nesse caso, diga ao
+AFT em uma linha por que está refazendo.
+
 Descubra primeiro o tamanho do documento:
 
 ```bash

--- a/novidades/2026-08-20-06-extrato-ja-existe.md
+++ b/novidades/2026-08-20-06-extrato-ja-existe.md
@@ -1,0 +1,17 @@
+## 20/08/2026
+<!-- commit: extrato-ja-existe -->
+
+**PGR, AET e laudo da NR-12 não são mais extraídos duas vezes.** As três skills de análise
+de documento longo (`/aft-PGR-analise`, `/aft-aet-auditoria`, `/aft-auditoria-AR-NR12`)
+mandam o documento para o agente extrator antes de analisar, justamente para não gastar a
+sua conversa lendo cem páginas. Só que elas não conferiam se aquele documento **já tinha
+sido extraído antes** — e, no silêncio, mandavam extrair de novo. Quem sentia isso era
+quem extraiu o PGR numa etapa anterior (numa triagem de vários documentos entregues pela
+empresa, por exemplo) e depois acionou a skill: o mesmo documento ia para o extrator pela
+segunda vez, dobrando a parte mais cara do trabalho, sem nenhum aviso na tela. Agora cada
+uma das três olha primeiro se o extrato correspondente (`pgr-extrato.md`, `aet-extrato.md`
+ou `laudo-extrato.md`) já está na pasta da OS: se estiver, confere se ele cobre o roteiro
+esperado e vai direto para a análise. Se o extrato estiver vazio, truncado ou fora do
+roteiro, ela refaz a extração e diz a você por quê.
+
+---


### PR DESCRIPTION
## O problema

As tres skills que delegam a leitura ao `aft-extrator-documento` --- `/aft-PGR-analise`, `/aft-aet-auditoria` e `/aft-auditoria-AR-NR12` --- medem o PDF e delegam a extracao **sem antes conferir se o extrato correspondente ja esta na pasta da OS**. Nao ha, hoje, nenhum ramo condicional para isso: o caminho e sempre `pdf_texto_paginado.py --so-resumo` -> mais de 20 paginas -> delega.

O efeito aparece para quem extrai o documento numa etapa anterior --- tipico de uma triagem que processa de uma vez varios documentos entregues pela empresa em resposta a uma notificacao do DET. O mesmo PGR vai para o extrator uma segunda vez, dobrando em silencio a operacao mais cara do trabalho, que e justamente o custo que a delegacao existe para evitar. Nao ha aviso na tela: o AFT so percebe pelo tempo e pelo consumo.

## A correcao

Cada uma das tres skills passa a conferir primeiro se `pgr-extrato.md` / `aet-extrato.md` / `laudo-extrato.md` ja existe na pasta da OS. Se existir, confere que cobre o roteiro esperado (as sete ementas do PGR, as cinco da AET, os seis blocos da NR-12) e analisa sobre ele, sem medir o PDF nem delegar de novo.

A reextracao continua acontecendo quando o extrato esta vazio, truncado ou visivelmente fora do roteiro --- e, nesse caso, a skill diz ao AFT em uma linha por que esta refazendo, em vez de refazer calado.

Sao apenas 3 paragrafos de instrucao, um por skill, no ponto em que a decisao e tomada. Nenhuma mudanca de comportamento fora desse caso.

## Conferido

- `_scripts/montar_novidades.py --conferir`: OK, 93 entradas.
- `_scripts/aft_doctor.py`: 22 ok, 0 erros (o unico aviso e pre-existente e nao relacionado --- agente `aft-autos-lavrados` desatualizado nesta maquina).
- Achado em uso real, auditando um fluxo de analise de resposta a NAD que extrai PGR, AET e laudo numa triagem inicial e so depois aciona as skills.

---

PR independente do #23 (ramificado de `origin/main`, sem sobreposicao de arquivos com aquele).

[Claude Code](https://claude.com/claude-code) ajudou a levantar e escrever esta correcao.