### PR TITLE
PDFs da notificação DET dentro da pasta da notificação

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ Documentos\AFT\
 │       ├── autos.md                 (autos redigidos)
 │       ├── autos-lavrados.md        (o que já foi transmitido — fica na raiz)
 │       ├── NOTIFICACOES\            (PDFs do DET + respostas do empregador)
-│       │   ├── notificacao-ABC123.pdf
-│       │   └── notificacao-ABC123\  (itens entregues pela empresa)
+│       │   └── notificacao-ABC123\  (tudo daquela notificação)
+│       │       ├── notificacao-ABC123.pdf
+│       │       ├── relatorio-atendimento-ABC123.pdf
+│       │       └── item1_...\       (itens entregues pela empresa)
 │       ├── AUTOS\
 │       │   ├── Autos 19-05\         (TXT importável + anexos PDF)
 │       │   └── Relacao de autos\    (relação .docx)

--- a/_scripts/det_baixar.py
+++ b/_scripts/det_baixar.py
@@ -9,14 +9,18 @@ servir_painel.py. Nenhum navegador envolvido: são 4 ou 5 requisições HTTP e o
 download termina em segundos — substitui o fluxo antigo de dirigir o Chrome
 clique a clique (10 minutos por notificação).
 
-O que é baixado, e para onde (pasta da OS em OS ATIVAS/):
+O que é baixado, e para onde (pasta da OS em OS ATIVAS/) — tudo dentro da
+pasta da notificação, para não poluir a raiz da OS:
 
-    notificacao-<CODIGO>.pdf              o PDF da notificação
-    relatorio-atendimento-<CODIGO>.pdf    o Relatório de Atendimento
-    notificacao-<CODIGO>/                 os arquivos entregues pelo empregador
+    notificacao-<CODIGO>/
+        notificacao-<CODIGO>.pdf              o PDF da notificação
+        relatorio-atendimento-<CODIGO>.pdf    o Relatório de Atendimento
         item<N>_<descrição do item>/          um por item solicitado
             <arquivo entregue>
             invalidados/<arquivo>             o que o AFT rejeitou/dispensou
+
+PDF que um download antigo deixou na raiz da OS é movido para dentro da pasta
+na próxima execução (migração automática; conta em `movidos`).
 
 Em vez do ZIP geral do site (que exige segundo request numa URL volátil e
 chega sem estrutura), cada arquivo é baixado individualmente pelo endpoint de
@@ -233,33 +237,45 @@ def baixar_notificacao(pasta_os: Path, token: str, codigo: str) -> dict:
     def conta(gravou: bool):
         r["baixados" if gravou else "ja_existiam"] += 1
 
+    # Tudo fica DENTRO de notificacao-<COD>/ — inclusive os 2 PDFs, para não
+    # poluir a raiz da OS (pedido do AFT em 21/08/2026). PDF que um download
+    # antigo deixou na raiz é MOVIDO para dentro (migração, nunca re-baixado).
+    raiz = pasta_os / f"notificacao-{codigo}"
+
+    def _migrar(nome: str) -> None:
+        antigo, novo = pasta_os / nome, raiz / nome
+        if antigo.is_file() and not novo.exists():
+            novo.parent.mkdir(parents=True, exist_ok=True)
+            antigo.rename(novo)
+            r["movidos"] = r.get("movidos", 0) + 1
+
     # Os 2 PDFs. numeroDeLinhas=0 é o que o próprio site passa no download
-    # direto (sem o modal de paginação).
-    try:
-        conta(_salvar(pasta_os / f"notificacao-{codigo}.pdf",
-                      _requisicao(token, f"/notificacoes/{uid}/pdf",
-                                  params={"numeroDeLinhas": 0},
-                                  timeout=TIMEOUT_BLOB)))
-    except TokenExpirado:
-        raise
-    except Exception as e:
-        r["erros"].append(f"PDF da notificação: {e}")
-    # tipo=0 e exibeHistorico=true são os padrões do modal do site — o tipo é
-    # OBRIGATÓRIO (sem ele a API devolve 400 "Parâmetro de URL tipo inválido",
-    # constatado na primeira execução real em 21/08/2026).
-    try:
-        conta(_salvar(pasta_os / f"relatorio-atendimento-{codigo}.pdf",
-                      _requisicao(token,
-                                  f"/notificacoes/{uid}/pdf-relatorio-atendimento",
-                                  params={"tipo": 0, "exibeHistorico": "true"},
-                                  timeout=TIMEOUT_BLOB)))
-    except TokenExpirado:
-        raise
-    except Exception as e:
-        r["erros"].append(f"Relatório de Atendimento: {e}")
+    # direto (sem o modal de paginação); no relatório, tipo=0 e
+    # exibeHistorico=true são os padrões do modal — e o tipo é OBRIGATÓRIO
+    # (sem ele a API devolve 400 "Parâmetro de URL tipo inválido", constatado
+    # na primeira execução real em 21/08/2026).
+    pdfs = [
+        ("PDF da notificação", f"notificacao-{codigo}.pdf",
+         f"/notificacoes/{uid}/pdf", {"numeroDeLinhas": 0}),
+        ("Relatório de Atendimento", f"relatorio-atendimento-{codigo}.pdf",
+         f"/notificacoes/{uid}/pdf-relatorio-atendimento",
+         {"tipo": 0, "exibeHistorico": "true"}),
+    ]
+    for rotulo, nome, caminho, params in pdfs:
+        try:
+            _migrar(nome)
+            destino = raiz / nome
+            if destino.exists() and destino.stat().st_size > 0:
+                r["ja_existiam"] += 1
+                continue
+            conta(_salvar(destino, _requisicao(token, caminho, params=params,
+                                               timeout=TIMEOUT_BLOB)))
+        except TokenExpirado:
+            raise
+        except Exception as e:
+            r["erros"].append(f"{rotulo}: {e}")
 
     # Arquivos entregues, item a item.
