### PR TITLE
docs(det-baixar): diz que o Relatorio de Atendimento e relatorio de excecao

### DIFF
--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -139,6 +139,23 @@ a nova versão da extensão precisa ser publicada na Chrome Web Store.
 
 ---
 
+## 21/08/2026
+<!-- commit: relatorio-atendimento-excecao -->
+
+**O Relatório de Atendimento baixado do DET lista o que NÃO foi entregue — e isso agora
+está dito onde você vai ler.** Quando o `/aft-det-baixar` traz uma notificação, ele grava
+o `relatorio-atendimento-<CODIGO>.pdf`, que é o documento oficial do Ministério do Trabalho
+e Emprego sobre o atendimento daquela notificação. O detalhe que faltava estar escrito: ele
+é um relatório de **exceção**. Lista os itens **não entregues**, e não os entregues. Isso
+significa que, numa empresa que atendeu tudo, o PDF sai dizendo "não consta item para o
+critério selecionado", com zero itens e zero arquivos — o que parece um download vazio ou
+com defeito, mas é o contrário: é a **certidão oficial de que não há omissão**, prova
+documental direta para o art. 630, § 4º, da CLT. Quem abrir o arquivo esperando o
+inventário do que a empresa mandou vai entender exatamente ao contrário do que ele diz. O
+inventário do que veio continua nas pastas `item<N>/` e no `historico-itens.md`. Nada mudou
+no comportamento do download: só passou a estar documentado, no script e na skill, o que o
+arquivo é e o que ele não é.
+
 ## 20/08/2026
 <!-- commit: painel-auditoria-de-documentos -->
 

--- a/_scripts/det_baixar.py
+++ b/_scripts/det_baixar.py
@@ -382,6 +382,17 @@ def baixar_notificacao(pasta_os: Path, token: str, codigo: str) -> dict:
     # regravado (o DET carimba data de emissão no PDF, então comparar bytes
     # não diz nada). tipo=0/exibeHistorico=true são os padrões do modal do
     # site; o tipo é OBRIGATÓRIO (400 sem ele, constatado em 21/08/2026).
+    #
+    # ATENÇÃO ao que o PDF contém com tipo=0: ele é um relatório de EXCEÇÃO.
+    # O próprio texto do documento diz que exibe "os itens da notificação NÃO
+    # ENTREGUES" — não os entregues. Quando a empresa atendeu tudo, o PDF sai
+    # dizendo "não consta item para o critério selecionado", com contagem de
+    # 0 itens e 0 arquivos (constatado em fiscalização real, 21/08/2026).
+    # Isso NÃO é falha do download: é a certidão oficial de que não há
+    # omissão — prova documental direta para o art. 630, §4º, da CLT. Quem
+    # ler o arquivo esperando o inventário do que foi entregue vai concluir
+    # o contrário do que ele diz. O inventário do que veio está nas pastas
+    # item<N>/ e no historico-itens.md.
     try:
         _migrar(f"relatorio-atendimento-{codigo}.pdf")
         destino = raiz / f"relatorio-atendimento-{codigo}.pdf"

--- a/aft-det-baixar/SKILL.md
+++ b/aft-det-baixar/SKILL.md
@@ -41,6 +41,10 @@ passa por aqui. O que chega vai todo para o pacote da notificação, dentro de
 <OS>/NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/   ← data do primeiro download
 ├── notificacao-<CODIGO>.pdf              ← o PDF da notificação
 ├── relatorio-atendimento-<CODIGO>.pdf    ← SEMPRE refrescado (entrega nova o muda)
+│                                            RELATÓRIO DE EXCEÇÃO: lista os itens NÃO
+│                                            entregues. Vazio = certidão oficial de que
+│                                            não há omissão (art. 630, §4º). O que foi
+│                                            entregue está nas pastas item<N>/.
 ├── historico-itens.md                    ← prorrogações, justificativas e status
 │                                            de cada item (derivado; regravado)
 ├── canal-comunicacao/                    ← só quando há mensagens na notificação

