### PR TITLE
Arquitetura do subsistema DET baixar (JSON + página)

### DIFF
--- a/arquitetura/DET baixar/arquitetura-det-baixar.html
+++ b/arquitetura/DET baixar/arquitetura-det-baixar.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Arquitetura — DET baixar (AFT Toolkit)</title>
+<style>
+  :root {
+    --bg: #f8fafc;         --card: #ffffff;      --ink: #1e293b;
+    --muted: #64748b;      --line: #e2e8f0;      --teal: #14b8a6;
+    --teal-dark: #0f766e;  --amber: #f59e0b;     --violet: #6366f1;
+    --rose: #ef4444;       --code-bg: #f1f5f9;   --chip: #ccfbf1;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;       --card: #1e293b;      --ink: #e2e8f0;
+      --muted: #94a3b8;    --line: #334155;      --code-bg: #0b1220;
+      --chip: #134e4a;
+    }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.65; padding: 2rem 1rem 4rem;
+  }
+  main { max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 1.7rem; margin-bottom: .3rem; }
+  h2 {
+    font-size: 1.25rem; margin: 2.6rem 0 .9rem; padding-bottom: .4rem;
+    border-bottom: 2px solid var(--teal); color: var(--teal-dark);
+  }
+  @media (prefers-color-scheme: dark) { h2 { color: var(--teal); } }
+  h3 { font-size: 1.02rem; margin: 1.4rem 0 .5rem; }
+  p  { margin-bottom: .9rem; }
+  .sub { color: var(--muted); margin-bottom: 1.6rem; }
+  .card {
+    background: var(--card); border: 1px solid var(--line);
+    border-radius: 14px; padding: 1.2rem 1.4rem; margin-bottom: 1rem;
+  }
+  code, .mono {
+    font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: .86em;
+    background: var(--code-bg); padding: .12em .4em; border-radius: 5px;
+  }
+  pre {
+    background: var(--code-bg); border: 1px solid var(--line);
+    border-radius: 10px; padding: .9rem 1.1rem; overflow-x: auto;
+    font-size: .82rem; line-height: 1.5; margin: .8rem 0 1.1rem;
+  }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0 1.2rem; font-size: .9rem; }
+  th, td { border: 1px solid var(--line); padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: var(--code-bg); }
+  ol.steps { counter-reset: passo; list-style: none; margin: .5rem 0 1rem; }
+  ol.steps li {
+    position: relative; padding: .55rem 0 .55rem 3rem;
+    border-left: 2px solid var(--line); margin-left: 1rem;
+  }
+  ol.steps li::before {
+    counter-increment: passo; content: counter(passo);
+    position: absolute; left: -1rem; top: .55rem;
+    width: 2rem; height: 2rem; border-radius: 50%;
+    background: var(--teal); color: #fff; font-weight: 700;
+    display: flex; align-items: center; justify-content: center; font-size: .9rem;
+  }
+  .diagram-wrap { overflow-x: auto; margin: 1rem 0 1.4rem; }
+  .diagram-wrap svg { min-width: 720px; width: 100%; height: auto; }
+  .note {
+    border-left: 4px solid var(--amber); background: var(--code-bg);
+    padding: .7rem 1rem; border-radius: 0 10px 10px 0; margin: .9rem 0;
+    font-size: .92rem;
+  }
+  .ok { border-left-color: var(--teal); }
+  ul { margin: 0 0 .9rem 1.3rem; }
+  li { margin-bottom: .35rem; }
+  a { color: var(--teal-dark); }
+  @media (prefers-color-scheme: dark) { a { color: #5eead4; } }
+  footer { color: var(--muted); font-size: .8rem; margin-top: 3rem; border-top: 1px solid var(--line); padding-top: 1rem; }
+</style>
+</head>
+<body>
+<main>
+
+<h1>⬇️ DET baixar — arquitetura completa</h1>
+<p class="sub">
+  Como o AFT Toolkit baixa as notificações do DET pela <strong>API oficial</strong>,
+  em segundos e sem navegador — o botão "⬇ baixar arquivos" do painel e a skill
+  <code>/aft-det-baixar</code>. Nasceu em 21/08/2026, substituindo um fluxo por
+  navegador automatizado que levava ~10 minutos por notificação.
+</p>
+
+<div class="card">
+  <strong>A ideia em uma frase:</strong> com o crachá que a extensão
+  <a href="../Extensao%20Chrome/arquitetura-sync-det.html">Sync DET</a> já empresta
+  ao painel (o token de sessão do próprio site), o motor <code>det_baixar.py</code>
+  busca na API oficial o PDF da notificação, o Relatório de Atendimento e os
+  arquivos entregues pelo empregador — organizados por item no pacote
+  <code>NOTIFICACOES/&lt;CODIGO&gt; &lt;dd-mm-aaaa&gt;/</code> da OS — e ainda
+  registra a visualização no DET, apagando o alerta amarelo da tela. O token nunca
+  passa pela conversa do assistente.
+</div>
+
+<h2>1. Mapa geral</h2>
+<div class="diagram-wrap">
+<svg viewBox="0 0 900 470" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system,Segoe UI,sans-serif">
+  <defs>
+    <marker id="seta" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#64748b"/>
+    </marker>
+    <marker id="setaT" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#14b8a6"/>
+    </marker>
+  </defs>
+
+  <!-- Chrome / extensão -->
+  <rect x="20" y="20" width="250" height="86" rx="12" fill="none" stroke="#6366f1" stroke-width="2"/>
+  <text x="145" y="46" text-anchor="middle" font-size="14" font-weight="700" fill="#6366f1">Chrome do AFT</text>
+  <text x="145" y="66" text-anchor="middle" font-size="12" fill="#64748b">site do DET (logado)</text>
+  <text x="145" y="84" text-anchor="middle" font-size="12" fill="#64748b">extensão Sync DET captura o token</text>
+
+  <!-- Servidor painel -->
+  <rect x="330" y="20" width="270" height="86" rx="12" fill="none" stroke="#14b8a6" stroke-width="2.5"/>
+  <text x="465" y="46" text-anchor="middle" font-size="14" font-weight="700" fill="#0f766e">Servidor do painel</text>
+  <text x="465" y="66" text-anchor="middle" font-size="12" fill="#64748b">127.0.0.1:8347 · servir_painel.py</text>
+  <text x="465" y="84" text-anchor="middle" font-size="12" fill="#64748b">token na RAM por 25 min</text>
+  <line x1="270" y1="63" x2="322" y2="63" stroke="#14b8a6" stroke-width="2" marker-end="url(#setaT)"/>
+  <text x="296" y="54" text-anchor="middle" font-size="11" fill="#0f766e">Sincronizar</text>
+
+  <!-- Gatilhos -->
+  <rect x="20" y="160" width="250" height="60" rx="12" fill="none" stroke="#64748b" stroke-width="1.5"/>
+  <text x="145" y="185" text-anchor="middle" font-size="13" font-weight="700">botão "⬇ baixar arquivos"</text>
+  <text x="145" y="204" text-anchor="middle" font-size="12" fill="#64748b">cartão Notificações DET do painel</text>
+  <rect x="20" y="240" width="250" height="60" rx="12" fill="none" stroke="#64748b" stroke-width="1.5"/>
+  <text x="145" y="265" text-anchor="middle" font-size="13" font-weight="700">skill /aft-det-baixar</text>
+  <text x="145" y="284" text-anchor="middle" font-size="12" fill="#64748b">det_baixar.py --via-painel</text>
+  <line x1="270" y1="190" x2="330" y2="150" stroke="#64748b" stroke-width="1.5" marker-end="url(#seta)"/>
+  <line x1="270" y1="268" x2="330" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#seta)"/>
+  <text x="300" y="230" text-anchor="middle" font-size="11" fill="#64748b">POST /api/det-baixar</text>
+
+  <!-- Motor -->
+  <rect x="330" y="150" width="270" height="70" rx="12" fill="none" stroke="#14b8a6" stroke-width="2.5"/>
+  <text x="465" y="178" text-anchor="middle" font-size="14" font-weight="700" fill="#0f766e">det_baixar.py</text>
+  <text x="465" y="198" text-anchor="middle" font-size="12" fill="#64748b">pesquisa · PDFs · itens · blobs · visto</text>
+  <line x1="465" y1="106" x2="465" y2="142" stroke="#14b8a6" stroke-width="2" marker-end="url(#setaT)"/>
+
+  <!-- API DET -->
+  <rect x="660" y="20" width="220" height="200" rx="12" fill="none" stroke="#f59e0b" stroke-width="2"/>
+  <text x="770" y="46" text-anchor="middle" font-size="14" font-weight="700" fill="#f59e0b">API oficial do DET</text>
+  <text x="770" y="70" text-anchor="middle" font-size="11" fill="#64748b">/notificacoes/pesquisa</text>
+  <text x="770" y="88" text-anchor="middle" font-size="11" fill="#64748b">/notificacoes/{uid}/pdf</text>
+  <text x="770" y="106" text-anchor="middle" font-size="11" fill="#64748b">/pdf-relatorio-atendimento</text>
+  <text x="770" y="124" text-anchor="middle" font-size="11" fill="#64748b">/itens-notificacao</text>
+  <text x="770" y="142" text-anchor="middle" font-size="11" fill="#64748b">/arquivos-item + /blob</text>
+  <text x="770" y="166" text-anchor="middle" font-size="11" fill="#0f766e">GET {uid} + GET item =</text>
+  <text x="770" y="182" text-anchor="middle" font-size="11" fill="#0f766e">visualização registrada</text>
+  <text x="770" y="200" text-anchor="middle" font-size="11" fill="#0f766e">(alerta amarelo apaga)</text>
+  <line x1="600" y1="185" x2="652" y2="150" stroke="#f59e0b" stroke-width="2" marker-end="url(#seta)"/>
+  <text x="628" y="152" text-anchor="middle" font-size="11" fill="#f59e0b">Bearer</text>
+
+  <!-- Pacote -->
+  <rect x="330" y="290" width="550" height="150" rx="12" fill="none" stroke="#14b8a6" stroke-width="2" stroke-dasharray="6 3"/>
+  <text x="605" y="318" text-anchor="middle" font-size="13" font-weight="700" fill="#0f766e">Pasta da OS · NOTIFICACOES/&lt;CODIGO&gt; &lt;dd-mm-aaaa&gt;/</text>
+  <text x="605" y="342" text-anchor="middle" font-size="12" fill="#64748b">notificacao-&lt;COD&gt;.pdf · relatorio-atendimento-&lt;COD&gt;.pdf</text>
+  <text x="605" y="362" text-anchor="middle" font-size="12" fill="#64748b">item1_&lt;descrição oficial&gt;/ … itemN_…/ (invalidados/ à parte)</text>
+  <text x="605" y="386" text-anchor="middle" font-size="12" fill="#64748b">idempotente · migra legados · registra na ficha (memory.md)</text>
+  <text x="605" y="410" text-anchor="middle" font-size="12" fill="#64748b">segundos por notificação, sem navegador</text>
+  <line x1="465" y1="220" x2="465" y2="282" stroke="#14b8a6" stroke-width="2" marker-end="url(#setaT)"/>
+</svg>
+</div>
+
+<h2>2. O fluxo, passo a passo</h2>
+<ol class="steps">
+  <li>O AFT navega no DET logado; a extensão captura o token de sessão e o guarda no <code>chrome.storage.local</code> (validade ~30 min).</li>
+  <li>O AFT clica em <strong>Sincronizar</strong>: o token chega ao servidor do painel (<code>POST /api/det-sync</code>), roda o sync das fichas e fica guardado <strong>em RAM por 25 min</strong> — nunca em disco.</li>
+  <li>O download é disparado pelo botão <strong>"⬇ baixar arquivos"</strong> do cartão ou pela skill <code>/aft-det-baixar</code>. Os dois caem no mesmo <code>POST /api/det-baixar {pasta, codigo}</code>.</li>
+  <li>O servidor valida a pasta (filha direta de OS ATIVAS, sem path traversal). Sem token fresco: <code>409 {token_expirado}</code> com a instrução de sincronizar.</li>
+  <li>O motor pesquisa a notificação pelo código (chave única), obtém o <code>uid</code> e resolve o pacote de destino (<code>pasta_do_pacote</code>).</li>
+  <li>Baixa os 2 PDFs e, item a item, cada arquivo entregue. Idempotente: o que existe é pulado; rejeitado/dispensado vai para <code>invalidados/</code>.</li>
+  <li>Registra a <strong>visualização</strong> no DET (GET do detalhe + GET de cada item — as mesmas chamadas do site ao abrir a tela): o triângulo amarelo se apaga.</li>
+  <li>Grava a linha no Registro de atividades do <code>memory.md</code> (com backup) e o painel recarrega sozinho.</li>
+  <li>Devolve o resultado: <code>pacote, baixados, ja_existiam, movidos, itens, sem_arquivo, invalidados, visto_no_det, erros</code>.</li>
+</ol>
+
+<h2>3. Endpoints da API do DET</h2>
+<p>Levantados no <strong>bundle público do front</strong> do DET (chunk 251) em
+21/08/2026 — o front é a fonte primária quando um campo é ambíguo: baixar o
+<code>index.html</code>, achar o <code>runtime.&lt;hash&gt;.js</code>, montar a URL
+do chunk e procurar o serviço. Autenticação: <code>Authorization: Bearer</code>
+com o token de sessão do próprio AFT.</p>
+<table>
+  <tr><th>Chamada</th><th>Para quê</th><th>Detalhe que custou caro</th></tr>
+  <tr><td><code>POST /notificacoes/pesquisa</code></td><td>localizar pelo código → <code>uid</code></td><td><code>isSomenteMinhas=false</code> cobre notificações da equipe</td></tr>
+  <tr><td><code>GET /notificacoes/{uid}/pdf?numeroDeLinhas=0</code></td><td>PDF da notificação</td><td><code>numeroDeLinhas=0</code> é o download direto do site</td></tr>
+  <tr><td><code>GET .../pdf-relatorio-atendimento?tipo=0&amp;exibeHistorico=true</code></td><td>Relatório de Atendimento</td><td><strong><code>tipo</code> é obrigatório</strong> — sem ele, 400; o bundle não denunciava porque o modal sempre manda os padrões</td></tr>
+  <tr><td><code>GET /itens-notificacao?uidNotificacao=</code></td><td>itens (uid, ordem, descrição)</td><td>a descrição oficial vira o nome da pasta do item</td></tr>
+  <tr><td><code>GET /arquivos-item?uidItem=</code> + <code>/{uid}/blob</code></td><td>cada arquivo entregue</td><td>status: 0 INICIAL · 1 RECEBIDO · 2 REJEITADO · 3 DISPENSADO</td></tr>
+  <tr><td><code>GET /notificacoes/{uid}</code> e <code>GET /itens-notificacao/{uidItem}</code></td><td>registro de visualização</td><td>é o que apaga o alerta amarelo — pesquisa, lista de arquivos e blob comprovadamente NÃO apagam</td></tr>
+</table>
+<div class="note">
+  <strong>Dispensados de propósito:</strong> o ZIP do site
+  (<code>PUT /download-documentos</code> — URL volátil, conteúdo sem estrutura) e o
+  <code>GET /eventos-item</code> (anexos de prorrogação/justificativa — reservado
+  para a etapa de entregas parceladas).
+</div>
+
+<h2>4. O pacote na pasta da OS</h2>
+<pre><code>NOTIFICACOES/&lt;CODIGO&gt; &lt;dd-mm-aaaa&gt;/     ← data do PRIMEIRO download
+├── notificacao-&lt;CODIGO&gt;.pdf
+├── relatorio-atendimento-&lt;CODIGO&gt;.pdf
+└── item&lt;N&gt;_&lt;descrição oficial&gt;/
+    ├── &lt;arquivos entregues&gt;
+    └── invalidados/                       ← rejeitados/dispensados no DET</code></pre>
+<ul>
+  <li>Downloads repetidos (entrega parcelada, prorrogação aceita) <strong>acumulam no mesmo pacote</strong>, sem duplicar.</li>
+  <li>Legados migram sozinhos: <code>notificacao-&lt;COD&gt;</code> (raiz ou NOTIFICACOES/) é renomeado ao padrão; PDF solto é movido para dentro.</li>
+  <li>Apelido do AFT (<code>&lt;COD&gt; jornada</code>) é respeitado; pacotes nunca são mesclados automaticamente.</li>
+  <li>Nomes saneados para valerem também no Windows; colisão ganha sufixo <code>-2</code>, <code>-3</code>…</li>
+</ul>
+
+<h2>5. Segurança</h2>
+<ul>
+  <li>O token vive <strong>só na RAM</strong> do servidor do painel, por 25 min — nunca em disco, nunca no chat, nunca na skill.</li>
+  <li>O servidor só escuta <code>127.0.0.1</code> e valida a pasta contra path traversal.</li>
+  <li>401/403 do DET limpa o cache e devolve 409 com a instrução ("clique em Sincronizar").</li>
+  <li>Falha no registro de visualização nunca derruba o download (<code>visto_no_det: false</code>).</li>
+</ul>
+
+<h2>6. Pendências conhecidas</h2>
+<ul>
+  <li>Anexos de <strong>prorrogação/justificativa</strong> (<code>/eventos-item</code>) — etapa futura de entregas parceladas.</li>
+  <li>O Relatório de Atendimento não é re-baixado quando já existe — fica obsoleto se houver entrega nova (mesma etapa).</li>
+  <li>Reinício do serviço do painel zera o token: primeiro download depois de publicar pede novo Sincronizar (não é defeito).</li>
+  <li><code>det_baixar.py</code> é importado pelo servidor: mexeu, <strong>reinicie o serviço</strong> (o <code>publicar.py</code> já reinicia).</li>
+</ul>
+
+<footer>
+  AFT Toolkit · arquitetura do subsistema DET baixar · escrita em 21/08/2026, no dia
+  em que o fluxo nasceu e foi validado em produção. Fonte estruturada:
+  <code>arquitetura-det-baixar.json</code> nesta mesma pasta. Mecânica do token e da
+  extensão: <a href="../Extensao%20Chrome/arquitetura-sync-det.html">arquitetura Sync DET</a>.
+  História das decisões: nota <code>sync-det-e-extensao.md</code> no cofre.
+</footer>
+
+</main>
+</body>
+</html>

--- a/arquitetura/DET baixar/arquitetura-det-baixar.json
+++ b/arquitetura/DET baixar/arquitetura-det-baixar.json
@@ -1,0 +1,99 @@
+{
+ "projeto": "DET baixar — download de notificações do DET pela API oficial (AFT Toolkit)",
+ "data": "2026-08-21",
+ "resumo": "Substitui o download manual (ou por navegador automatizado) das notificações do DET: com o token de sessão que a extensão Sync DET empresta ao servidor do painel, o motor det_baixar.py busca na API oficial do DET o PDF da notificação, o Relatório de Atendimento e os arquivos entregues pelo empregador, item a item, e grava tudo no pacote NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/ da pasta da OS — em segundos, sem navegador e sem o token jamais passar pela conversa do assistente. Ao final, registra a visualização no DET (o triângulo amarelo 'Existe atualização pendente' se apaga como se o AFT tivesse aberto a notificação no site). Nasceu em 21/08/2026, substituindo um fluxo por Claude in Chrome que levava ~10 minutos por notificação.",
+ "onde_mora": {
+  "motor": "_scripts/det_baixar.py (baixar_notificacao, pasta_do_pacote, via_painel)",
+  "servidor_local": "_scripts/servir_painel.py — POST /api/det-baixar em 127.0.0.1:8347 + cache do token em RAM (25 min)",
+  "botao_no_painel": "_scripts/gerar_painel.py — botão '⬇ baixar arquivos' em cada notificação do cartão Notificações DET (função agDetBaixar)",
+  "skill_de_chat": "aft-det-baixar/SKILL.md — invólucro fino: resolve pedido (código/CNPJ/nome) e chama det_baixar.py --via-painel",
+  "token": "extensão Chrome 'Sync DET' (repo SisOS) — a mesma captura documentada em arquitetura/Extensao Chrome/",
+  "nota_tecnica": "cofre aft-toolkit-history: sync-det-e-extensao.md (motor e decisões) + aft-det-baixar.md (a skill)"
+ },
+ "fluxo": [
+  "1. O AFT navega no DET logado; a extensão captura o token de sessão (webRequest) e o guarda no chrome.storage.local (validade ~30 min).",
+  "2. O AFT clica no botão flutuante 'Sincronizar' (extensão): o token chega ao servidor do painel via POST /api/det-sync, roda o sync das fichas e fica guardado em RAM por 25 min (_DET_TOKEN; nunca em disco).",
+  "3. O AFT dispara o download: botão '⬇ baixar arquivos' no cartão do painel OU skill /aft-det-baixar no chat (que roda det_baixar.py --via-painel). Os dois caem no mesmo POST /api/det-baixar {pasta, codigo}.",
+  "4. O servidor valida a pasta (filha direta de OS ATIVAS, sem path traversal) e chama det_baixar.baixar_notificacao com o token da RAM. Sem token fresco: 409 {token_expirado: true} com a instrução de sincronizar.",
+  "5. O motor pesquisa a notificação pelo código (chave única, isSomenteMinhas=false), obtém o uid e resolve o pacote de destino (pasta_do_pacote).",
+  "6. Baixa os 2 PDFs e, item a item, a lista de arquivos e cada blob. Idempotente: arquivo existente (tamanho > 0) é pulado; status 2/3 vai para invalidados/.",
+  "7. Registra a visualização no DET: GET do detalhe da notificação + GET de cada item (as mesmas chamadas do site ao abrir a tela) — apaga o triângulo 'Existe atualização pendente'.",
+  "8. Grava linha no Registro de atividades do memory.md (com backup prévio) quando algo foi baixado; o painel recarrega sozinho pelo /api/estado (mtime das fichas).",
+  "9. Devolve o JSON de resultado: pacote, baixados, ja_existiam, movidos, itens, sem_arquivo, invalidados, visto_no_det, erros."
+ ],
+ "api_det": {
+  "base": "https://auditor-det.sit.trabalho.gov.br/services/auditor/v1",
+  "autenticacao": "Authorization: Bearer <token de sessão do AFT> (o mesmo do site; capturado pela extensão)",
+  "fonte_dos_endpoints": "Bundle público do front Angular do DET — chunk 251 (~550 KB), lido em 21/08/2026. O front é a fonte primária: baixar o index.html, achar o runtime.<hash>.js, montar a URL do chunk e procurar o serviço. O hash muda a cada deploy do DET.",
+  "endpoints_usados": [
+   {"metodo": "POST", "caminho": "/notificacoes/pesquisa", "para": "localizar a notificação pelo código (campo codigoNotificacao; isSomenteMinhas=false para cobrir equipe) — devolve o uid", "obs": "mesmo corpo de pesquisa do det_sync.py"},
+   {"metodo": "GET", "caminho": "/notificacoes/{uid}/pdf?numeroDeLinhas=0", "para": "o PDF da notificação", "obs": "numeroDeLinhas=0 é o que o site passa no download direto"},
+   {"metodo": "GET", "caminho": "/notificacoes/{uid}/pdf-relatorio-atendimento?tipo=0&exibeHistorico=true", "para": "o Relatório de Atendimento", "obs": "tipo é OBRIGATÓRIO: sem ele a API devolve 400 'Parâmetro de URL tipo inválido' (pego na 1ª execução real; o bundle não denunciava porque o modal do site sempre manda os padrões)"},
+   {"metodo": "GET", "caminho": "/itens-notificacao?uidNotificacao={uid}", "para": "itens solicitados: uid, ordem, descricao (a descrição oficial vira o nome da pasta do item)", "obs": null},
+   {"metodo": "GET", "caminho": "/arquivos-item?uidItem={uid}", "para": "arquivos entregues no item: uid, nome, status", "obs": "status: 0 INICIAL · 1 RECEBIDO · 2 REJEITADO · 3 DISPENSADO (enum do front)"},
+   {"metodo": "GET", "caminho": "/arquivos-item/{uid}/blob", "para": "o arquivo em si (até 20 MB por arquivo, limite do próprio DET)", "obs": null},
+   {"metodo": "GET", "caminho": "/notificacoes/{uid}", "para": "registro de visualização: é o 'abrir a notificação' do site", "obs": "apaga o triângulo amarelo — confirmado em produção 21/08/2026"},
+   {"metodo": "GET", "caminho": "/itens-notificacao/{uidItem}?uidNotificacao={uid}", "para": "registro de visualização por item: o 'Visualizar Item Solicitado' do site", "obs": null}
+  ],
+  "endpoints_conhecidos_e_nao_usados": [
+   {"caminho": "PUT /notificacoes/{uid}/download-documentos", "porque_nao": "é o ZIP do site: devolve uma URL volátil para segundo request e o conteúdo chega sem estrutura — o download arquivo a arquivo dispensa ZIP, unzip e adivinhação de nomes"},
+   {"caminho": "GET /eventos-item?uidItem=", "porque_nao": "eventos do item (pedidos de prorrogação, justificativas e seus anexos) — reservado para a etapa de entregas parceladas/prorrogação"}
+  ],
+  "o_que_apaga_o_alerta_amarelo": "Não existe endpoint 'marcar como visto'. O que apaga o itemAtualizado são os GETs de abrir a notificação e cada item (por isso o passo 7 do fluxo). Comprovadamente NÃO apagam: a pesquisa, pesquisarArquivos e o GET do blob."
+ },
+ "layout_do_pacote": {
+  "convencao": "NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/ — dentro da pasta NOTIFICACOES da OS, sem o prefixo 'notificacao-' no nome, com a data do PRIMEIRO download",
+  "arvore": [
+   "NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/",
+   "  notificacao-<CODIGO>.pdf",
+   "  relatorio-atendimento-<CODIGO>.pdf",
+   "  item<N>_<descrição oficial do item, 40 chars>/",
+   "    <arquivos entregues>",
+   "    invalidados/<arquivos com status 2/3>"
+  ],
+  "regras": [
+   "Downloads repetidos (entrega parcelada, prorrogação aceita) acumulam no MESMO pacote; nada é duplicado.",
+   "pasta_do_pacote() resolve por 'nome contém o código', em NOTIFICACOES/ e na raiz da OS.",
+   "Pacote legado com nome puro (notificacao-<COD>, com ou sem data) é renomeado ao padrão — data do nome preservada; sem data, vale o mtime da pasta.",
+   "Sufixo descritivo do AFT ('<COD> jornada') é respeitado: a pasta é usada como está, nunca renomeada.",
+   "Pacotes nunca são mesclados automaticamente.",
+   "PDF solto (na raiz da OS ou em NOTIFICACOES/) é movido para dentro do pacote — migração, nunca re-download.",
+   "Nomes saneados para valerem também no Windows (remove <>:\"/\\|?*, apara ponto final; acentos ficam); colisão ganha sufixo -2, -3."
+  ]
+ },
+ "seguranca": [
+  "O token vive só na RAM do processo do servidor do painel, por 25 min — nunca em disco, nunca no chat, nunca na skill.",
+  "O servidor só escuta 127.0.0.1 e valida a pasta contra path traversal (mesma validação do /api/acao).",
+  "401/403 do DET vira TokenExpirado: o cache é limpo e o chamador recebe 409 com a instrução de sincronizar.",
+  "Falha no registro de visualização nunca derruba o download (visto_no_det: false + erro no relatório)."
+ ],
+ "consumidores_do_layout": [
+  {"quem": "botão '⬇ baixar arquivos' (gerar_painel.py)", "como": "chama POST /api/det-baixar e mostra o resultado em toast"},
+  {"quem": "skill /aft-det-baixar", "como": "det_baixar.py --via-painel '<pasta>' <CODIGO> — resolve código/CNPJ/nome pelo memory.md antes"},
+  {"quem": "varredor de notificações não cadastradas (gerar_painel.varrer_notificacoes_novas)", "como": "varre também o 2º nível sob NOTIFICACOES/ (os PDFs desceram um nível)"},
+  {"quem": "/aft-organiza-os", "como": "layout canônico das OS importadas usa o mesmo pacote NOTIFICACOES/<CODIGO> <data>/"},
+  {"quem": "skills pessoais de análise (ex.: analise-preliminar do AFT)", "como": "localizam o PDF por find -maxdepth 4 e tratam o diretório do PDF como o pacote"}
+ ],
+ "decisoes": [
+  {"decisao": "API direta em vez de navegador automatizado", "porque": "o fluxo por Claude in Chrome levava ~10 min por notificação (modelo no loop de cada clique); por API são 4-8 requests e segundos, com custo de tokens quase zero"},
+  {"decisao": "arquivo a arquivo em vez do ZIP do site", "porque": "o ZIP exige segundo request em URL volátil e chega sem estrutura; por arquivo, a pasta nasce organizada por item com a descrição oficial da API"},
+  {"decisao": "token emprestado via Sincronizar + cache RAM 25 min", "porque": "reusa o gesto que o AFT já faz; o token nunca é digitado, gravado ou exposto — e o download funciona na janela em que o token vive (~30 min)"},
+  {"decisao": "registrar a visualização ao final do download", "porque": "sem isso o DET mantinha o alerta 'Existe atualização pendente' aceso mesmo com tudo baixado; os GETs replicam fielmente o abrir do site (caso real MASTER, confirmado pelo AFT)"},
+  {"decisao": "data do primeiro download no nome do pacote", "porque": "pedido do AFT (inspirado no nome do ZIP do site, só a data, sem hora); downloads seguintes acumulam sem renomear"}
+ ],
+ "limites_e_pendencias": [
+  "Anexos de pedidos de prorrogação e justificativas moram em /eventos-item — ainda não baixados (etapa de entregas parceladas/prorrogação, a desenhar).",
+  "O Relatório de Atendimento não é re-baixado quando já existe — fica obsoleto se a empresa entregar de novo depois (mesma etapa futura).",
+  "Porta 8347 fixa no modo --via-painel (igual às demais referências do painel).",
+  "Reinício do serviço do painel zera o token (RAM): o primeiro download depois de publicar toolkit pede um novo Sincronizar — não é defeito.",
+  "det_baixar.py é importado pelo servir_painel.py: mexeu no arquivo, reinicie o serviço (o publicar.py já reinicia).",
+  "O hash dos bundles do DET muda a cada deploy; endpoints REST tendem a ser estáveis, mas mudança de contrato aparece como erro legível no resultado."
+ ],
+ "historico": [
+  {"quando": "2026-08-21", "o_que": "Nasce o motor det_baixar.py + POST /api/det-baixar + botão no painel (endpoints levantados no chunk 251). Primeira execução real: 189 arquivos em segundos."},
+  {"quando": "2026-08-21", "o_que": "Correção: tipo=0&exibeHistorico=true obrigatórios no Relatório de Atendimento (400 sem eles)."},
+  {"quando": "2026-08-21", "o_que": "Skill oficial /aft-det-baixar (ex-skill pessoal do AFT); modo --via-painel para chamada por argumentos."},
+  {"quando": "2026-08-21", "o_que": "Layout: pacote NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/ com migração automática de legados."},
+  {"quando": "2026-08-21", "o_que": "Registro de visualização no DET ao final do download — o alerta amarelo apaga (confirmado em produção)."}
+ ]
+}

--- a/novidades/2026-08-21-06-arquitetura-det-baixar.md
+++ b/novidades/2026-08-21-06-arquitetura-det-baixar.md
@@ -1,0 +1,12 @@
+## 21/08/2026
+<!-- commit: arquitetura-det-baixar -->
+
+**Arquitetura do "DET baixar" documentada.** O subsistema de download das
+notificações ganhou a própria pasta em `arquitetura/DET baixar/`, no mesmo
+formato da extensão Sync DET: um `.json` com o mapa completo (fluxo do token,
+todos os endpoints da API do DET com as pegadinhas que custaram caro, o layout
+do pacote, decisões e pendências) e uma página `.html` legível, com diagrama —
+abra no navegador para entender o caminho inteiro, do Sincronizar até a pasta
+da OS.
+
+---


### PR DESCRIPTION
A pedido do AFT: o que construímos hoje merece mais que uma nota. Nova pasta `arquitetura/DET baixar/` no formato consagrado pela `Extensao Chrome/`: `arquitetura-det-baixar.json` como fonte estruturada (fluxo do token, os 8 endpoints usados + 2 dispensados com o porquê, o que apaga o alerta amarelo e o que comprovadamente não apaga, layout do pacote com regras de migração, decisões, segurança, pendências e a linha do tempo de 21/08/2026) e `arquitetura-det-baixar.html` como página legível com diagrama SVG. Sem dado real de empresa ou trabalhador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)