### PR TITLE
Correção: parâmetro obrigatório do Relatório de Atendimento no det_baixar

### DIFF
--- a/_scripts/det_baixar.py
+++ b/_scripts/det_baixar.py
@@ -244,10 +244,14 @@ def baixar_notificacao(pasta_os: Path, token: str, codigo: str) -> dict:
         raise
     except Exception as e:
         r["erros"].append(f"PDF da notificação: {e}")
+    # tipo=0 e exibeHistorico=true são os padrões do modal do site — o tipo é
+    # OBRIGATÓRIO (sem ele a API devolve 400 "Parâmetro de URL tipo inválido",
+    # constatado na primeira execução real em 21/08/2026).
     try:
         conta(_salvar(pasta_os / f"relatorio-atendimento-{codigo}.pdf",
                       _requisicao(token,
                                   f"/notificacoes/{uid}/pdf-relatorio-atendimento",
+                                  params={"tipo": 0, "exibeHistorico": "true"},
                                   timeout=TIMEOUT_BLOB)))
     except TokenExpirado:
         raise


### PR DESCRIPTION
Primeira execução real do botão "⬇ baixar arquivos": 189 arquivos baixados com sucesso, mas o Relatório de Atendimento falhou com 400 "Parâmetro de URL tipo inválido" — a API exige `tipo`, e o bundle não denunciava porque o modal do site sempre envia os padrões. Agora o `det_baixar.py` manda `tipo=0&exibeHistorico=true`, como o site. Teste de mentira atualizado para exigir os parâmetros; nota técnica corrigida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)