--- a/novidades/2026-08-21-09-relatorio-atendimento-excecao.md
+++ b/novidades/2026-08-21-09-relatorio-atendimento-excecao.md
@@ -1,0 +1,16 @@
+## 21/08/2026
+<!-- commit: relatorio-atendimento-excecao -->
+
+**O Relatório de Atendimento baixado do DET lista o que NÃO foi entregue — e isso agora
+está dito onde você vai ler.** Quando o `/aft-det-baixar` traz uma notificação, ele grava
+o `relatorio-atendimento-<CODIGO>.pdf`, que é o documento oficial do Ministério do Trabalho
+e Emprego sobre o atendimento daquela notificação. O detalhe que faltava estar escrito: ele
+é um relatório de **exceção**. Lista os itens **não entregues**, e não os entregues. Isso
+significa que, numa empresa que atendeu tudo, o PDF sai dizendo "não consta item para o
+critério selecionado", com zero itens e zero arquivos — o que parece um download vazio ou
+com defeito, mas é o contrário: é a **certidão oficial de que não há omissão**, prova
+documental direta para o art. 630, § 4º, da CLT. Quem abrir o arquivo esperando o
+inventário do que a empresa mandou vai entender exatamente ao contrário do que ele diz. O
+inventário do que veio continua nas pastas `item<N>/` e no `historico-itens.md`. Nada mudou
+no comportamento do download: só passou a estar documentado, no script e na skill, o que o
+arquivo é e o que ele não é.


### PR DESCRIPTION
## O que mudou

Só documentação. Nenhuma mudança de comportamento no download.

O `relatorio-atendimento-<CODIGO>.pdf` que o `/aft-det-baixar` grava é pedido com `tipo=0` (o padrão do modal do site). Com esse tipo, o PDF é um **relatório de exceção**: lista os itens **NÃO entregues** da notificação, e não os entregues. O comentário no `det_baixar.py` e o desenho da estrutura de pastas na skill descreviam o arquivo só como "o Relatório de Atendimento", sem dizer o que ele traz.

## Por que importa

Quando a empresa atende tudo, o PDF sai dizendo *"não consta item para o critério selecionado"*, com contagem de **0 itens e 0 arquivos**. Aberto sem contexto, parece download vazio ou com defeito. É o contrário: é a **certidão oficial do MTE de que não há omissão** — prova documental direta para o art. 630, § 4º, da CLT.

O risco na outra direção é pior: quem abrir o arquivo esperando o inventário do que a empresa mandou lê exatamente o inverso do que ele diz.

## Como apareceu

Fiscalização real, 21/08/2026: notificação de 18 itens (SST — PGR, NR-10, NR-12, AEP), todos entregues dentro do prazo de cada um (7 no prazo original, 11 na prorrogação parcialmente deferida). O relatório devolveu 0/0, como deveria.

## Conferido

- `montar_novidades.py --conferir`: OK, 101 entradas; o diff do NOVIDADES.md contém só a entrada nova.
- `aft_doctor.py`: 22 ok, 0 erros (o único aviso é pré-existente e sem relação — agente `aft-autos-lavrados` desatualizado nesta máquina).
- Ramificado de `origin/main` atual, sem sobreposição com os PRs #23 e #24, que seguem abertos.

## Uma pergunta que não consegui responder

O `tipo` é obrigatório na chamada e hoje vai fixo em `0`. Não sei se a API aceita outro valor que devolva o relatório **completo** (todos os itens com status), o que seria uma base ainda melhor para a análise documental. Não testei de propósito: o token fica só em memória no servidor do painel, por desenho, e não me pareceu certo contornar isso para um experimento. Fica o registro, caso valha investigar com a sessão do DET aberta no navegador.

---

[Claude Code](https://claude.com/claude-code) ajudou a levantar e escrever esta correção.