-    raiz = pasta_os / f"notificacao-{codigo}"
     itens = _json_api(token, "/itens-notificacao", params={"uidNotificacao": uid})
     r["itens"] = len(itens or [])
     for item in itens or []:

--- a/aft-organiza-os/SKILL.md
+++ b/aft-organiza-os/SKILL.md
@@ -177,10 +177,11 @@ só com as fichas e os relatórios `.md`**:
 ├── inspecao-fisica.md            ← RAIZ OBRIGATÓRIA
 ├── tn-nco-*.md · nad-*.md        ← RAIZ OBRIGATÓRIA (texto que o AFT recola no DET)
 ├── NOTIFICACOES/
-│   ├── notificacao-<CODIGO>.pdf
-│   ├── relatorio-atendimento-<CODIGO>.pdf
 │   ├── tn-nco-*.docx · nad-*.docx  ← versão fechada da notificação emitida
-│   └── notificacao-<CODIGO>/     ← resposta do empregador (item1/, item2/...)
+│   └── notificacao-<CODIGO>/     ← TUDO daquela notificação
+│       ├── notificacao-<CODIGO>.pdf
+│       ├── relatorio-atendimento-<CODIGO>.pdf
+│       └── item1/ item2/ ...     ← resposta do empregador
 ├── AUTOS/
 │   ├── Autos <DD-MM>/            ← TXT + anexos gerados pelo /aft-gera-ai
 │   └── Relacao de autos/         ← relação .docx do /aft-autos-lavrados
@@ -206,10 +207,11 @@ Regras do plano:
 - **Nome da pasta**: `<EMPREGADOR EM CAIXA ALTA> <identificador só dígitos>` (padrão do
   toolkit). Sem identificador encontrado → só o nome, e avise que o CNPJ/CPF será exigido
   no `/aft-gera-ai`.
-- **Notificações** → tudo em `NOTIFICACOES/`: o PDF como
-  `NOTIFICACOES/notificacao-<CODIGO>.pdf`, o relatório de atendimento como
-  `NOTIFICACOES/relatorio-atendimento-<CODIGO>.pdf` e a resposta do empregador na
-  subpasta `NOTIFICACOES/notificacao-<CODIGO>/` (mantendo `item1/`, `item2/`... ou
+- **Notificações** → tudo em `NOTIFICACOES/`, e cada notificação inteira dentro da
+  SUA subpasta (regra de 21/08/2026 — os PDFs moram junto com a resposta, não soltos):
+  o PDF como `NOTIFICACOES/notificacao-<CODIGO>/notificacao-<CODIGO>.pdf`, o relatório
+  de atendimento como `NOTIFICACOES/notificacao-<CODIGO>/relatorio-atendimento-<CODIGO>.pdf`
+  e a resposta do empregador na mesma subpasta (mantendo `item1/`, `item2/`... ou
   `01 - .../`). Sufixo descritivo que o AFT tenha dado à pasta é **preservado**
   (`notificacao-<CODIGO> jornada/`) — o que identifica é o código.
 - **Notificação também é o que o AFT emitiu**, não só o que voltou do DET: os `.docx`

--- a/novidades/2026-08-21-02-pdfs-dentro-da-pasta-da-notificacao.md
+++ b/novidades/2026-08-21-02-pdfs-dentro-da-pasta-da-notificacao.md
@@ -1,0 +1,14 @@
+## 21/08/2026
+<!-- commit: pdfs-dentro-da-pasta-da-notificacao -->
+
+**Os PDFs da notificação agora moram dentro da pasta dela.** O PDF da
+notificação e o Relatório de Atendimento deixam de ficar soltos na raiz da
+pasta da fiscalização: o botão "⬇ baixar arquivos" passa a guardar tudo dentro
+de `notificacao-<CÓDIGO>/`, junto com os itens entregues pelo empregador — a
+raiz da OS fica limpa, e cada notificação vira um pacote completo. PDFs que
+downloads anteriores deixaram na raiz são movidos para dentro automaticamente
+no próximo clique, sem baixar nada de novo. A regra vale também para o
+`/aft-organiza-os` (nas OS organizadas, dentro de `NOTIFICACOES/`) e para a
+análise preliminar, que já sabe procurar no lugar novo.
+
+---


### PR DESCRIPTION
A pedido do AFT: o PDF da notificação e o Relatório de Atendimento deixam de poluir a raiz da OS — moram dentro de `notificacao-<CÓDIGO>/`, junto com os itens entregues. O `det_baixar.py` migra sozinho PDFs que execuções anteriores deixaram na raiz (rename, nunca re-download) e passou a checar existência antes de requisitar os 2 PDFs (antes re-baixava os bytes a cada rodada idempotente). Layout canônico do `/aft-organiza-os` e diagrama do README acompanham; a skill pessoal analise-preliminar já procura no lugar novo (maxdepth 4). Testes de mentira atualizados, incluindo o caso de migração; nota técnica com o adendo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)