### PR TITLE
Botão "baixar arquivos" nas notificações DET do painel (API direta, sem navegador)

### DIFF
--- a/_scripts/det_baixar.py
+++ b/_scripts/det_baixar.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+det_baixar.py — baixa os arquivos de uma notificação do DET para a pasta da OS.
+
+Irmão do det_sync.py e mesma via de acesso: a API oficial do DET (a MESMA que o
+site usa), com o token de sessão que a extensão Chrome "Sync DET" empresta ao
+servir_painel.py. Nenhum navegador envolvido: são 4 ou 5 requisições HTTP e o
+download termina em segundos — substitui o fluxo antigo de dirigir o Chrome
+clique a clique (10 minutos por notificação).
+
+O que é baixado, e para onde (pasta da OS em OS ATIVAS/):
+
+    notificacao-<CODIGO>.pdf              o PDF da notificação
+    relatorio-atendimento-<CODIGO>.pdf    o Relatório de Atendimento
+    notificacao-<CODIGO>/                 os arquivos entregues pelo empregador
+        item<N>_<descrição do item>/          um por item solicitado
+            <arquivo entregue>
+            invalidados/<arquivo>             o que o AFT rejeitou/dispensou
+
+Em vez do ZIP geral do site (que exige segundo request numa URL volátil e
+chega sem estrutura), cada arquivo é baixado individualmente pelo endpoint de
+arquivos do item — assim a pasta nasce organizada por item, com a descrição
+oficial vinda da API (nada de raspar o PDF para adivinhar nomes).
+
+Endpoints (lidos do bundle público do front do DET em 21/08/2026 — chunk 251;
+ver a nota sync-det-e-extensao.md para o método de conferência no bundle):
+
+    POST /services/auditor/v1/notificacoes/pesquisa          (codigoNotificacao)
+    GET  /services/auditor/v1/notificacoes/{uid}/pdf?numeroDeLinhas=0
+    GET  /services/auditor/v1/notificacoes/{uid}/pdf-relatorio-atendimento
+    GET  /services/auditor/v1/itens-notificacao?uidNotificacao={uid}
+    GET  /services/auditor/v1/arquivos-item?uidItem={uid}
+    GET  /services/auditor/v1/arquivos-item/{uid}/blob
+
+Status do arquivo (enum do front): 0 INICIAL e 1 RECEBIDO são entrega válida;
+2 REJEITADO e 3 DISPENSADO vão para a subpasta invalidados/ — o AFT os
+invalidou no DET, mas continuam sendo evidência.
+
+Idempotente: arquivo que já existe (tamanho > 0) não é baixado de novo.
+O token é usado em memória e nunca gravado (regra da extensão). Cada download
+registra uma linha no Registro de atividades do memory.md (com backup prévio).
+
+Uso normal: via servir_painel.py (POST /api/det-baixar — botão do painel e a
+skill det-baixar-empregador). Direto (debug):
+    python det_baixar.py "<pasta da OS>" "<CODIGO>" "<token>"
+"""
+from __future__ import annotations
+
+try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
+    import sys as _sys
+    from pathlib import Path as _Path
+    _aqui = _Path(__file__).resolve()
+    for _p in (_aqui.parent, *(_a / "_scripts" for _a in _aqui.parents)):
+        if (_p / "erro_ticket.py").is_file():
+            _sys.path.insert(0, str(_p))
+            from erro_ticket import ativar as _ativar_ticket
+            _ativar_ticket(__file__)
+            break
+except Exception:
+    pass
+
+import datetime
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+AQUI = Path(__file__).resolve().parent
+BACKUP = AQUI / "backup_arquivo.py"
+
+DET_BASE = "https://auditor-det.sit.trabalho.gov.br/services/auditor/v1"
+TIMEOUT_JSON = 15   # segundos — respostas pequenas (pesquisa, listas)
+TIMEOUT_BLOB = 120  # segundos — arquivos (o DET aceita até 20 MB por arquivo)
+
+# Arquivo entregue: 0 INICIAL · 1 RECEBIDO · 2 REJEITADO · 3 DISPENSADO
+STATUS_INVALIDADOS = (2, 3)
+
+
+class TokenExpirado(RuntimeError):
+    """401/403 do DET: o token de sessão venceu (dura ~30 min)."""
+
+
+# ── HTTP (urllib puro, como no det_sync) ─────────────────────────────────────
+
+def _requisicao(token: str, caminho: str, *, params: dict | None = None,
+                corpo: dict | None = None, timeout: int = TIMEOUT_JSON) -> bytes:
+    url = DET_BASE + caminho
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(corpo).encode("utf-8") if corpo is not None else None,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/plain, */*",
+        },
+        method="POST" if corpo is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            raise TokenExpirado(
+                "token do DET expirado — clique em Sincronizar na aba do DET "
+                "e tente de novo") from e
+        detalhe = e.read().decode("utf-8", errors="replace")[:200]
+        raise RuntimeError(f"DET API {e.code} em {caminho}: {detalhe}") from e
+    except Exception as e:
+        raise RuntimeError(f"DET inacessível ({caminho}): {e}") from e
+
+
+def _json_api(token: str, caminho: str, **kw):
+    return json.loads(_requisicao(token, caminho, **kw).decode("utf-8"))
+
+
+def pesquisar_por_codigo(token: str, codigo: str) -> dict | None:
+    """A notificação com esse código, ou None. Mesmo corpo de pesquisa do
+    det_sync, mas pelo código (chave única — inclui as da equipe)."""
+    corpo = {
+        "isPesquisaPadrao": False,
+        "niEmpregador": None,
+        "ri": None,
+        "codigoNotificacao": codigo,
+        "cifAuditor": None,
+        "isSomenteMinhas": False,
+        "sequencia": 0,
+        "ordenacaoCampo": "id",
+        "ordenacaoDesc": False,
+        "isPendenciaComunicacaoAuditor": False,
+        "isPendenciaComunicacaoEmpregador": False,
+        "situacaoFisc": None,
+    }
+    dados = _json_api(token, "/notificacoes/pesquisa", corpo=corpo)
+    for n in dados.get("notificacoes") or []:
+        if (n.get("codigo") or "").strip() == codigo:
+            return n
+    return None
+
+
+# ── Nomes seguros de pasta/arquivo (funções puras, testáveis sem rede) ───────
+
+_RE_PROIBIDOS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def _limpo(nome: str) -> str:
+    """Nome utilizável em pasta/arquivo no macOS E no Windows: troca os
+    caracteres proibidos por espaço e apara pontas (ponto final é inválido
+    no Windows). Acentos ficam."""
+    nome = _RE_PROIBIDOS.sub(" ", nome or "")
+    return re.sub(r"\s+", " ", nome).strip().strip(".").strip()
+
+
+def pasta_do_item(ordem, descricao: str) -> str:
+    """`item<N>_<descrição>` — descrição oficial da API, cortada em 40
+    caracteres na última palavra inteira (mesma convenção do fluxo antigo)."""
+    desc = _limpo(descricao)
+    if len(desc) > 40:
+        desc = desc[:40]
+        if " " in desc:
+            desc = desc.rsplit(" ", 1)[0]
+    base = f"item{ordem}"
+    return f"{base}_{desc}" if desc else base
+
+
+def nome_do_arquivo(nome: str, usados: set[str]) -> str:
+    """Nome do arquivo como veio do DET, saneado; colisão no mesmo item
+    ganha sufixo -2, -3..."""
+    limpo = _limpo(nome) or "arquivo"
+    candidato, n = limpo, 1
+    while candidato.lower() in usados:
+        n += 1
+        raiz, ponto, ext = limpo.rpartition(".")
+        candidato = f"{raiz}-{n}.{ext}" if ponto else f"{limpo}-{n}"
+    usados.add(candidato.lower())
+    return candidato
+
+
+def registrar_atividade(texto: str, detalhe: str) -> str:
+    """Linha no Registro de atividades (best-effort, como no det_sync)."""
+    linhas = texto.splitlines(keepends=True)
+    ini = next((i + 1 for i, l in enumerate(linhas)
+                if l.strip() == "## Registro de atividades"), -1)
+    if ini < 0:
+        return texto
+    fim = next((i for i in range(ini, len(linhas))
+                if linhas[i].strip().startswith("## ")), len(linhas))
+    ult = max((i for i in range(ini, fim) if linhas[i].strip().startswith("|")),
+              default=None)
+    if ult is None:
+        return texto
+    hoje = datetime.date.today().strftime("%d/%m/%Y")
+    linhas.insert(ult + 1, f"| {hoje} | Download DET (painel) | {detalhe} |\n")
+    return "".join(linhas)
+
+
+# ── Download de uma notificação ──────────────────────────────────────────────
+
+def _salvar(destino: Path, conteudo: bytes) -> bool:
+    """Grava se ainda não existe (idempotência). True = gravou agora."""
+    if destino.exists() and destino.stat().st_size > 0:
+        return False
+    destino.parent.mkdir(parents=True, exist_ok=True)
+    destino.write_bytes(conteudo)
+    return True
+
+
+def baixar_notificacao(pasta_os: Path, token: str, codigo: str) -> dict:
+    """Baixa os 2 PDFs e os arquivos de todos os itens para a pasta da OS.
+    Um arquivo com erro não derruba os demais; token vencido derruba tudo
+    (TokenExpirado sobe para o chamador avisar o AFT)."""
+    codigo = (codigo or "").strip().upper()
+    if not re.fullmatch(r"[A-Z0-9]{6,}", codigo):
+        raise ValueError(f"código de notificação inválido: {codigo!r}")
+    r = {"ok": True, "codigo": codigo, "pasta": pasta_os.name,
+         "baixados": 0, "ja_existiam": 0, "invalidados": 0,
+         "itens": 0, "sem_arquivo": 0, "erros": []}
+
+    n = pesquisar_por_codigo(token, codigo)
+    if not n:
+        raise RuntimeError(f"notificação {codigo} não encontrada no DET "
+                           "(confira o código)")
+    uid = n.get("uid")
+    if not uid:
+        raise RuntimeError(f"notificação {codigo} veio sem uid na pesquisa")
+
+    def conta(gravou: bool):
+        r["baixados" if gravou else "ja_existiam"] += 1
+
+    # Os 2 PDFs. numeroDeLinhas=0 é o que o próprio site passa no download
+    # direto (sem o modal de paginação).
+    try:
+        conta(_salvar(pasta_os / f"notificacao-{codigo}.pdf",
+                      _requisicao(token, f"/notificacoes/{uid}/pdf",
+                                  params={"numeroDeLinhas": 0},
+                                  timeout=TIMEOUT_BLOB)))
+    except TokenExpirado:
+        raise
+    except Exception as e:
+        r["erros"].append(f"PDF da notificação: {e}")
+    try:
+        conta(_salvar(pasta_os / f"relatorio-atendimento-{codigo}.pdf",
+                      _requisicao(token,
+                                  f"/notificacoes/{uid}/pdf-relatorio-atendimento",
+                                  timeout=TIMEOUT_BLOB)))
+    except TokenExpirado:
+        raise
+    except Exception as e:
+        r["erros"].append(f"Relatório de Atendimento: {e}")
+
+    # Arquivos entregues, item a item.
+    raiz = pasta_os / f"notificacao-{codigo}"
+    itens = _json_api(token, "/itens-notificacao", params={"uidNotificacao": uid})
+    r["itens"] = len(itens or [])
+    for item in itens or []:
+        uid_item = item.get("uid")
+        rot = pasta_do_item(item.get("ordem", "?"), item.get("descricao") or "")
+        if not uid_item:
+            r["erros"].append(f"{rot}: item sem uid")
+            continue
+        try:
+            arquivos = _json_api(token, "/arquivos-item",
+                                 params={"uidItem": uid_item})
+        except TokenExpirado:
+            raise
+        except Exception as e:
+            r["erros"].append(f"{rot}: {e}")
+            continue
+        if not arquivos:
+            r["sem_arquivo"] += 1
+            continue
+        usados: set[str] = set()
+        for arq in arquivos:
+            nome = nome_do_arquivo(arq.get("nome") or "", usados)
+            invalidado = arq.get("status") in STATUS_INVALIDADOS
+            destino = raiz / rot / ("invalidados/" if invalidado else "") / nome
+            if invalidado:
+                r["invalidados"] += 1
+            if destino.exists() and destino.stat().st_size > 0:
+                r["ja_existiam"] += 1
+                continue
+            try:
+                conta(_salvar(destino,
+                              _requisicao(token, f"/arquivos-item/{arq['uid']}/blob",
+                                          timeout=TIMEOUT_BLOB)))
+            except TokenExpirado:
+                raise
+            except Exception as e:
+                r["erros"].append(f"{rot}/{nome}: {e}")
+
+    _registrar_no_memory(pasta_os, r)
+    return r
+
+
+def _registrar_no_memory(pasta_os: Path, r: dict) -> None:
+    """Linha de atividade na ficha — só quando algo foi baixado agora."""
+    if not r["baixados"]:
+        return
+    mem = pasta_os / "memory.md"
+    if not mem.exists():
+        return
+    try:
+        texto = mem.read_text(encoding="utf-8")
+        partes = [f"{r['codigo']}: {r['baixados']} arquivo(s) baixado(s)"]
+        if r["ja_existiam"]:
+            partes.append(f"{r['ja_existiam']} já existia(m)")
+        if r["erros"]:
+            partes.append(f"{len(r['erros'])} erro(s)")
+        novo = registrar_atividade(texto, " · ".join(partes))
+        if novo == texto:
+            return
+        if BACKUP.exists():
+            subprocess.run([sys.executable, str(BACKUP), str(mem)],
+                           capture_output=True, timeout=30)
+        mem.write_text(novo, encoding="utf-8")
+    except Exception as e:
+        r["erros"].append(f"registro no memory.md: {e}")
+
+
+if __name__ == "__main__":
+    if hasattr(sys.stdout, "reconfigure"):  # console Windows é cp1252
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if len(sys.argv) != 4:
+        print("uso: python det_baixar.py \"<pasta da OS>\" <CODIGO> <token>",
+              file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(baixar_notificacao(Path(sys.argv[1]), sys.argv[3],
+                                        sys.argv[2]),
+                     ensure_ascii=False, indent=2))

--- a/_scripts/gerar_painel.py
+++ b/_scripts/gerar_painel.py
@@ -1183,6 +1183,21 @@ function agCal(j){const v=DATA.venc[j];
   encodeURIComponent('Notificação DET '+v.codigo+' — '+v.empregador+' (AFT Toolkit)'),'_blank')}
 function agDet(i,k){const o=DATA.os[i];api({acao:'det',pasta:o.pasta,codigo:o.dets[k].codigo})}
 function agDetVisto(i,k){const o=DATA.os[i];api({acao:'det_visto',pasta:o.pasta,codigo:o.dets[k].codigo})}
+// "baixar arquivos": o servidor busca na API do DET (com o token do último
+// Sincronizar) o PDF da notificação, o Relatório de Atendimento e os arquivos
+// entregues, direto na pasta da OS. Pode levar alguns segundos.
+async function agDetBaixar(i,k,ev,b){ev.stopPropagation();
+ const o=DATA.os[i];b.disabled=true;const rot=b.textContent;b.textContent='baixando…';
+ try{const r=await fetch('/api/det-baixar',{method:'POST',
+  headers:{'Content-Type':'application/json'},
+  body:JSON.stringify({pasta:o.pasta,codigo:o.dets[k].codigo})});
+  const j=await r.json();
+  if(j.ok){const e=(j.erros||[]).length;
+   aviso(j.baixados?j.baixados+' arquivo(s) baixado(s) na pasta da OS'+
+    (e?' — '+e+' com erro':''):'nada novo — tudo já estava baixado')}
+  else aviso((j.token_expirado?'⚠️ ':'Erro: ')+(j.erro||'?'));
+ }catch(e){aviso('Servidor do painel não respondeu — abra pelo http://127.0.0.1:8347')}
+ b.disabled=false;b.textContent=rot}
 function agPend(i,k){const o=DATA.os[i];api({acao:'pendencia',pasta:o.pasta,texto:o.pendencias[k]})}
 function agPendAdd(i){const el=document.getElementById('pend-txt');const v=(el.value||'').trim();
  if(!v){aviso('Escreva a pendência antes');return}
@@ -1295,6 +1310,9 @@ function cartaoDets(o,i){
    (d.rotulo?'<span class="rotulo">'+esc(d.rotulo)+'</span>':'')+'</div>'+
    (campos?'<div class="info campos">'+campos+'</div>':'')+
    (d.notas?'<div class="info notas">'+esc(d.notas)+'</div>':'')+
+   (ATIVO&&o.pasta&&d.codigo&&!d.cancelada?'<button class="mini acao" '+
+    'title="baixa da API do DET o PDF da notificação, o Relatório de Atendimento e os arquivos entregues, organizados por item na pasta da OS (precisa de um Sincronizar na aba do DET nos últimos 25 min)" '+
+    'onclick="agDetBaixar('+i+','+k+',event,this)">⬇ baixar arquivos</button>':'')+
    (d.selo?'<span class="selo '+esc(d.urg)+'">'+esc(d.selo)+'</span>':'')+'</div></div>'}).join('');
  return h+'</div>'}
 function cartaoNovas(o){

--- a/_scripts/servir_painel.py
+++ b/_scripts/servir_painel.py
@@ -79,7 +79,28 @@ MAX_BODY = 64_000
 # CORS restrito ao site do DET: é de lá que a extensão dispara o fetch.
 sys.path.insert(0, str(AQUI))
 import det_sync  # noqa: E402
+import det_baixar  # noqa: E402  (download dos arquivos de uma notificação)
 import diario_registrar  # noqa: E402  (diário de atividades — letras A-F)
+
+# Token do DET emprestado pela extensão no último Sincronizar. Vive SÓ na RAM
+# deste processo (nunca em disco — regra da extensão) e vale 25 min, a mesma
+# janela que a própria extensão usa (o token do DET dura ~30). É o que permite
+# ao botão "baixar arquivos" e à skill det-baixar-empregador funcionarem sem
+# pedir token nenhum: o Sincronizar de sempre abastece.
+_DET_TOKEN: dict = {"token": None, "ts": 0.0}
+_DET_TOKEN_TTL = 25 * 60
+
+
+def _token_guardar(token: str) -> None:
+    import time
+    _DET_TOKEN["token"], _DET_TOKEN["ts"] = token, time.time()
+
+
+def _token_atual() -> str | None:
+    import time
+    if _DET_TOKEN["token"] and time.time() - _DET_TOKEN["ts"] < _DET_TOKEN_TTL:
+        return _DET_TOKEN["token"]
+    return None
 
 ORIGEM_DET = "https://auditor-det.sit.trabalho.gov.br"
 CORS_DET = {
@@ -802,6 +823,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._json(403, {"ok": False, "erro": "host não permitido"})
         if self.path == "/api/det-sync":
             return self._det_sync()
+        if self.path == "/api/det-baixar":
+            return self._det_baixar()
         if self.path != "/api/acao":
             return self._json(404, {"ok": False, "erro": "rota desconhecida"})
         try:
@@ -840,11 +863,42 @@ class Handler(BaseHTTPRequestHandler):
                 return self._json(400, {"ok": False,
                                         "erro": "det_access_token ausente ou inválido"},
                                   CORS_DET)
+            _token_guardar(token)  # abastece o "baixar arquivos" por 25 min
             resultado = det_sync.sincronizar_todas(self.base, token)
             self._json(200, resultado, CORS_DET)
         except Exception as e:
             self._json(500, {"ok": False, "erro": f"{type(e).__name__}: {e}"},
                        CORS_DET)
+
+    def _det_baixar(self):
+        """POST /api/det-baixar — corpo {pasta, codigo}; chamado pelo botão
+        "baixar arquivos" do painel e pela skill det-baixar-empregador. Usa o
+        token guardado pelo último Sincronizar; sem token fresco devolve 409
+        com a instrução (o download demora segundos, o clique no DET também)."""
+        try:
+            n = min(int(self.headers.get("Content-Length") or 0), MAX_BODY)
+            p = json.loads(self.rfile.read(n).decode("utf-8"))
+            pasta = (p.get("pasta") or "").strip()
+            if not pasta or "/" in pasta or "\\" in pasta or pasta.startswith("."):
+                raise ValueError("pasta inválida")
+            alvo = (self.base / pasta).resolve()
+            if self.base.resolve() != alvo.parent or not alvo.is_dir():
+                raise ValueError(f"pasta {pasta} não encontrada em OS ATIVAS")
+            token = _token_atual()
+            if not token:
+                return self._json(409, {"ok": False, "token_expirado": True,
+                                        "erro": "sem token do DET — abra a aba do DET "
+                                                "e clique em Sincronizar; depois tente "
+                                                "de novo (vale 25 min)"})
+            r = det_baixar.baixar_notificacao(alvo, token, p.get("codigo") or "")
+            self._json(200, r)
+        except det_baixar.TokenExpirado as e:
+            _DET_TOKEN["token"] = None
+            self._json(409, {"ok": False, "token_expirado": True, "erro": str(e)})
+        except ValueError as e:
+            self._json(400, {"ok": False, "erro": str(e)})
+        except Exception as e:
+            self._json(500, {"ok": False, "erro": f"{type(e).__name__}: {e}"})
 
 
 def porta_ocupada(porta: int) -> bool:

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -132,816 +132,822 @@
 
 <script>
 const ARCH = {
-  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
-  "repo": "github.com/ryckardo42/aft-toolkit",
-  "data": "2026-08-20",
-  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
-  "stats": {
-    "skills": 46,
-    "scripts": 40,
-    "dados": 6,
-    "commit": "ver `git log -1` — atualizado em 14/08/2026"
+ "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
+ "repo": "github.com/ryckardo42/aft-toolkit",
+ "data": "2026-08-21",
+ "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+ "stats": {
+  "skills": 47,
+  "scripts": 46,
+  "dados": 6,
+  "commit": "ver `git log -1` — atualizado em 21/08/2026"
+ },
+ "atores": [
+  {
+   "nome": "AFT colega (novo usuário)",
+   "papel": "Auditor no Windows",
+   "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
   },
-  "atores": [
+  {
+   "nome": "Claude Code",
+   "papel": "Assistente técnico",
+   "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
+  },
+  {
+   "nome": "Sistema Auditor",
+   "papel": "App oficial do MTE",
+   "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
+  },
+  {
+   "nome": "NotebookLM",
+   "papel": "Fonte de ementas",
+   "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
+  },
+  {
+   "nome": "Ricardo (mantenedor)",
+   "papel": "AFT — SRTE/GO",
+   "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
+  }
+ ],
+ "fluxo": [
+  {
+   "who": "/aft-preparacao-acao-fiscal",
+   "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, estuda os temas no NotebookLM e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
+  },
+  {
+   "who": "/aft-nova-auditoria",
+   "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
+  },
+  {
+   "who": "/aft-painel",
+   "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
+  },
+  {
+   "who": "Visita ao estabelecimento",
+   "act": "Inspeção física presencial."
+  },
+  {
+   "who": "/aft-inspecao-fisica",
+   "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
+  },
+  {
+   "who": "/aft-auditoria-geral",
+   "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
+  },
+  {
+   "who": "/aft-revisa-auto",
+   "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
+  },
+  {
+   "who": "/aft-gera-ai",
+   "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
+  },
+  {
+   "who": "Sistema Auditor",
+   "act": "Botão imp. txt → revisão do AFT → transmissão."
+  },
+  {
+   "who": "/aft-autos-lavrados",
+   "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
+  },
+  {
+   "who": "/aft-relatorio",
+   "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
+  }
+ ],
+ "instalacao": [
+  {
+   "who": "Instalar o app Claude",
+   "act": "claude.com/claude-code — único passo realmente inicial."
+  },
+  {
+   "who": "Instalar o Git + reiniciar pela bandeja",
+   "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
+  },
+  {
+   "who": "Colar o prompt de instalação no </> Code",
+   "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
+  },
+  {
+   "who": "/aft-setup",
+   "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
+  },
+  {
+   "who": "Codex: dois atalhos (opcional)",
+   "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
+  }
+ ],
+ "camadas": [
+  {
+   "nome": "Configuração e visão geral",
+   "cor": "accent2",
+   "skills": [
     {
-      "nome": "AFT colega (novo usuário)",
-      "papel": "Auditor no Windows",
-      "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
+     "nome": "/aft-setup",
+     "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+     "tech": "winget · pipx · uorgs.csv · model: sonnet"
     },
     {
-      "nome": "Claude Code",
-      "papel": "Assistente técnico",
-      "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
+     "nome": "/aft-doctor",
+     "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
+     "tech": "aft_doctor.py · model: sonnet"
     },
     {
-      "nome": "Sistema Auditor",
-      "papel": "App oficial do MTE",
-      "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
+     "nome": "/aft-erro",
+     "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
+     "tech": "erro_ticket.py · model: sonnet"
     },
     {
-      "nome": "NotebookLM",
-      "papel": "Fonte de ementas",
-      "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
+     "nome": "/aft-atualizar",
+     "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
+     "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
     },
     {
-      "nome": "Ricardo (mantenedor)",
-      "papel": "AFT — SRTE/GO",
-      "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
+     "nome": "/aft-notebooklm-login",
+     "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
+     "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
+    },
+    {
+     "nome": "/aft-nova-auditoria",
+     "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
+     "tech": "cria memory.md · model: sonnet"
+    },
+    {
+     "nome": "/aft-organiza-os",
+     "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
+     "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
+    },
+    {
+     "nome": "/aft-painel",
+     "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
+     "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
+    },
+    {
+     "nome": "/aft-agenda-det",
+     "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
+    },
+    {
+     "nome": "/aft-nova-skill",
+     "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
+     "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
     }
-  ],
-  "fluxo": [
+   ]
+  },
+  {
+   "nome": "Preparação da ação fiscal (antes da visita)",
+   "cor": "accent2",
+   "skills": [
     {
-      "who": "/aft-preparacao-acao-fiscal",
-      "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, estuda os temas no NotebookLM e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
+     "nome": "/aft-preparacao-acao-fiscal",
+     "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, estuda os temas nos NotebookLMs (sem nome de empresa/trabalhador, com fontes) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Salva preparacao.md na pasta da OS.",
+     "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
     },
     {
-      "who": "/aft-nova-auditoria",
-      "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
-    },
-    {
-      "who": "/aft-painel",
-      "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
-    },
-    {
-      "who": "Visita ao estabelecimento",
-      "act": "Inspeção física presencial."
-    },
-    {
-      "who": "/aft-inspecao-fisica",
-      "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
-    },
-    {
-      "who": "/aft-auditoria-geral",
-      "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
-    },
-    {
-      "who": "/aft-revisa-auto",
-      "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
-    },
-    {
-      "who": "/aft-gera-ai",
-      "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
-    },
-    {
-      "who": "Sistema Auditor",
-      "act": "Botão imp. txt → revisão do AFT → transmissão."
-    },
-    {
-      "who": "/aft-autos-lavrados",
-      "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
-    },
-    {
-      "who": "/aft-relatorio",
-      "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
+     "nome": "/aft-NAD",
+     "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
+     "tech": "espelha /aft-tn-nco · model: sonnet"
     }
-  ],
-  "instalacao": [
+   ]
+  },
+  {
+   "nome": "Inspeção e lavratura",
+   "cor": "accent",
+   "skills": [
     {
-      "who": "Instalar o app Claude",
-      "act": "claude.com/claude-code — único passo realmente inicial."
+     "nome": "/aft-inspecao-fisica",
+     "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
+     "tech": "relato → memory.md · model: sonnet"
     },
     {
-      "who": "Instalar o Git + reiniciar pela bandeja",
-      "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
+     "nome": "/aft-consulta",
+     "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
+     "tech": "notebooklm ask · herda o modelo da sessão"
     },
     {
-      "who": "Colar o prompt de instalação no </> Code",
-      "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
+     "nome": "/aft-auditoria-geral",
+     "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
+     "tech": "orquestra consultoras · herda o modelo da sessão"
     },
     {
-      "who": "/aft-setup",
-      "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
+     "nome": "/aft-informalidade",
+     "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
+     "tech": "data de admissão dd/mm/aaaa · model: sonnet"
     },
     {
-      "who": "Codex: dois atalhos (opcional)",
-      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
+     "nome": "/aft-PGR-analise",
+     "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
+     "tech": "handoff p/ gera-ai · model: opus 1M"
+    },
+    {
+     "nome": "/aft-aet-auditoria",
+     "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
+     "tech": "handoff p/ gera-ai · model: opus 1M"
+    },
+    {
+     "nome": "/aft-auditoria-AR-NR12",
+     "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
+     "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
+    },
+    {
+     "nome": "/aft-det-630",
+     "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
+     "tech": "escreve em ## Notificações DET · model: sonnet"
+    },
+    {
+     "nome": "/aft-tn-nco",
+     "role": "Redige a Notificação para Correção de Irregularidades (texto pronto para colar no DET, item por item; preenchimento manual).",
+     "tech": "limite 1000 char/campo · model: sonnet"
+    },
+    {
+     "nome": "/aft-email",
+     "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
+     "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
+    },
+    {
+     "nome": "/aft-embargo-interdicao",
+     "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
+     "tech": "template.docx SRTE/GO · herda o modelo da sessão"
+    },
+    {
+     "nome": "/aft-embargo-interdicao-manutencao",
+     "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
+     "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
+    },
+    {
+     "nome": "/aft-embargo-interdicao-levantamento",
+     "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
+     "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
+    },
+    {
+     "nome": "/aft-analise-acidente",
+     "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
+     "tech": "gerar_relatorio_docx.py · model: opus 1M"
     }
-  ],
-  "camadas": [
+   ]
+  },
+  {
+   "nome": "Consultoras especializadas por NR",
+   "cor": "warn",
+   "skills": [
     {
-      "nome": "Configuração e visão geral",
-      "cor": "accent2",
-      "skills": [
-        {
-          "nome": "/aft-setup",
-          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
-          "tech": "winget · pipx · uorgs.csv · model: sonnet"
-        },
-        {
-          "nome": "/aft-doctor",
-          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
-          "tech": "aft_doctor.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-erro",
-          "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
-          "tech": "erro_ticket.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-atualizar",
-          "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
-          "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-notebooklm-login",
-          "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
-          "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
-        },
-        {
-          "nome": "/aft-nova-auditoria",
-          "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
-          "tech": "cria memory.md · model: sonnet"
-        },
-        {
-          "nome": "/aft-organiza-os",
-          "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
-          "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
-        },
-        {
-          "nome": "/aft-painel",
-          "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
-          "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
-        },
-        {
-          "nome": "/aft-agenda-det",
-          "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
-        },
-        {
-          "nome": "/aft-nova-skill",
-          "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
-          "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
-        }
-      ]
+     "nome": "/aft-NR01",
+     "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
+     "tech": ""
     },
     {
-      "nome": "Preparação da ação fiscal (antes da visita)",
-      "cor": "accent2",
-      "skills": [
-        {
-          "nome": "/aft-preparacao-acao-fiscal",
-          "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, estuda os temas nos NotebookLMs (sem nome de empresa/trabalhador, com fontes) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Salva preparacao.md na pasta da OS.",
-          "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
-        },
-        {
-          "nome": "/aft-NAD",
-          "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
-          "tech": "espelha /aft-tn-nco · model: sonnet"
-        }
-      ]
+     "nome": "/aft-NR12",
+     "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
+     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
     },
     {
-      "nome": "Inspeção e lavratura",
-      "cor": "accent",
-      "skills": [
-        {
-          "nome": "/aft-inspecao-fisica",
-          "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
-          "tech": "relato → memory.md · model: sonnet"
-        },
-        {
-          "nome": "/aft-consulta",
-          "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
-          "tech": "notebooklm ask · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-auditoria-geral",
-          "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
-          "tech": "orquestra consultoras · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-informalidade",
-          "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
-          "tech": "data de admissão dd/mm/aaaa · model: sonnet"
-        },
-        {
-          "nome": "/aft-PGR-analise",
-          "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
-          "tech": "handoff p/ gera-ai · model: opus 1M"
-        },
-        {
-          "nome": "/aft-aet-auditoria",
-          "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
-          "tech": "handoff p/ gera-ai · model: opus 1M"
-        },
-        {
-          "nome": "/aft-auditoria-AR-NR12",
-          "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
-          "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
-        },
-        {
-          "nome": "/aft-det-630",
-          "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
-          "tech": "escreve em ## Notificações DET · model: sonnet"
-        },
-        {
-          "nome": "/aft-tn-nco",
-          "role": "Redige a Notificação para Correção de Irregularidades (texto pronto para colar no DET, item por item; preenchimento manual).",
-          "tech": "limite 1000 char/campo · model: sonnet"
-        },
-        {
-          "nome": "/aft-email",
-          "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
-          "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
-        },
-        {
-          "nome": "/aft-embargo-interdicao",
-          "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
-          "tech": "template.docx SRTE/GO · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-embargo-interdicao-manutencao",
-          "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
-          "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
-        },
-        {
-          "nome": "/aft-embargo-interdicao-levantamento",
-          "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
-          "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
-        },
-        {
-          "nome": "/aft-analise-acidente",
-          "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
-          "tech": "gerar_relatorio_docx.py · model: opus 1M"
-        }
-      ]
+     "nome": "/aft-NR18",
+     "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
+     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
     },
     {
-      "nome": "Consultoras especializadas por NR",
-      "cor": "warn",
-      "skills": [
-        {
-          "nome": "/aft-NR01",
-          "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
-          "tech": ""
-        },
-        {
-          "nome": "/aft-NR12",
-          "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
-          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-NR18",
-          "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
-          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-cnae-grau-risco-nr04",
-          "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
-          "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-dimensionamento-sesmt-nr04",
-          "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
-          "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-cipa-nr05-dimensionamento",
-          "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
-          "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-nr24-dimensionamento",
-          "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
-          "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
-        }
-      ]
+     "nome": "/aft-cnae-grau-risco-nr04",
+     "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
+     "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
     },
     {
-      "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
-      "cor": "accent2",
-      "skills": [
-        {
-          "nome": "/aft-jornada-analise",
-          "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
-          "tech": "roteador · model: sonnet"
-        },
-        {
-          "nome": "/aft-jornada-valida-afd-aej",
-          "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
-          "tech": "validar.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-jornada-atestado",
-          "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
-          "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-jornada-auto-afd-aej",
-          "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
-          "tech": "handoff p/ gera-ai · model: sonnet"
-        }
-      ]
+     "nome": "/aft-dimensionamento-sesmt-nr04",
+     "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
+     "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
     },
     {
-      "nome": "Empacotamento, rastreamento e relatórios",
-      "cor": "ok",
-      "skills": [
-        {
-          "nome": "/aft-revisa-auto",
-          "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
-          "tech": "gate dentro do /aft-gera-ai · model: sonnet"
-        },
-        {
-          "nome": "/aft-gera-ai",
-          "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
-          "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-autos-lavrados",
-          "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
-          "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
-        },
-        {
-          "nome": "/aft-autos-pdf-reunidos",
-          "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
-          "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
-        },
-        {
-          "nome": "/aft-relatorio",
-          "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
-          "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
-        },
-        {
-          "nome": "/aft-relatorio-acidentes",
-          "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
-          "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
-        },
-        {
-          "nome": "/aft-cat-trabalhador",
-          "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
-          "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
-        },
-        {
-          "nome": "/aft-modelo-docx",
-          "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
-          "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
-        },
-        {
-          "nome": "/aft-sessoes-os",
-          "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
-          "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
-        }
-      ]
+     "nome": "/aft-cipa-nr05-dimensionamento",
+     "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
+     "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
+    },
+    {
+     "nome": "/aft-nr24-dimensionamento",
+     "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
+     "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
     }
-  ],
-  "scripts": [
+   ]
+  },
+  {
+   "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
+   "cor": "accent2",
+   "skills": [
     {
-      "nome": "rehydrate.py",
-      "caminho": "_scripts/rehydrate.py",
-      "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-analise",
+     "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
+     "tech": "roteador · model: sonnet"
     },
     {
-      "nome": "bloco3_inject.py",
-      "caminho": "_scripts/bloco3_inject.py",
-      "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-valida-afd-aej",
+     "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
+     "tech": "validar.py · model: sonnet"
     },
     {
-      "nome": "validar_txt.py",
-      "caminho": "_scripts/validar_txt.py",
-      "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-atestado",
+     "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
+     "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
     },
     {
-      "nome": "checar_pii.py",
-      "caminho": "_scripts/checar_pii.py",
-      "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_diff.py",
-      "caminho": "_scripts/checar_diff.py",
-      "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_arquivo_aberto.py",
-      "caminho": "_scripts/checar_arquivo_aberto.py",
-      "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "backup_arquivo.py",
-      "caminho": "_scripts/backup_arquivo.py",
-      "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_rt_autos.py",
-      "caminho": "_scripts/checar_rt_autos.py",
-      "papel": "Confere a coerência entre a Seção 4 do RT (.docx) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "gerar_painel.py",
-      "caminho": "_scripts/gerar_painel.py",
-      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
-      "runtime": "Python stdlib (+pdfplumber opcional)"
-    },
-    {
-      "nome": "servir_painel.py",
-      "caminho": "_scripts/servir_painel.py",
-      "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "det_sync.py",
-      "caminho": "_scripts/det_sync.py",
-      "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "instalar_rotina_painel.py",
-      "caminho": "_scripts/instalar_rotina_painel.py",
-      "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "instalar_servidor_painel.py",
-      "caminho": "_scripts/instalar_servidor_painel.py",
-      "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
-      "runtime": "Python stdlib (+ PowerShell no Windows)"
-    },
-    {
-      "nome": "aft_doctor.py",
-      "caminho": "_scripts/aft_doctor.py",
-      "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "fotos_para_pdf.py",
-      "caminho": "_scripts/fotos_para_pdf.py",
-      "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
-      "runtime": "Python · pillow"
-    },
-    {
-      "nome": "comprimir_pdf.py",
-      "caminho": "_scripts/comprimir_pdf.py",
-      "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
-      "runtime": "Python · pikepdf/pypdf"
-    },
-    {
-      "nome": "docx_pack.py / docx_unpack.py",
-      "caminho": "_scripts/docx_*.py",
-      "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
-      "runtime": "Python stdlib · zipfile"
-    },
-    {
-      "nome": "scan_autos.py",
-      "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
-      "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
-      "runtime": "Python · pypdf"
-    },
-    {
-      "nome": "gera_relacao_autos.py",
-      "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
-      "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
-      "runtime": "Python (python-docx)"
-    },
-    {
-      "nome": "inspecionar_assinatura.py",
-      "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
-      "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
-      "runtime": "Python"
-    },
-    {
-      "nome": "validar.py",
-      "caminho": "aft-jornada-valida-afd-aej/validar.py",
-      "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "gerar_relatorio_docx.py",
-      "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
-      "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
-      "runtime": "Python stdlib · zipfile"
-    },
-    {
-      "runtime": "Python stdlib",
-      "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
-      "nome": "pasta_aft.py",
-      "caminho": "_scripts/pasta_aft.py"
-    },
-    {
-      "nome": "instalar_agentes.py",
-      "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
-    },
-    {
-      "nome": "erro_ticket.py",
-      "caminho": "_scripts/erro_ticket.py",
-      "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "sync_perfil.py",
-      "caminho": "_scripts/sync_perfil.py",
-      "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "sessoes_os.py",
-      "caminho": "_scripts/sessoes_os.py",
-      "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "instalar_vigia_sessoes.py",
-      "caminho": "_scripts/instalar_vigia_sessoes.py",
-      "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
-      "runtime": "Python stdlib (+ PowerShell no Windows)"
-    },
-    {
-      "nome": "checar_acentos.py",
-      "caminho": "_scripts/checar_acentos.py",
-      "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_arquivos_internos.py",
-      "caminho": "_scripts/checar_arquivos_internos.py",
-      "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "indenta_quebras.py",
-      "caminho": "_scripts/indenta_quebras.py",
-      "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-auto-afd-aej",
+     "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
+     "tech": "handoff p/ gera-ai · model: sonnet"
     }
-  ],
-  "dados": [
+   ]
+  },
+  {
+   "nome": "Empacotamento, rastreamento e relatórios",
+   "cor": "ok",
+   "skills": [
     {
-      "arquivo": "config/notebooks.json",
-      "conteudo": "49 notebooks (IDs do NotebookLM, ex.: nr-12, nr-18, ementario-sst)",
-      "uso": "Consulta de ementa pelas skills (especialmente /aft-consulta)."
+     "nome": "/aft-revisa-auto",
+     "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
+     "tech": "gate dentro do /aft-gera-ai · model: sonnet"
     },
     {
-      "arquivo": "config/uorgs.csv",
-      "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
-      "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
+     "nome": "/aft-gera-ai",
+     "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
+     "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
     },
     {
-      "arquivo": "config/CLAUDE-aft.md",
-      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
-      "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
+     "nome": "/aft-autos-lavrados",
+     "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
+     "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
     },
     {
-      "arquivo": "config/blocos_auto.md",
-      "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
-      "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
+     "nome": "/aft-autos-pdf-reunidos",
+     "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
+     "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
     },
     {
-      "arquivo": "config/settings-aft.json",
-      "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
-      "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
+     "nome": "/aft-relatorio",
+     "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
+     "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
     },
     {
-      "arquivo": "config/models-validos.json",
-      "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
-      "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
+     "nome": "/aft-relatorio-acidentes",
+     "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
+     "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
+    },
+    {
+     "nome": "/aft-cat-trabalhador",
+     "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
+     "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
+    },
+    {
+     "nome": "/aft-modelo-docx",
+     "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
+     "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
+    },
+    {
+     "nome": "/aft-sessoes-os",
+     "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
+     "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
     }
-  ],
-  "ementas": [
-    {
-      "camada": "1. NotebookLM (recomendado)",
-      "txt": "CLI notebooklm-py + skill /aft-consulta; IDs em config/notebooks.json; acesso em notebooks-aft.vercel.app. Envia só a descrição da irregularidade."
-    },
-    {
-      "camada": "2. Google Drive compartilhado",
-      "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
-    },
-    {
-      "camada": "3. O AFT informa o código",
-      "txt": "Formato XXXXXX-X, conferido no ementário oficial."
-    }
-  ],
-  "anonimizacao": [
-    "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
-    "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
-    "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
-    "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
-    "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
-    "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT."
-  ],
-  "decisoes": [
-    {
-      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
-      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
-    },
-    {
-      "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
-      "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
-    },
-    {
-      "topico": "Relação de autos é .docx, sem PDF",
-      "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
-    },
-    {
-      "topico": "Nomes das skills",
-      "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
-    },
-    {
-      "topico": "Instalação",
-      "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
-    },
-    {
-      "topico": "Git obrigatório",
-      "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
-    },
-    {
-      "topico": "Sem SISOS/Supabase",
-      "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
-    },
-    {
-      "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
-      "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
-    },
-    {
-      "topico": "Empacotamento único",
-      "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
-    },
-    {
-      "topico": "Latin-1 sem iconv",
-      "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
-    },
-    {
-      "topico": "Lotação pela cidade",
-      "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
-    },
-    {
-      "topico": "Ementas em 3 camadas",
-      "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
-    },
-    {
-      "topico": "Bloco 3 centralizado",
-      "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
-    },
-    {
-      "topico": "Atualização separada do diagnóstico",
-      "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
-    },
-    {
-      "topico": "Política de model por skill",
-      "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
-    },
-    {
-      "topico": "allowed-tools como garantia",
-      "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
-    },
-    {
-      "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
-      "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
-    },
-    {
-      "topico": "Detecção determinística no /aft-painel",
-      "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
-    },
-    {
-      "topico": "Bases distintas",
-      "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
-    },
-    {
-      "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
-      "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
-    },
-    {
-      "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
-      "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
-    },
-    {
-      "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
-      "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
-    },
-    {
-      "topico": "Painel virou dashboard de cards (SISOS local, offline)",
-      "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
-    },
-    {
-      "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
-      "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
-    },
-    {
-      "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
-      "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
-    },
-    {
-      "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
-      "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
-    },
-    {
-      "topico": "Painel ativo (modo interativo local)",
-      "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
-    },
-    {
-      "topico": "Extensão Chrome sincroniza o DET com o painel local",
-      "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
-    },
-    {
-      "topico": "Servidor do painel sempre ligado (padrão na instalação)",
-      "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
-    },
-    {
-      "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
-      "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
-    },
-    {
-      "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
-      "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
-    },
-    {
-      "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
-      "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
-    },
-    {
-      "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
-      "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
-    },
-    {
-      "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
-      "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
-    },
-    {
-      "topico": "Google Calendar: conector do Claude, não OAuth próprio",
-      "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
-    },
-    {
-      "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
-      "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
-    },
-    {
-      "topico": "Pasta única interdicao-embargo/ por OS",
-      "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
-    },
-    {
-      "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
-      "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
-    },
-    {
-      "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
-      "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
-    },
-    {
-      "titulo": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
-      "texto": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro)."
-    }
-  ],
-  "diferencas": [
-    {
-      "topico": "Plataforma",
-      "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
-    },
-    {
-      "topico": "Estado central",
-      "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
-    },
-    {
-      "topico": "Empacotamento",
-      "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
-    },
-    {
-      "topico": "Identidade do AFT",
-      "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
-    }
-  ],
-  "foraDoToolkit": [
-    "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
-    "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
-    "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
-    "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
-    "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
-  ],
-  "avisos": [
-    "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
-    "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
-    "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
-    "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
-    "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
-    "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
-    "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
-    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
-  ]
+   ]
+  }
+ ],
+ "scripts": [
+  {
+   "nome": "rehydrate.py",
+   "caminho": "_scripts/rehydrate.py",
+   "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "bloco3_inject.py",
+   "caminho": "_scripts/bloco3_inject.py",
+   "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "validar_txt.py",
+   "caminho": "_scripts/validar_txt.py",
+   "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_pii.py",
+   "caminho": "_scripts/checar_pii.py",
+   "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_diff.py",
+   "caminho": "_scripts/checar_diff.py",
+   "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_arquivo_aberto.py",
+   "caminho": "_scripts/checar_arquivo_aberto.py",
+   "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "backup_arquivo.py",
+   "caminho": "_scripts/backup_arquivo.py",
+   "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_rt_autos.py",
+   "caminho": "_scripts/checar_rt_autos.py",
+   "papel": "Confere a coerência entre a Seção 4 do RT (.docx) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "gerar_painel.py",
+   "caminho": "_scripts/gerar_painel.py",
+   "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+   "runtime": "Python stdlib (+pdfplumber opcional)"
+  },
+  {
+   "nome": "servir_painel.py",
+   "caminho": "_scripts/servir_painel.py",
+   "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill det-baixar-empregador): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "det_sync.py",
+   "caminho": "_scripts/det_sync.py",
+   "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "det_baixar.py",
+   "caminho": "_scripts/det_baixar.py",
+   "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): a pasta nasce notificacao-<COD>/item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Idempotente por existência do arquivo; nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill pessoal det-baixar-empregador).",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "instalar_rotina_painel.py",
+   "caminho": "_scripts/instalar_rotina_painel.py",
+   "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "instalar_servidor_painel.py",
+   "caminho": "_scripts/instalar_servidor_painel.py",
+   "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
+   "runtime": "Python stdlib (+ PowerShell no Windows)"
+  },
+  {
+   "nome": "aft_doctor.py",
+   "caminho": "_scripts/aft_doctor.py",
+   "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "fotos_para_pdf.py",
+   "caminho": "_scripts/fotos_para_pdf.py",
+   "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
+   "runtime": "Python · pillow"
+  },
+  {
+   "nome": "comprimir_pdf.py",
+   "caminho": "_scripts/comprimir_pdf.py",
+   "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
+   "runtime": "Python · pikepdf/pypdf"
+  },
+  {
+   "nome": "docx_pack.py / docx_unpack.py",
+   "caminho": "_scripts/docx_*.py",
+   "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
+   "runtime": "Python stdlib · zipfile"
+  },
+  {
+   "nome": "scan_autos.py",
+   "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
+   "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
+   "runtime": "Python · pypdf"
+  },
+  {
+   "nome": "gera_relacao_autos.py",
+   "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
+   "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
+   "runtime": "Python (python-docx)"
+  },
+  {
+   "nome": "inspecionar_assinatura.py",
+   "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
+   "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
+   "runtime": "Python"
+  },
+  {
+   "nome": "validar.py",
+   "caminho": "aft-jornada-valida-afd-aej/validar.py",
+   "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "gerar_relatorio_docx.py",
+   "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
+   "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
+   "runtime": "Python stdlib · zipfile"
+  },
+  {
+   "runtime": "Python stdlib",
+   "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
+   "nome": "pasta_aft.py",
+   "caminho": "_scripts/pasta_aft.py"
+  },
+  {
+   "nome": "instalar_agentes.py",
+   "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
+  },
+  {
+   "nome": "erro_ticket.py",
+   "caminho": "_scripts/erro_ticket.py",
+   "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "sync_perfil.py",
+   "caminho": "_scripts/sync_perfil.py",
+   "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "sessoes_os.py",
+   "caminho": "_scripts/sessoes_os.py",
+   "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "instalar_vigia_sessoes.py",
+   "caminho": "_scripts/instalar_vigia_sessoes.py",
+   "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
+   "runtime": "Python stdlib (+ PowerShell no Windows)"
+  },
+  {
+   "nome": "checar_acentos.py",
+   "caminho": "_scripts/checar_acentos.py",
+   "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_arquivos_internos.py",
+   "caminho": "_scripts/checar_arquivos_internos.py",
+   "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "indenta_quebras.py",
+   "caminho": "_scripts/indenta_quebras.py",
+   "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
+   "runtime": "Python stdlib"
+  }
+ ],
+ "dados": [
+  {
+   "arquivo": "config/notebooks.json",
+   "conteudo": "49 notebooks (IDs do NotebookLM, ex.: nr-12, nr-18, ementario-sst)",
+   "uso": "Consulta de ementa pelas skills (especialmente /aft-consulta)."
+  },
+  {
+   "arquivo": "config/uorgs.csv",
+   "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
+   "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
+  },
+  {
+   "arquivo": "config/CLAUDE-aft.md",
+   "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
+   "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
+  },
+  {
+   "arquivo": "config/blocos_auto.md",
+   "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
+   "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
+  },
+  {
+   "arquivo": "config/settings-aft.json",
+   "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
+   "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
+  },
+  {
+   "arquivo": "config/models-validos.json",
+   "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
+   "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
+  }
+ ],
+ "ementas": [
+  {
+   "camada": "1. NotebookLM (recomendado)",
+   "txt": "CLI notebooklm-py + skill /aft-consulta; IDs em config/notebooks.json; acesso em notebooks-aft.vercel.app. Envia só a descrição da irregularidade."
+  },
+  {
+   "camada": "2. Google Drive compartilhado",
+   "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
+  },
+  {
+   "camada": "3. O AFT informa o código",
+   "txt": "Formato XXXXXX-X, conferido no ementário oficial."
+  }
+ ],
+ "anonimizacao": [
+  "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
+  "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
+  "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
+  "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
+  "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
+  "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT."
+ ],
+ "decisoes": [
+  {
+   "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+   "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+  },
+  {
+   "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
+   "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
+  },
+  {
+   "topico": "Relação de autos é .docx, sem PDF",
+   "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
+  },
+  {
+   "topico": "Nomes das skills",
+   "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
+  },
+  {
+   "topico": "Instalação",
+   "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
+  },
+  {
+   "topico": "Git obrigatório",
+   "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
+  },
+  {
+   "topico": "Sem SISOS/Supabase",
+   "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
+  },
+  {
+   "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
+   "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
+  },
+  {
+   "topico": "Empacotamento único",
+   "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
+  },
+  {
+   "topico": "Latin-1 sem iconv",
+   "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
+  },
+  {
+   "topico": "Lotação pela cidade",
+   "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
+  },
+  {
+   "topico": "Ementas em 3 camadas",
+   "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
+  },
+  {
+   "topico": "Bloco 3 centralizado",
+   "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
+  },
+  {
+   "topico": "Atualização separada do diagnóstico",
+   "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
+  },
+  {
+   "topico": "Política de model por skill",
+   "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
+  },
+  {
+   "topico": "allowed-tools como garantia",
+   "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
+  },
+  {
+   "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
+   "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
+  },
+  {
+   "topico": "Detecção determinística no /aft-painel",
+   "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
+  },
+  {
+   "topico": "Bases distintas",
+   "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
+  },
+  {
+   "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
+   "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
+  },
+  {
+   "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
+   "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
+  },
+  {
+   "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
+   "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
+  },
+  {
+   "topico": "Painel virou dashboard de cards (SISOS local, offline)",
+   "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
+  },
+  {
+   "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
+   "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
+  },
+  {
+   "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
+   "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
+  },
+  {
+   "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
+   "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
+  },
+  {
+   "topico": "Painel ativo (modo interativo local)",
+   "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
+  },
+  {
+   "topico": "Extensão Chrome sincroniza o DET com o painel local",
+   "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
+  },
+  {
+   "topico": "Servidor do painel sempre ligado (padrão na instalação)",
+   "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
+  },
+  {
+   "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
+   "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
+  },
+  {
+   "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
+   "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
+  },
+  {
+   "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
+   "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
+  },
+  {
+   "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
+   "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
+  },
+  {
+   "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
+   "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
+  },
+  {
+   "topico": "Google Calendar: conector do Claude, não OAuth próprio",
+   "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
+  },
+  {
+   "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
+   "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
+  },
+  {
+   "topico": "Pasta única interdicao-embargo/ por OS",
+   "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
+  },
+  {
+   "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
+   "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
+  },
+  {
+   "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
+   "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
+  },
+  {
+   "titulo": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
+   "texto": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro)."
+  }
+ ],
+ "diferencas": [
+  {
+   "topico": "Plataforma",
+   "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
+  },
+  {
+   "topico": "Estado central",
+   "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
+  },
+  {
+   "topico": "Empacotamento",
+   "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
+  },
+  {
+   "topico": "Identidade do AFT",
+   "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
+  }
+ ],
+ "foraDoToolkit": [
+  "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
+  "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
+  "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
+  "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
+  "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
+ ],
+ "avisos": [
+  "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
+  "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
+  "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
+  "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
+  "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
+  "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
+  "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
+  "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+  "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
+ ]
 };
 
 const $=s=>document.querySelector(s), el=(t,c,h)=>{const e=document.createElement(t);if(c)e.className=c;if(h!=null)e.innerHTML=h;return e;};

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -1,812 +1,818 @@
 {
-  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
-  "repo": "github.com/ryckardo42/aft-toolkit",
-  "data": "2026-08-20",
-  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
-  "stats": {
-    "skills": 46,
-    "scripts": 40,
-    "dados": 6,
-    "commit": "ver `git log -1` — atualizado em 14/08/2026"
+ "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
+ "repo": "github.com/ryckardo42/aft-toolkit",
+ "data": "2026-08-21",
+ "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+ "stats": {
+  "skills": 47,
+  "scripts": 46,
+  "dados": 6,
+  "commit": "ver `git log -1` — atualizado em 21/08/2026"
+ },
+ "atores": [
+  {
+   "nome": "AFT colega (novo usuário)",
+   "papel": "Auditor no Windows",
+   "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
   },
-  "atores": [
+  {
+   "nome": "Claude Code",
+   "papel": "Assistente técnico",
+   "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
+  },
+  {
+   "nome": "Sistema Auditor",
+   "papel": "App oficial do MTE",
+   "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
+  },
+  {
+   "nome": "NotebookLM",
+   "papel": "Fonte de ementas",
+   "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
+  },
+  {
+   "nome": "Ricardo (mantenedor)",
+   "papel": "AFT — SRTE/GO",
+   "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
+  }
+ ],
+ "fluxo": [
+  {
+   "who": "/aft-preparacao-acao-fiscal",
+   "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, estuda os temas no NotebookLM e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
+  },
+  {
+   "who": "/aft-nova-auditoria",
+   "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
+  },
+  {
+   "who": "/aft-painel",
+   "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
+  },
+  {
+   "who": "Visita ao estabelecimento",
+   "act": "Inspeção física presencial."
+  },
+  {
+   "who": "/aft-inspecao-fisica",
+   "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
+  },
+  {
+   "who": "/aft-auditoria-geral",
+   "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
+  },
+  {
+   "who": "/aft-revisa-auto",
+   "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
+  },
+  {
+   "who": "/aft-gera-ai",
+   "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
+  },
+  {
+   "who": "Sistema Auditor",
+   "act": "Botão imp. txt → revisão do AFT → transmissão."
+  },
+  {
+   "who": "/aft-autos-lavrados",
+   "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
+  },
+  {
+   "who": "/aft-relatorio",
+   "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
+  }
+ ],
+ "instalacao": [
+  {
+   "who": "Instalar o app Claude",
+   "act": "claude.com/claude-code — único passo realmente inicial."
+  },
+  {
+   "who": "Instalar o Git + reiniciar pela bandeja",
+   "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
+  },
+  {
+   "who": "Colar o prompt de instalação no </> Code",
+   "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
+  },
+  {
+   "who": "/aft-setup",
+   "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
+  },
+  {
+   "who": "Codex: dois atalhos (opcional)",
+   "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
+  }
+ ],
+ "camadas": [
+  {
+   "nome": "Configuração e visão geral",
+   "cor": "accent2",
+   "skills": [
     {
-      "nome": "AFT colega (novo usuário)",
-      "papel": "Auditor no Windows",
-      "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
+     "nome": "/aft-setup",
+     "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+     "tech": "winget · pipx · uorgs.csv · model: sonnet"
     },
     {
-      "nome": "Claude Code",
-      "papel": "Assistente técnico",
-      "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
+     "nome": "/aft-doctor",
+     "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
+     "tech": "aft_doctor.py · model: sonnet"
     },
     {
-      "nome": "Sistema Auditor",
-      "papel": "App oficial do MTE",
-      "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
+     "nome": "/aft-erro",
+     "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
+     "tech": "erro_ticket.py · model: sonnet"
     },
     {
-      "nome": "NotebookLM",
-      "papel": "Fonte de ementas",
-      "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
+     "nome": "/aft-atualizar",
+     "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
+     "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
     },
     {
-      "nome": "Ricardo (mantenedor)",
-      "papel": "AFT — SRTE/GO",
-      "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
+     "nome": "/aft-notebooklm-login",
+     "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
+     "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
+    },
+    {
+     "nome": "/aft-nova-auditoria",
+     "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
+     "tech": "cria memory.md · model: sonnet"
+    },
+    {
+     "nome": "/aft-organiza-os",
+     "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
+     "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
+    },
+    {
+     "nome": "/aft-painel",
+     "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
+     "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
+    },
+    {
+     "nome": "/aft-agenda-det",
+     "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
+    },
+    {
+     "nome": "/aft-nova-skill",
+     "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
+     "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
     }
-  ],
-  "fluxo": [
+   ]
+  },
+  {
+   "nome": "Preparação da ação fiscal (antes da visita)",
+   "cor": "accent2",
+   "skills": [
     {
-      "who": "/aft-preparacao-acao-fiscal",
-      "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, estuda os temas no NotebookLM e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
+     "nome": "/aft-preparacao-acao-fiscal",
+     "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, estuda os temas nos NotebookLMs (sem nome de empresa/trabalhador, com fontes) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Salva preparacao.md na pasta da OS.",
+     "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
     },
     {
-      "who": "/aft-nova-auditoria",
-      "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
-    },
-    {
-      "who": "/aft-painel",
-      "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
-    },
-    {
-      "who": "Visita ao estabelecimento",
-      "act": "Inspeção física presencial."
-    },
-    {
-      "who": "/aft-inspecao-fisica",
-      "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
-    },
-    {
-      "who": "/aft-auditoria-geral",
-      "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
-    },
-    {
-      "who": "/aft-revisa-auto",
-      "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
-    },
-    {
-      "who": "/aft-gera-ai",
-      "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
-    },
-    {
-      "who": "Sistema Auditor",
-      "act": "Botão imp. txt → revisão do AFT → transmissão."
-    },
-    {
-      "who": "/aft-autos-lavrados",
-      "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
-    },
-    {
-      "who": "/aft-relatorio",
-      "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
+     "nome": "/aft-NAD",
+     "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
+     "tech": "espelha /aft-tn-nco · model: sonnet"
     }
-  ],
-  "instalacao": [
+   ]
+  },
+  {
+   "nome": "Inspeção e lavratura",
+   "cor": "accent",
+   "skills": [
     {
-      "who": "Instalar o app Claude",
-      "act": "claude.com/claude-code — único passo realmente inicial."
+     "nome": "/aft-inspecao-fisica",
+     "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
+     "tech": "relato → memory.md · model: sonnet"
     },
     {
-      "who": "Instalar o Git + reiniciar pela bandeja",
-      "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
+     "nome": "/aft-consulta",
+     "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
+     "tech": "notebooklm ask · herda o modelo da sessão"
     },
     {
-      "who": "Colar o prompt de instalação no </> Code",
-      "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
+     "nome": "/aft-auditoria-geral",
+     "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
+     "tech": "orquestra consultoras · herda o modelo da sessão"
     },
     {
-      "who": "/aft-setup",
-      "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
+     "nome": "/aft-informalidade",
+     "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
+     "tech": "data de admissão dd/mm/aaaa · model: sonnet"
     },
     {
-      "who": "Codex: dois atalhos (opcional)",
-      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
+     "nome": "/aft-PGR-analise",
+     "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
+     "tech": "handoff p/ gera-ai · model: opus 1M"
+    },
+    {
+     "nome": "/aft-aet-auditoria",
+     "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
+     "tech": "handoff p/ gera-ai · model: opus 1M"
+    },
+    {
+     "nome": "/aft-auditoria-AR-NR12",
+     "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
+     "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
+    },
+    {
+     "nome": "/aft-det-630",
+     "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
+     "tech": "escreve em ## Notificações DET · model: sonnet"
+    },
+    {
+     "nome": "/aft-tn-nco",
+     "role": "Redige a Notificação para Correção de Irregularidades (texto pronto para colar no DET, item por item; preenchimento manual).",
+     "tech": "limite 1000 char/campo · model: sonnet"
+    },
+    {
+     "nome": "/aft-email",
+     "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
+     "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
+    },
+    {
+     "nome": "/aft-embargo-interdicao",
+     "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
+     "tech": "template.docx SRTE/GO · herda o modelo da sessão"
+    },
+    {
+     "nome": "/aft-embargo-interdicao-manutencao",
+     "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
+     "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
+    },
+    {
+     "nome": "/aft-embargo-interdicao-levantamento",
+     "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
+     "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
+    },
+    {
+     "nome": "/aft-analise-acidente",
+     "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
+     "tech": "gerar_relatorio_docx.py · model: opus 1M"
     }
-  ],
-  "camadas": [
+   ]
+  },
+  {
+   "nome": "Consultoras especializadas por NR",
+   "cor": "warn",
+   "skills": [
     {
-      "nome": "Configuração e visão geral",
-      "cor": "accent2",
-      "skills": [
-        {
-          "nome": "/aft-setup",
-          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
-          "tech": "winget · pipx · uorgs.csv · model: sonnet"
-        },
-        {
-          "nome": "/aft-doctor",
-          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
-          "tech": "aft_doctor.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-erro",
-          "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
-          "tech": "erro_ticket.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-atualizar",
-          "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
-          "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-notebooklm-login",
-          "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
-          "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
-        },
-        {
-          "nome": "/aft-nova-auditoria",
-          "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
-          "tech": "cria memory.md · model: sonnet"
-        },
-        {
-          "nome": "/aft-organiza-os",
-          "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
-          "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
-        },
-        {
-          "nome": "/aft-painel",
-          "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
-          "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
-        },
-        {
-          "nome": "/aft-agenda-det",
-          "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
-        },
-        {
-          "nome": "/aft-nova-skill",
-          "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
-          "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
-        }
-      ]
+     "nome": "/aft-NR01",
+     "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
+     "tech": ""
     },
     {
-      "nome": "Preparação da ação fiscal (antes da visita)",
-      "cor": "accent2",
-      "skills": [
-        {
-          "nome": "/aft-preparacao-acao-fiscal",
-          "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, estuda os temas nos NotebookLMs (sem nome de empresa/trabalhador, com fontes) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Salva preparacao.md na pasta da OS.",
-          "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
-        },
-        {
-          "nome": "/aft-NAD",
-          "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
-          "tech": "espelha /aft-tn-nco · model: sonnet"
-        }
-      ]
+     "nome": "/aft-NR12",
+     "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
+     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
     },
     {
-      "nome": "Inspeção e lavratura",
-      "cor": "accent",
-      "skills": [
-        {
-          "nome": "/aft-inspecao-fisica",
-          "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
-          "tech": "relato → memory.md · model: sonnet"
-        },
-        {
-          "nome": "/aft-consulta",
-          "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
-          "tech": "notebooklm ask · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-auditoria-geral",
-          "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
-          "tech": "orquestra consultoras · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-informalidade",
-          "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
-          "tech": "data de admissão dd/mm/aaaa · model: sonnet"
-        },
-        {
-          "nome": "/aft-PGR-analise",
-          "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
-          "tech": "handoff p/ gera-ai · model: opus 1M"
-        },
-        {
-          "nome": "/aft-aet-auditoria",
-          "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
-          "tech": "handoff p/ gera-ai · model: opus 1M"
-        },
-        {
-          "nome": "/aft-auditoria-AR-NR12",
-          "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
-          "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
-        },
-        {
-          "nome": "/aft-det-630",
-          "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
-          "tech": "escreve em ## Notificações DET · model: sonnet"
-        },
-        {
-          "nome": "/aft-tn-nco",
-          "role": "Redige a Notificação para Correção de Irregularidades (texto pronto para colar no DET, item por item; preenchimento manual).",
-          "tech": "limite 1000 char/campo · model: sonnet"
-        },
-        {
-          "nome": "/aft-email",
-          "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
-          "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
-        },
-        {
-          "nome": "/aft-embargo-interdicao",
-          "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
-          "tech": "template.docx SRTE/GO · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-embargo-interdicao-manutencao",
-          "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
-          "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
-        },
-        {
-          "nome": "/aft-embargo-interdicao-levantamento",
-          "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
-          "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
-        },
-        {
-          "nome": "/aft-analise-acidente",
-          "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
-          "tech": "gerar_relatorio_docx.py · model: opus 1M"
-        }
-      ]
+     "nome": "/aft-NR18",
+     "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
+     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
     },
     {
-      "nome": "Consultoras especializadas por NR",
-      "cor": "warn",
-      "skills": [
-        {
-          "nome": "/aft-NR01",
-          "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
-          "tech": ""
-        },
-        {
-          "nome": "/aft-NR12",
-          "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
-          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-NR18",
-          "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
-          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-cnae-grau-risco-nr04",
-          "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
-          "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-dimensionamento-sesmt-nr04",
-          "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
-          "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-cipa-nr05-dimensionamento",
-          "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
-          "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-nr24-dimensionamento",
-          "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
-          "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
-        }
-      ]
+     "nome": "/aft-cnae-grau-risco-nr04",
+     "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
+     "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
     },
     {
-      "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
-      "cor": "accent2",
-      "skills": [
-        {
-          "nome": "/aft-jornada-analise",
-          "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
-          "tech": "roteador · model: sonnet"
-        },
-        {
-          "nome": "/aft-jornada-valida-afd-aej",
-          "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
-          "tech": "validar.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-jornada-atestado",
-          "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
-          "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
-        },
-        {
-          "nome": "/aft-jornada-auto-afd-aej",
-          "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
-          "tech": "handoff p/ gera-ai · model: sonnet"
-        }
-      ]
+     "nome": "/aft-dimensionamento-sesmt-nr04",
+     "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
+     "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
     },
     {
-      "nome": "Empacotamento, rastreamento e relatórios",
-      "cor": "ok",
-      "skills": [
-        {
-          "nome": "/aft-revisa-auto",
-          "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
-          "tech": "gate dentro do /aft-gera-ai · model: sonnet"
-        },
-        {
-          "nome": "/aft-gera-ai",
-          "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
-          "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
-        },
-        {
-          "nome": "/aft-autos-lavrados",
-          "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
-          "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
-        },
-        {
-          "nome": "/aft-autos-pdf-reunidos",
-          "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
-          "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
-        },
-        {
-          "nome": "/aft-relatorio",
-          "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
-          "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
-        },
-        {
-          "nome": "/aft-relatorio-acidentes",
-          "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
-          "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
-        },
-        {
-          "nome": "/aft-cat-trabalhador",
-          "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
-          "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
-        },
-        {
-          "nome": "/aft-modelo-docx",
-          "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
-          "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
-        },
-        {
-          "nome": "/aft-sessoes-os",
-          "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
-          "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
-        }
-      ]
+     "nome": "/aft-cipa-nr05-dimensionamento",
+     "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
+     "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
+    },
+    {
+     "nome": "/aft-nr24-dimensionamento",
+     "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
+     "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
     }
-  ],
-  "scripts": [
+   ]
+  },
+  {
+   "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
+   "cor": "accent2",
+   "skills": [
     {
-      "nome": "rehydrate.py",
-      "caminho": "_scripts/rehydrate.py",
-      "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-analise",
+     "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
+     "tech": "roteador · model: sonnet"
     },
     {
-      "nome": "bloco3_inject.py",
-      "caminho": "_scripts/bloco3_inject.py",
-      "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-valida-afd-aej",
+     "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
+     "tech": "validar.py · model: sonnet"
     },
     {
-      "nome": "validar_txt.py",
-      "caminho": "_scripts/validar_txt.py",
-      "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-atestado",
+     "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
+     "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
     },
     {
-      "nome": "checar_pii.py",
-      "caminho": "_scripts/checar_pii.py",
-      "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_diff.py",
-      "caminho": "_scripts/checar_diff.py",
-      "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_arquivo_aberto.py",
-      "caminho": "_scripts/checar_arquivo_aberto.py",
-      "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "backup_arquivo.py",
-      "caminho": "_scripts/backup_arquivo.py",
-      "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_rt_autos.py",
-      "caminho": "_scripts/checar_rt_autos.py",
-      "papel": "Confere a coerência entre a Seção 4 do RT (.docx) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "gerar_painel.py",
-      "caminho": "_scripts/gerar_painel.py",
-      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
-      "runtime": "Python stdlib (+pdfplumber opcional)"
-    },
-    {
-      "nome": "servir_painel.py",
-      "caminho": "_scripts/servir_painel.py",
-      "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "det_sync.py",
-      "caminho": "_scripts/det_sync.py",
-      "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "instalar_rotina_painel.py",
-      "caminho": "_scripts/instalar_rotina_painel.py",
-      "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "instalar_servidor_painel.py",
-      "caminho": "_scripts/instalar_servidor_painel.py",
-      "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
-      "runtime": "Python stdlib (+ PowerShell no Windows)"
-    },
-    {
-      "nome": "aft_doctor.py",
-      "caminho": "_scripts/aft_doctor.py",
-      "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "fotos_para_pdf.py",
-      "caminho": "_scripts/fotos_para_pdf.py",
-      "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
-      "runtime": "Python · pillow"
-    },
-    {
-      "nome": "comprimir_pdf.py",
-      "caminho": "_scripts/comprimir_pdf.py",
-      "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
-      "runtime": "Python · pikepdf/pypdf"
-    },
-    {
-      "nome": "docx_pack.py / docx_unpack.py",
-      "caminho": "_scripts/docx_*.py",
-      "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
-      "runtime": "Python stdlib · zipfile"
-    },
-    {
-      "nome": "scan_autos.py",
-      "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
-      "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
-      "runtime": "Python · pypdf"
-    },
-    {
-      "nome": "gera_relacao_autos.py",
-      "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
-      "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
-      "runtime": "Python (python-docx)"
-    },
-    {
-      "nome": "inspecionar_assinatura.py",
-      "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
-      "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
-      "runtime": "Python"
-    },
-    {
-      "nome": "validar.py",
-      "caminho": "aft-jornada-valida-afd-aej/validar.py",
-      "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "gerar_relatorio_docx.py",
-      "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
-      "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
-      "runtime": "Python stdlib · zipfile"
-    },
-    {
-      "runtime": "Python stdlib",
-      "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
-      "nome": "pasta_aft.py",
-      "caminho": "_scripts/pasta_aft.py"
-    },
-    {
-      "nome": "instalar_agentes.py",
-      "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
-    },
-    {
-      "nome": "erro_ticket.py",
-      "caminho": "_scripts/erro_ticket.py",
-      "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "sync_perfil.py",
-      "caminho": "_scripts/sync_perfil.py",
-      "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "sessoes_os.py",
-      "caminho": "_scripts/sessoes_os.py",
-      "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "instalar_vigia_sessoes.py",
-      "caminho": "_scripts/instalar_vigia_sessoes.py",
-      "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
-      "runtime": "Python stdlib (+ PowerShell no Windows)"
-    },
-    {
-      "nome": "checar_acentos.py",
-      "caminho": "_scripts/checar_acentos.py",
-      "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "checar_arquivos_internos.py",
-      "caminho": "_scripts/checar_arquivos_internos.py",
-      "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
-      "runtime": "Python stdlib"
-    },
-    {
-      "nome": "indenta_quebras.py",
-      "caminho": "_scripts/indenta_quebras.py",
-      "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
-      "runtime": "Python stdlib"
+     "nome": "/aft-jornada-auto-afd-aej",
+     "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
+     "tech": "handoff p/ gera-ai · model: sonnet"
     }
-  ],
-  "dados": [
+   ]
+  },
+  {
+   "nome": "Empacotamento, rastreamento e relatórios",
+   "cor": "ok",
+   "skills": [
     {
-      "arquivo": "config/notebooks.json",
-      "conteudo": "49 notebooks (IDs do NotebookLM, ex.: nr-12, nr-18, ementario-sst)",
-      "uso": "Consulta de ementa pelas skills (especialmente /aft-consulta)."
+     "nome": "/aft-revisa-auto",
+     "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
+     "tech": "gate dentro do /aft-gera-ai · model: sonnet"
     },
     {
-      "arquivo": "config/uorgs.csv",
-      "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
-      "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
+     "nome": "/aft-gera-ai",
+     "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
+     "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
     },
     {
-      "arquivo": "config/CLAUDE-aft.md",
-      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
-      "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
+     "nome": "/aft-autos-lavrados",
+     "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
+     "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
     },
     {
-      "arquivo": "config/blocos_auto.md",
-      "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
-      "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
+     "nome": "/aft-autos-pdf-reunidos",
+     "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
+     "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
     },
     {
-      "arquivo": "config/settings-aft.json",
-      "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
-      "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
+     "nome": "/aft-relatorio",
+     "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
+     "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
     },
     {
-      "arquivo": "config/models-validos.json",
-      "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
-      "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
+     "nome": "/aft-relatorio-acidentes",
+     "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
+     "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
+    },
+    {
+     "nome": "/aft-cat-trabalhador",
+     "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
+     "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
+    },
+    {
+     "nome": "/aft-modelo-docx",
+     "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
+     "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
+    },
+    {
+     "nome": "/aft-sessoes-os",
+     "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
+     "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
     }
-  ],
-  "ementas": [
-    {
-      "camada": "1. NotebookLM (recomendado)",
-      "txt": "CLI notebooklm-py + skill /aft-consulta; IDs em config/notebooks.json; acesso em notebooks-aft.vercel.app. Envia só a descrição da irregularidade."
-    },
-    {
-      "camada": "2. Google Drive compartilhado",
-      "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
-    },
-    {
-      "camada": "3. O AFT informa o código",
-      "txt": "Formato XXXXXX-X, conferido no ementário oficial."
-    }
-  ],
-  "anonimizacao": [
-    "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
-    "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
-    "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
-    "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
-    "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
-    "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT."
-  ],
-  "decisoes": [
-    {
-      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
-      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
-    },
-    {
-      "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
-      "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
-    },
-    {
-      "topico": "Relação de autos é .docx, sem PDF",
-      "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
-    },
-    {
-      "topico": "Nomes das skills",
-      "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
-    },
-    {
-      "topico": "Instalação",
-      "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
-    },
-    {
-      "topico": "Git obrigatório",
-      "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
-    },
-    {
-      "topico": "Sem SISOS/Supabase",
-      "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
-    },
-    {
-      "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
-      "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
-    },
-    {
-      "topico": "Empacotamento único",
-      "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
-    },
-    {
-      "topico": "Latin-1 sem iconv",
-      "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
-    },
-    {
-      "topico": "Lotação pela cidade",
-      "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
-    },
-    {
-      "topico": "Ementas em 3 camadas",
-      "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
-    },
-    {
-      "topico": "Bloco 3 centralizado",
-      "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
-    },
-    {
-      "topico": "Atualização separada do diagnóstico",
-      "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
-    },
-    {
-      "topico": "Política de model por skill",
-      "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
-    },
-    {
-      "topico": "allowed-tools como garantia",
-      "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
-    },
-    {
-      "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
-      "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
-    },
-    {
-      "topico": "Detecção determinística no /aft-painel",
-      "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
-    },
-    {
-      "topico": "Bases distintas",
-      "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
-    },
-    {
-      "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
-      "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
-    },
-    {
-      "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
-      "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
-    },
-    {
-      "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
-      "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
-    },
-    {
-      "topico": "Painel virou dashboard de cards (SISOS local, offline)",
-      "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
-    },
-    {
-      "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
-      "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
-    },
-    {
-      "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
-      "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
-    },
-    {
-      "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
-      "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
-    },
-    {
-      "topico": "Painel ativo (modo interativo local)",
-      "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
-    },
-    {
-      "topico": "Extensão Chrome sincroniza o DET com o painel local",
-      "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
-    },
-    {
-      "topico": "Servidor do painel sempre ligado (padrão na instalação)",
-      "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
-    },
-    {
-      "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
-      "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
-    },
-    {
-      "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
-      "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
-    },
-    {
-      "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
-      "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
-    },
-    {
-      "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
-      "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
-    },
-    {
-      "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
-      "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
-    },
-    {
-      "topico": "Google Calendar: conector do Claude, não OAuth próprio",
-      "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
-    },
-    {
-      "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
-      "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
-    },
-    {
-      "topico": "Pasta única interdicao-embargo/ por OS",
-      "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
-    },
-    {
-      "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
-      "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
-    },
-    {
-      "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
-      "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
-    },
-    {
-      "titulo": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
-      "texto": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro)."
-    }
-  ],
-  "diferencas": [
-    {
-      "topico": "Plataforma",
-      "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
-    },
-    {
-      "topico": "Estado central",
-      "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
-    },
-    {
-      "topico": "Empacotamento",
-      "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
-    },
-    {
-      "topico": "Identidade do AFT",
-      "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
-    }
-  ],
-  "foraDoToolkit": [
-    "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
-    "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
-    "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
-    "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
-    "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
-  ],
-  "avisos": [
-    "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
-    "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
-    "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
-    "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
-    "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
-    "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
-    "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
-    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
-  ]
+   ]
+  }
+ ],
+ "scripts": [
+  {
+   "nome": "rehydrate.py",
+   "caminho": "_scripts/rehydrate.py",
+   "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "bloco3_inject.py",
+   "caminho": "_scripts/bloco3_inject.py",
+   "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "validar_txt.py",
+   "caminho": "_scripts/validar_txt.py",
+   "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_pii.py",
+   "caminho": "_scripts/checar_pii.py",
+   "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_diff.py",
+   "caminho": "_scripts/checar_diff.py",
+   "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_arquivo_aberto.py",
+   "caminho": "_scripts/checar_arquivo_aberto.py",
+   "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "backup_arquivo.py",
+   "caminho": "_scripts/backup_arquivo.py",
+   "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_rt_autos.py",
+   "caminho": "_scripts/checar_rt_autos.py",
+   "papel": "Confere a coerência entre a Seção 4 do RT (.docx) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "gerar_painel.py",
+   "caminho": "_scripts/gerar_painel.py",
+   "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+   "runtime": "Python stdlib (+pdfplumber opcional)"
+  },
+  {
+   "nome": "servir_painel.py",
+   "caminho": "_scripts/servir_painel.py",
+   "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill det-baixar-empregador): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "det_sync.py",
+   "caminho": "_scripts/det_sync.py",
+   "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "det_baixar.py",
+   "caminho": "_scripts/det_baixar.py",
+   "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): a pasta nasce notificacao-<COD>/item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Idempotente por existência do arquivo; nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill pessoal det-baixar-empregador).",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "instalar_rotina_painel.py",
+   "caminho": "_scripts/instalar_rotina_painel.py",
+   "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "instalar_servidor_painel.py",
+   "caminho": "_scripts/instalar_servidor_painel.py",
+   "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
+   "runtime": "Python stdlib (+ PowerShell no Windows)"
+  },
+  {
+   "nome": "aft_doctor.py",
+   "caminho": "_scripts/aft_doctor.py",
+   "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "fotos_para_pdf.py",
+   "caminho": "_scripts/fotos_para_pdf.py",
+   "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
+   "runtime": "Python · pillow"
+  },
+  {
+   "nome": "comprimir_pdf.py",
+   "caminho": "_scripts/comprimir_pdf.py",
+   "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
+   "runtime": "Python · pikepdf/pypdf"
+  },
+  {
+   "nome": "docx_pack.py / docx_unpack.py",
+   "caminho": "_scripts/docx_*.py",
+   "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
+   "runtime": "Python stdlib · zipfile"
+  },
+  {
+   "nome": "scan_autos.py",
+   "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
+   "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
+   "runtime": "Python · pypdf"
+  },
+  {
+   "nome": "gera_relacao_autos.py",
+   "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
+   "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
+   "runtime": "Python (python-docx)"
+  },
+  {
+   "nome": "inspecionar_assinatura.py",
+   "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
+   "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
+   "runtime": "Python"
+  },
+  {
+   "nome": "validar.py",
+   "caminho": "aft-jornada-valida-afd-aej/validar.py",
+   "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "gerar_relatorio_docx.py",
+   "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
+   "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
+   "runtime": "Python stdlib · zipfile"
+  },
+  {
+   "runtime": "Python stdlib",
+   "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
+   "nome": "pasta_aft.py",
+   "caminho": "_scripts/pasta_aft.py"
+  },
+  {
+   "nome": "instalar_agentes.py",
+   "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
+  },
+  {
+   "nome": "erro_ticket.py",
+   "caminho": "_scripts/erro_ticket.py",
+   "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "sync_perfil.py",
+   "caminho": "_scripts/sync_perfil.py",
+   "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "sessoes_os.py",
+   "caminho": "_scripts/sessoes_os.py",
+   "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "instalar_vigia_sessoes.py",
+   "caminho": "_scripts/instalar_vigia_sessoes.py",
+   "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
+   "runtime": "Python stdlib (+ PowerShell no Windows)"
+  },
+  {
+   "nome": "checar_acentos.py",
+   "caminho": "_scripts/checar_acentos.py",
+   "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "checar_arquivos_internos.py",
+   "caminho": "_scripts/checar_arquivos_internos.py",
+   "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
+   "runtime": "Python stdlib"
+  },
+  {
+   "nome": "indenta_quebras.py",
+   "caminho": "_scripts/indenta_quebras.py",
+   "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
+   "runtime": "Python stdlib"
+  }
+ ],
+ "dados": [
+  {
+   "arquivo": "config/notebooks.json",
+   "conteudo": "49 notebooks (IDs do NotebookLM, ex.: nr-12, nr-18, ementario-sst)",
+   "uso": "Consulta de ementa pelas skills (especialmente /aft-consulta)."
+  },
+  {
+   "arquivo": "config/uorgs.csv",
+   "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
+   "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
+  },
+  {
+   "arquivo": "config/CLAUDE-aft.md",
+   "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
+   "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
+  },
+  {
+   "arquivo": "config/blocos_auto.md",
+   "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
+   "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
+  },
+  {
+   "arquivo": "config/settings-aft.json",
+   "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
+   "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
+  },
+  {
+   "arquivo": "config/models-validos.json",
+   "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
+   "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
+  }
+ ],
+ "ementas": [
+  {
+   "camada": "1. NotebookLM (recomendado)",
+   "txt": "CLI notebooklm-py + skill /aft-consulta; IDs em config/notebooks.json; acesso em notebooks-aft.vercel.app. Envia só a descrição da irregularidade."
+  },
+  {
+   "camada": "2. Google Drive compartilhado",
+   "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
+  },
+  {
+   "camada": "3. O AFT informa o código",
+   "txt": "Formato XXXXXX-X, conferido no ementário oficial."
+  }
+ ],
+ "anonimizacao": [
+  "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
+  "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
+  "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
+  "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
+  "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
+  "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT."
+ ],
+ "decisoes": [
+  {
+   "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+   "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+  },
+  {
+   "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
+   "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
+  },
+  {
+   "topico": "Relação de autos é .docx, sem PDF",
+   "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
+  },
+  {
+   "topico": "Nomes das skills",
+   "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
+  },
+  {
+   "topico": "Instalação",
+   "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
+  },
+  {
+   "topico": "Git obrigatório",
+   "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
+  },
+  {
+   "topico": "Sem SISOS/Supabase",
+   "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
+  },
+  {
+   "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
+   "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
+  },
+  {
+   "topico": "Empacotamento único",
+   "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
+  },
+  {
+   "topico": "Latin-1 sem iconv",
+   "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
+  },
+  {
+   "topico": "Lotação pela cidade",
+   "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
+  },
+  {
+   "topico": "Ementas em 3 camadas",
+   "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
+  },
+  {
+   "topico": "Bloco 3 centralizado",
+   "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
+  },
+  {
+   "topico": "Atualização separada do diagnóstico",
+   "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
+  },
+  {
+   "topico": "Política de model por skill",
+   "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
+  },
+  {
+   "topico": "allowed-tools como garantia",
+   "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
+  },
+  {
+   "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
+   "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
+  },
+  {
+   "topico": "Detecção determinística no /aft-painel",
+   "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
+  },
+  {
+   "topico": "Bases distintas",
+   "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
+  },
+  {
+   "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
+   "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
+  },
+  {
+   "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
+   "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
+  },
+  {
+   "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
+   "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
+  },
+  {
+   "topico": "Painel virou dashboard de cards (SISOS local, offline)",
+   "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
+  },
+  {
+   "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
+   "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
+  },
+  {
+   "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
+   "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
+  },
+  {
+   "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
+   "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
+  },
+  {
+   "topico": "Painel ativo (modo interativo local)",
+   "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
+  },
+  {
+   "topico": "Extensão Chrome sincroniza o DET com o painel local",
+   "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
+  },
+  {
+   "topico": "Servidor do painel sempre ligado (padrão na instalação)",
+   "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
+  },
+  {
+   "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
+   "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
+  },
+  {
+   "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
+   "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
+  },
+  {
+   "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
+   "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
+  },
+  {
+   "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
+   "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
+  },
+  {
+   "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
+   "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
+  },
+  {
+   "topico": "Google Calendar: conector do Claude, não OAuth próprio",
+   "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
+  },
+  {
+   "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
+   "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
+  },
+  {
+   "topico": "Pasta única interdicao-embargo/ por OS",
+   "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
+  },
+  {
+   "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
+   "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
+  },
+  {
+   "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
+   "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
+  },
+  {
+   "titulo": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
+   "texto": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro)."
+  }
+ ],
+ "diferencas": [
+  {
+   "topico": "Plataforma",
+   "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
+  },
+  {
+   "topico": "Estado central",
+   "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
+  },
+  {
+   "topico": "Empacotamento",
+   "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
+  },
+  {
+   "topico": "Identidade do AFT",
+   "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
+  }
+ ],
+ "foraDoToolkit": [
+  "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
+  "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
+  "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
+  "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
+  "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
+ ],
+ "avisos": [
+  "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
+  "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
+  "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
+  "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
+  "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
+  "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
+  "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
+  "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+  "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
+ ]
 }

--- a/novidades/2026-08-21-01-det-baixar-arquivos.md
+++ b/novidades/2026-08-21-01-det-baixar-arquivos.md
@@ -1,0 +1,18 @@
+## 21/08/2026
+<!-- commit: det-baixar-arquivos -->
+
+**Botão "baixar arquivos" nas notificações DET do painel.** Cada notificação
+do cartão Notificações DET ganhou o botão **⬇ baixar arquivos**: um clique e o
+painel busca direto na API do DET o PDF da notificação, o Relatório de
+Atendimento e todos os arquivos que o empregador entregou — já organizados na
+pasta da OS, uma subpasta por item solicitado, com a descrição oficial do item
+no nome (o que o AFT rejeitou ou dispensou no DET vai separado, em
+`invalidados/`). Nada de navegador clicando sozinho: são segundos, não minutos.
+Funciona com o mesmo gesto de sempre: o **Sincronizar** da extensão Sync DET
+abastece o painel por 25 minutos; se a janela passar, o botão avisa e basta
+sincronizar de novo. Baixar de novo não duplica nada: o que já está na pasta é
+pulado, e cada download entra no Registro de atividades da ficha. Quem prefere
+pedir pelo chat usa a skill de download do DET, que agora chama esse mesmo
+motor.
+
+---


### PR DESCRIPTION
## O que muda para o AFT

Cada notificação do cartão **Notificações DET** ganha o botão **⬇ baixar arquivos**: um clique baixa da API do DET o PDF da notificação, o Relatório de Atendimento e todos os arquivos entregues pelo empregador — organizados na pasta da OS, uma subpasta por item com a descrição oficial (`item<N>_<descrição>/`; rejeitados/dispensados em `invalidados/`). Segundos, em vez dos ~10 minutos do fluxo antigo por navegador.

Funciona com o gesto de sempre: o **Sincronizar** da extensão Sync DET abastece o painel por 25 minutos. Janela vencida → o botão avisa e basta sincronizar de novo. Idempotente: nada é baixado em duplicidade.

## Como

- **`_scripts/det_baixar.py`** (novo): pesquisa por código + downloads pela API oficial (endpoints conferidos no bundle público do front, chunk 251, em 21/08/2026). Dispensa o ZIP do site (URL volátil, sem estrutura) e o rename por `pdftotext`.
- **`servir_painel.py`**: `/api/det-sync` guarda o token em RAM por 25 min (nunca em disco); novo `POST /api/det-baixar` valida a pasta como o `/api/acao` e devolve 409 com instrução quando o token venceu (cache limpo em 401 do DET).
- **`gerar_painel.py`**: botão no cartão com feedback ("baixando…") e toast do resultado; JS validado com `node --check`.
- Registro de atividades na ficha a cada download (com backup prévio); nomes saneados para Windows.

## Testes

Ponta a ponta contra uma API DET de mentira (dados fictícios): estrutura das pastas, colisão de nome (sufixo -2), invalidados/, idempotência na 2ª rodada, token vencido no meio do lote (409 + cache limpo), pasta inválida (400). Documentação em dia: `novidades/`, nota técnica (`sync-det-e-extensao.md`, seção Atualização 21/08/2026) e arquitetura (.json + .html sincronizados).

⚠️ Após o merge: `publicar.py` (que já reinicia o serviço do painel — `det_baixar.py` é importado pelo `servir_painel.py`, mesma pegadinha do `det_sync.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)