### PR TITLE
det-criar: canal de leitura do molde (fase descoberta)

### DIFF
--- a/_scripts/det_criar.py
+++ b/_scripts/det_criar.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+det_criar.py — redige RASCUNHO de notificação DET pela API oficial.
+
+IRMÃO de escrita do det_baixar.py (que é leitura). Usa a MESMA via — o token
+de sessão emprestado pela extensão ao servidor do painel — mas agora para
+CRIAR uma notificação nova, em estado de rascunho, para um RI existente.
+
+Fronteira dura, técnica (a própria API do DET a impõe) e inegociável:
+  - POST /notificacoes           cria a casca (status EM_ELABORACAO)
+  - PUT  /notificacoes/{uid}/rascunho   preenche o rascunho (RI, itens...)
+  - PUT  /notificacoes/{uid}/lavratura  LAVRA — ato de autoridade, efeito legal
+Este módulo faz APENAS as duas primeiras. A LAVRATURA nunca é chamada aqui:
+é sempre um clique do AFT, no site, depois de revisar o rascunho. Regra de
+ouro do perfil: o assistente redige a minuta, o AFT decide e transmite.
+
+Estado atual (21/08/2026): FASE DE DESCOBERTA. Só `recuperar_crua` — leitura
+do JSON completo de uma notificação real, para servir de molde à construção
+do rascunho. A criação em si entra depois que o molde estiver conferido.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+AQUI = Path(__file__).resolve().parent
+sys.path.insert(0, str(AQUI))
+import det_baixar  # noqa: E402  (pesquisar_por_codigo, TokenExpirado, _requisicao)
+
+
+def recuperar_crua(token: str, codigo: str) -> dict:
+    """JSON completo de uma notificação (GET /notificacoes/{uid}), pelo código.
+    Leitura pura — serve de MOLDE para montar o rascunho. Lança TokenExpirado
+    (401/403) ou RuntimeError."""
+    n = det_baixar.pesquisar_por_codigo(token, codigo)
+    if not n:
+        raise RuntimeError(f"notificação {codigo} não encontrada no DET")
+    uid = n.get("uid")
+    if not uid:
+        raise RuntimeError(f"notificação {codigo} veio sem uid")
+    bruto = det_baixar._requisicao(token, f"/notificacoes/{uid}")
+    return json.loads(bruto.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if len(sys.argv) != 3:
+        print("uso: python det_criar.py <CODIGO> <token>", file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(recuperar_crua(sys.argv[2], sys.argv[1]),
+                     ensure_ascii=False, indent=2))

--- a/_scripts/servir_painel.py
+++ b/_scripts/servir_painel.py
@@ -80,6 +80,7 @@ MAX_BODY = 64_000
 sys.path.insert(0, str(AQUI))
 import det_sync  # noqa: E402
 import det_baixar  # noqa: E402  (download dos arquivos de uma notificação)
+import det_criar  # noqa: E402  (rascunho de notificação — leitura do molde, por ora)
 import diario_registrar  # noqa: E402  (diário de atividades — letras A-F)
 
 # Token do DET emprestado pela extensão. Vive SÓ na RAM deste processo (nunca
@@ -794,10 +795,32 @@ class Handler(BaseHTTPRequestHandler):
                                  "fichas": len(mts)})
             except OSError as e:
                 self._json(500, {"ok": False, "erro": str(e)})
+        elif self.path.startswith("/api/det-molde"):
+            self._det_molde()
         elif self.path.startswith("/doc/"):
             self._serve_doc()
         else:
             self._json(404, {"ok": False, "erro": "rota desconhecida"})
+
+    def _det_molde(self):
+        """GET /api/det-molde?codigo=XXX — JSON cru de uma notificação real,
+        para servir de molde à construção do rascunho (subsistema det-criar,
+        fase de descoberta). Leitura pura; usa o token guardado na RAM."""
+        try:
+            q = urllib.parse.urlparse(self.path).query
+            codigo = (urllib.parse.parse_qs(q).get("codigo") or [""])[0].strip().upper()
+            if not codigo:
+                return self._json(400, {"ok": False, "erro": "informe ?codigo="})
+            token = _token_atual()
+            if not token:
+                return self._json(409, {"ok": False, "token_expirado": True,
+                                        "erro": "sem token — sincronize no DET e tente de novo"})
+            self._json(200, {"ok": True, "notificacao": det_criar.recuperar_crua(token, codigo)})
+        except det_baixar.TokenExpirado as e:
+            _DET_TOKEN["token"] = None
+            self._json(409, {"ok": False, "token_expirado": True, "erro": str(e)})
+        except Exception as e:
+            self._json(500, {"ok": False, "erro": f"{type(e).__name__}: {e}"})
 
     def _serve_doc(self):
         """GET /doc/<pasta-da-OS>/<arquivo>.md — renderiza o relatório em HTML.


### PR DESCRIPTION
Primeiro passo da criação de rascunho de notificação pela API — só leitura por ora. `det_criar.recuperar_crua` + `GET /api/det-molde?codigo=` retornam o JSON completo de uma notificação real, para servir de molde à construção do rascunho, sem escrever nada no DET. A criação (POST casca + PUT rascunho) entra depois do molde conferido; a lavratura nunca será automatizada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)