### PR TITLE
det-criar: enriquece rascunho com modelo + endereco do RI

### DIFF
--- a/_scripts/det_criar.py
+++ b/_scripts/det_criar.py
@@ -66,6 +66,55 @@ def recuperar_crua(token: str, codigo: str) -> dict:
     return json.loads(det_baixar._requisicao(token, f"/notificacoes/{uid}").decode("utf-8"))
 
 
+def recuperar_modelo(token: str, id_modelo: int) -> dict:
+    """Modelo de notificação do AFT (GET /modelos-notificacao/{id}) — traz a
+    introdução/observações e textos padrão que ele consagrou no DET."""
+    return json.loads(det_baixar._requisicao(
+        token, f"/modelos-notificacao/{int(id_modelo)}").decode("utf-8"))
+
+
+def recuperar_detalhe_ri(token: str, ri: str) -> dict:
+    """Detalhe da fiscalização (GET /fiscalizacoes/detalhe/{ri}) — é de onde o
+    site tira o estabelecimento/endereço do RI."""
+    ri = re.sub(r"\D", "", ri or "")
+    return json.loads(det_baixar._requisicao(
+        token, f"/fiscalizacoes/detalhe/{ri}").decode("utf-8"))
+
+
+def _sem_uids(o):
+    """Cópia recursiva sem chaves 'uid' — conteúdo reaproveitado de modelo ou
+    detalhe não pode carregar identidade de outro registro."""
+    if isinstance(o, dict):
+        return {k: _sem_uids(v) for k, v in o.items() if k != "uid"}
+    if isinstance(o, list):
+        return [_sem_uids(x) for x in o]
+    return o
+
+
+def _cacar_enderecos(o, achados: list | None = None) -> list[dict]:
+    """Caça recursiva por objetos com cara de endereço (logradouro/cep) na
+    resposta do detalhe do RI — o nome exato da chave não está em contrato."""
+    achados = achados if achados is not None else []
+    if isinstance(o, dict):
+        chaves = {k.lower() for k in o}
+        if ("logradouro" in chaves or "cep" in chaves) and o not in achados:
+            achados.append(o)
+        else:
+            for v in o.values():
+                _cacar_enderecos(v, achados)
+    elif isinstance(o, list):
+        for v in o:
+            _cacar_enderecos(v, achados)
+    return achados
+
+
+def _secao_do_modelo(modelo: dict, chave: str) -> list:
+    """Uma lista de conteúdo do modelo (observacoes, textos padrão) sem os
+    uids do modelo — vai ser gravada num registro novo."""
+    v = modelo.get(chave)
+    return _sem_uids(v) if isinstance(v, list) else []
+
+
 def auditor_do_token(token: str) -> dict:
     """{cpf, nome, cif} do AFT lidos do próprio JWT (sit_username, name,
     sit_cif) — o site monta a casca com esses três campos."""
@@ -108,8 +157,45 @@ def ids_do_memory(texto: str) -> tuple[str, str]:
     return campo("ri"), (campo("cnpj") or campo("cpf") or campo("caepf"))
 
 
