### PR TITLE
aft-det-baixar na lista de skills oficiais

### DIFF
--- a/_scripts/skills_oficiais.txt
+++ b/_scripts/skills_oficiais.txt
@@ -18,6 +18,7 @@ aft-cipa-nr05-dimensionamento
 aft-cnae-grau-risco-nr04
 aft-consulta
 aft-det-630
+aft-det-baixar
 aft-diario
 aft-dimensionamento-sesmt-nr04
 aft-doctor


### PR DESCRIPTION
Uma linha: registra a `aft-det-baixar` em `_scripts/skills_oficiais.txt` (ficou de fora do PR #29 e travou o publicar, que achou a cópia principal suja com a regeneração local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)