+def enriquecer(payload: dict, token: str, ri: str,
+               id_modelo=None) -> dict:
+    """Acrescenta ao payload o que o modelo 521 e o detalhe do RI trazem —
+    introdução/observações (do modelo), textos padrão (do modelo), e o
+    endereço/estabelecimento (do RI). Defensivo: o que não vier fica de fora,
+    e o payload ganha `_enriquecimento` com a contagem do que entrou, para
+    conferência. NÃO escreve nada."""
+    relato = {"modelo": None, "observacoes": 0, "textos": 0, "enderecos": 0}
+    if id_modelo:
+        try:
+            modelo = recuperar_modelo(token, id_modelo)
+            obs = _secao_do_modelo(modelo, "observacoes")
+            txt = _secao_do_modelo(modelo, "textosInformativosPadraoAtivos")
+            if obs:
+                payload["observacoes"] = obs
+            if txt:
+                payload["textosInformativosPadraoAtivos"] = txt
+            if modelo.get("tipoAbrangencia") is not None:
+                payload["tipoAbrangencia"] = modelo["tipoAbrangencia"]
+            if modelo.get("titulo"):
+                payload["titulo"] = modelo["titulo"]
+            relato.update(modelo=bool(modelo), observacoes=len(obs), textos=len(txt))
+        except Exception as e:
+            relato["modelo_erro"] = str(e)[:150]
+    try:
+        detalhe = recuperar_detalhe_ri(token, ri)
+        ends = _sem_uids(_cacar_enderecos(detalhe))
+        if ends:
+            payload["enderecos"] = ends
+        relato["enderecos"] = len(ends)
+    except Exception as e:
+        relato["ri_erro"] = str(e)[:150]
+    payload["_enriquecimento"] = relato
+    return payload
+
+
 def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo: str,
-                   prazo_dias: int, token: str) -> tuple[dict, list[dict]]:
+                   prazo_dias: int, token: str, id_modelo=None
+                   ) -> tuple[dict, list[dict]]:
     """Lê a TN-NCO e o memory.md da OS e devolve (payload, itens) prontos —
     sem escrever nada. O endpoint usa isto para montar antes de criar."""
     alvo = (pasta_os / arquivo_tn)
@@ -121,7 +207,9 @@ def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo: str,
     if not ri:
         raise RuntimeError("RI não encontrado no memory.md da OS")
     prazo = _prazo_iso(prazo_dias)
-    return montar_payload(token, ri, cnpj, titulo, itens, prazo), itens
+    payload = montar_payload(token, ri, cnpj, titulo, itens, prazo)
+    enriquecer(payload, token, ri, id_modelo)
+    return payload, itens
 
 
 def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
@@ -168,6 +256,7 @@ def criar_rascunho(token: str, corpo: dict) -> dict:
     """ESCREVE: cria a casca (POST /notificacoes) e salva o rascunho
     (PUT /rascunho). NUNCA lavra. Devolve {uid, codigo?, url}. `corpo` é o que
     montar_payload devolveu (já conferido pelo AFT)."""
+    corpo = {k: v for k, v in corpo.items() if k != "_enriquecimento"}
     casca = {"cpfAuditor": corpo["cpfAuditor"], "status": STATUS_EM_ELABORACAO,
              "tipoGeracao": 0, "auditores": corpo["auditores"]}
     casca["rascunho"] = json.dumps(casca, ensure_ascii=False)

--- a/_scripts/servir_painel.py
+++ b/_scripts/servir_painel.py
@@ -825,11 +825,13 @@ class Handler(BaseHTTPRequestHandler):
                                         "erro": "sem token — sincronize no DET e tente de novo"})
             payload, itens = det_criar.preparar_de_os(
                 alvo, arquivo, p.get("titulo") or "Termo de Notificação",
-                int(p.get("prazo_dias") or 16), token)
+                int(p.get("prazo_dias") or 16), token,
+                id_modelo=p.get("modelo"))
             resumo = {"ri": payload["ri"], "ni": payload["ni"],
                       "titulo": payload["titulo"],
                       "prazo": payload["dataPrazoEntregaPadrao"],
                       "n_itens": len(payload["itens"]),
+                      "enriquecimento": payload.get("_enriquecimento"),
                       "itens": [{"ordem": it["ordem"], "descricao": it["descricao"][:80]}
                                 for it in payload["itens"]]}
             if not p.get("confirmar"):


### PR DESCRIPTION
O rascunho agora puxa introducao/observacoes/textos do modelo do AFT (por idModelo) e o endereco do estabelecimento pelo RI — resolvendo o que faltava (introducao, observacoes, enderecos). Defensivo e auto-relatando. Endpoint aceita `modelo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)