### PR TITLE
O tipo do item manda no retorno: tabela de opcoes do DET

### DIFF
--- a/_scripts/det_criar.py
+++ b/_scripts/det_criar.py
@@ -57,12 +57,11 @@ RETORNO_VISTORIA = 3
 STATUS_EM_ELABORACAO = 0
 PRAZO_PADRAO_DIAS = 16
 
-# "Todos os tipos de arquivo" marcados — a mesma concatenação que o front gera
-# (documentos + planilhas + imagens + jornadas + compactados), lida do chunk
-# 251. É o padrão da skill: todo item já vem aceitando qualquer arquivo.
-TIPOS_ARQUIVO_TODOS = (
-    ".txt, .pdf, .doc, .docx, .odt, .re, .xls, .xlsx, .ods, .csv, "
-    ".jpg, .jpeg, .png, .mp4, .mpeg4, .afd, .afdt, .acjef, .aej, .txt, .zip")
+# "Todos os tipos de arquivo" marcados — a string vem de config/det-opcoes.json
+# (o site concatena os grupos e repete o .txt; reproduzir igual é o que faz a
+# tela reconhecer a seleção ao reabrir o item).
+def tipos_arquivo_todos() -> str:
+    return opcoes()["tipos_de_arquivo"]["todos"]
 
 # Uma linha da TN-NCO: "*Título* - norma: texto [123456-7]"
 RE_ITEM_TN = re.compile(
@@ -185,18 +184,68 @@ def itens_da_tn_nco(texto: str) -> list[dict]:
     return itens
 
 
-# Palavras que o AFT lê no front-matter → enum do DET. O arquivo fala a língua
-# dele ("obrigacao", "digital"), não a do banco de dados (1, 1).
-PALAVRA_TIPO = {"solicitacao": TIPO_SOLICITACAO_DOCUMENTO,
-                "solicitacao_documento": TIPO_SOLICITACAO_DOCUMENTO,
-                "documento": TIPO_SOLICITACAO_DOCUMENTO,
-                "obrigacao": TIPO_CUMPRIMENTO_OBRIGACAO,
-                "cumprimento": TIPO_CUMPRIMENTO_OBRIGACAO,
-                "orientacao": TIPO_ORIENTACAO}
-PALAVRA_RETORNO = {"sem": RETORNO_SEM, "sem_retorno": RETORNO_SEM,
-                   "digital": RETORNO_DIGITAL, "impresso": RETORNO_IMPRESSO,
-                   "vistoria": RETORNO_VISTORIA,
-                   "vistoria_in_loco": RETORNO_VISTORIA}
+# ── As opções do DET vêm de config/det-opcoes.json ───────────────────────────
+# Fonte única: aquele arquivo espelha o formulário "Item Solicitado" do site,
+# com as regras de dependência entre os campos (quais retornos cada tipo aceita,
+# quando existe prazo, quando o item aceita arquivo). Elas NÃO estão duplicadas
+# aqui — se estivessem, um dia divergiriam.
+CONFIG_OPCOES = AQUI.parent / "config" / "det-opcoes.json"
+_OPCOES: dict | None = None
+
+
+def opcoes() -> dict:
+    """Carrega (uma vez) a tabela de opções do DET. Preguiçoso de propósito: um
+    arquivo faltando não pode derrubar o servidor do painel na importação."""
+    global _OPCOES
+    if _OPCOES is None:
+        try:
+            _OPCOES = json.loads(CONFIG_OPCOES.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            raise RuntimeError(
+                f"não consegui ler as opções do DET em {CONFIG_OPCOES} ({e}). "
+                "Rode /aft-atualizar para repor o arquivo.") from e
+    return _OPCOES
+
+
+def _palavras(secao: str) -> dict:
+    """{'digital': 1, ...} — as palavras que o AFT escreve no front-matter."""
+    return {p: int(cod)
+            for cod, o in opcoes()[secao]["opcoes"].items()
+            for p in o["palavras_no_frontmatter"]}
+
+
+def rotulo(secao: str, codigo) -> str:
+    o = opcoes()[secao]["opcoes"].get(str(codigo))
+    return o["rotulo"] if o else f"desconhecido ({codigo!r})"
+
+
+def retornos_permitidos(tipo: int) -> list[int]:
+    """Os retornos que o site oferece para aquele tipo de item. Fora desta
+    lista é combinação que a tela do DET jamais criaria."""
+    o = opcoes()["tipo_do_item"]["opcoes"].get(str(tipo))
+    return list(o["retornos_permitidos"]) if o else []
+
+
+def retorno_padrao(tipo: int, preferido: int | None = None) -> int:
+    """O retorno a usar para aquele tipo: o preferido, quando o tipo o aceita;
+    senão o padrão do próprio tipo. É o que impede um item de Orientação de
+    nascer com retorno digital só porque digital é o padrão da skill."""
+    permitidos = retornos_permitidos(tipo)
+    if preferido is not None and preferido in permitidos:
+        return preferido
+    o = opcoes()["tipo_do_item"]["opcoes"].get(str(tipo)) or {}
+    return o.get("retorno_padrao", RETORNO_SEM)
+
+
+def aceita_arquivo(retorno: int) -> bool:
+    """Só a entrega digital recebe arquivo pelo DET."""
+    regra = opcoes()["regras_do_formulario"]["tipos_de_arquivo"]
+    return retorno in regra["habilitado_somente_quando_retorno_for"]
+
+
+def exige_prazo(retorno: int) -> bool:
+    regra = opcoes()["regras_do_formulario"]["prazo_de_entrega"]
+    return retorno in regra["obrigatorio_quando_retorno_for"]
 
 
 def _sem_acento(s: str) -> str:
@@ -299,10 +348,10 @@ def parametros_do_md(texto: str) -> dict:
         p["prazo"] = simples["prazo"]
     if simples.get("prazo_dias"):
         p["prazo_dias"] = int(re.sub(r"\D", "", simples["prazo_dias"]) or 0)
-    t = _palavra(PALAVRA_TIPO, simples.get("tipo"))
+    t = _palavra(_palavras("tipo_do_item"), simples.get("tipo"))
     if t is not None:
         p["tipo"] = t
-    r = _palavra(PALAVRA_RETORNO, simples.get("retorno"))
+    r = _palavra(_palavras("retorno_solicitado"), simples.get("retorno"))
     if r is not None:
         p["retorno"] = r
     if "preassinalado" in simples:
@@ -313,8 +362,8 @@ def parametros_do_md(texto: str) -> dict:
         limpas = {}
         for ordem, campos in excecoes.items():
             e = {}
-            t = _palavra(PALAVRA_TIPO, campos.get("tipo"))
-            r = _palavra(PALAVRA_RETORNO, campos.get("retorno"))
+            t = _palavra(_palavras("tipo_do_item"), campos.get("tipo"))
+            r = _palavra(_palavras("retorno_solicitado"), campos.get("retorno"))
             if t is not None:
                 e["tipo"] = t
             if r is not None:
@@ -587,7 +636,7 @@ def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
                    tipo: int = TIPO_CUMPRIMENTO_OBRIGACAO,
                    retorno: int = RETORNO_DIGITAL,
                    preassinalado: bool = True,
-                   tipos_arquivo: str | None = TIPOS_ARQUIVO_TODOS,
+                   tipos_arquivo: str | None = None,
                    overrides: dict | None = None) -> dict:
     """Corpo do rascunho, PRONTO para conferência — NÃO envia nada.
     Espelha o molde real: casca (auditor/status) + itens com o texto integral.
@@ -604,10 +653,16 @@ def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
     for i, it in enumerate(itens, 1):
         ov = overrides.get(i, {})
         t = ov.get("tipo", tipo)
-        r = ov.get("retorno", retorno)
+        # O retorno tem de ser um dos que o SITE oferece para aquele tipo:
+        # Solicitação de Documento só aceita Digital/Impresso, e Orientação só
+        # aceita Sem Retorno. Pedir digital num item de Orientação criaria algo
+        # que a tela do DET jamais permitiria montar à mão.
+        r = retorno_padrao(t, ov.get("retorno", retorno))
         # o item pode ter prazo próprio (o DET aceita): correção de máquina
         # pede mais dias que fornecer água potável
         prazo_do_item = _prazo_para_iso(ov.get("prazo")) or prazo_iso
+        if not exige_prazo(r):
+            prazo_do_item = None   # Sem Retorno não tem prazo: o site o apaga
         # TODOS os campos que o site põe num item — inclusive os companheiros de
         # data em null. Sem eles, a tela de EDIÇÃO (formulário reativo) tenta
         # criar controle para um campo ausente e quebra (isDatasPadraoValidas /
@@ -626,8 +681,11 @@ def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
             "horaPrazoEntrega": None,
             "naoExigeDataInicialFinal": True,
             "mensagemInfo": None,
-            # Sem retorno não recebe arquivo — o site deixa tiposArquivos null.
-            "tiposArquivos": (tipos_arquivo if r != RETORNO_SEM else None),
+            # SÓ a entrega digital recebe arquivo pelo DET. Em Impresso,
+            # Vistoria ou Sem Retorno o site apaga a seleção — mandar extensões
+            # ali seria gravar o que a tela não mostraria.
+            "tiposArquivos": ((tipos_arquivo or tipos_arquivo_todos())
+                              if aceita_arquivo(r) else None),
             "preAssinalado": preassinalado,
             "status": 0,
             "versao": 1,
@@ -699,9 +757,17 @@ def revisar_payload(payload: dict) -> list[dict]:
         r = it.get("tipoRetornoSolicitado")
         if r not in (RETORNO_SEM, RETORNO_DIGITAL, RETORNO_IMPRESSO, RETORNO_VISTORIA):
             anota("impede", onde, f"tipo de retorno inválido ({r!r})")
+        elif r not in retornos_permitidos(it.get("tipo")):
+            permitidos = ", ".join(rotulo("retorno_solicitado", x)
+                                   for x in retornos_permitidos(it.get("tipo")))
+            anota("impede", onde,
+                  f"combinação impossível no DET: item do tipo "
+                  f"'{rotulo('tipo_do_item', it.get('tipo'))}' não aceita retorno "
+                  f"'{rotulo('retorno_solicitado', r)}' (aceita: {permitidos})")
         prazo = it.get("dataPrazoEntrega")
         if not prazo:
-            anota("impede", onde, "sem prazo de entrega")
+            if exige_prazo(r):
+                anota("impede", onde, "sem prazo de entrega")
         else:
             try:
                 d = datetime.date.fromisoformat(str(prazo)[:10])
@@ -711,11 +777,16 @@ def revisar_payload(payload: dict) -> list[dict]:
                     anota("aviso", onde, "prazo é hoje")
             except ValueError:
                 anota("impede", onde, f"prazo em formato inválido ({prazo!r})")
-        if r == RETORNO_SEM and it.get("tiposArquivos"):
-            anota("aviso", onde, "não pede retorno, mas aceita arquivo")
-        if r in (RETORNO_DIGITAL, RETORNO_IMPRESSO) and not it.get("tiposArquivos"):
+        # tipos de arquivo: o site só os habilita na entrega DIGITAL
+        if it.get("tiposArquivos") and not aceita_arquivo(r):
             anota("impede", onde,
-                  "pede retorno de documento, mas não aceita nenhum tipo de arquivo")
+                  f"aceita tipos de arquivo, mas o retorno é "
+                  f"'{rotulo('retorno_solicitado', r)}' — só a entrega Digital "
+                  "recebe arquivo pelo DET")
+        if aceita_arquivo(r) and not it.get("tiposArquivos"):
+            anota("impede", onde,
+                  "entrega digital sem nenhum tipo de arquivo aceito — a empresa "
+                  "não teria como anexar")
         if not RE_ITEM_TN.match(desc):
             anota("aviso", onde,
                   "fora do formato *Título* - norma: exigência [ementa] "

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -249,12 +249,22 @@ Texto sozinho não vira notificação. O DET exige, de **cada item**, o que a em
 | `preassinalado` | `sim` | o item já nasce marcado |
 | `arquivos` | `todos` | aceita qualquer extensão que o DET permite |
 
+> **O retorno depende do tipo.** O DET não oferece as quatro opções sempre — a lista muda conforme o tipo do item, e combinação fora dela é impossível na tela do site (e o toolkit recusa):
+>
+> | Tipo do item | Retornos que o DET aceita | Padrão |
+> |---|---|---|
+> | Solicitação de Documento | Digital · Impresso | Digital |
+> | Exigência do Cumprimento de Obrigação | Sem Retorno · Digital · Impresso · Vistoria in loco | Digital |
+> | Orientação | **só** Sem Retorno | Sem Retorno |
+>
+> Decorrências que valem lembrar ao AFT: **Sem Retorno não tem prazo** (o item será verificado em fiscalização futura), e **só a entrega Digital recebe arquivo** — em Impresso ou Vistoria não há o que anexar. A tabela completa, com os textos de ajuda do próprio DET, está em `~/.claude/skills/config/det-opcoes.json`.
+
 **Pergunte só o que muda o resultado**, numa passagem só, depois da tabela de itens:
 
 1. **Prazo** — data fixa (`dd/mm/aaaa`) ou "tantos dias"? Sem resposta, valem os 16 dias.
 2. **Exceções** — algum item foge do padrão? Os dois casos frequentes:
    - item que só manda **fazer**, sem pedir documento (organizar o local de pega, orientar os trabalhadores, cessar uma prática) → `retorno: sem` ou `retorno: vistoria`, para não obrigar a empresa a inventar um documento;
-   - item redigido como conselho, não como obrigação → `tipo: orientacao`.
+   - item redigido como conselho, não como obrigação → `tipo: orientacao` (que arrasta `retorno: sem`, o único que o DET aceita nesse tipo — e, por isso, item de orientação não tem prazo).
 3. **Prazo próprio de um item** — quando uma exigência é claramente mais pesada que as outras (instalar proteção com ART, contratar profissional habilitado), ofereça prazo maior só para ela.
 
 Não pergunte item a item: ofereça o padrão e recolha apenas as exceções.

--- a/arquitetura/DET criar/arquitetura-det-criar.html
+++ b/arquitetura/DET criar/arquitetura-det-criar.html
@@ -250,6 +250,42 @@ det:
   não os exige, e os arquivos antigos continuam válidos.
 </p>
 
+<h2>3-A. O tipo manda no retorno (e no resto do item)</h2>
+<p>
+  As opções de "Retorno Solicitado" <strong>não são as mesmas sempre</strong>: a lista
+  muda conforme o Tipo. Está no código do próprio site, e é o que a tela mostra:
+</p>
+<table>
+  <tr><th>Tipo do item</th><th>Retornos que o DET oferece</th><th>Padrão do toolkit</th></tr>
+  <tr><td>Solicitação de Documento</td><td>Digital · Impresso</td><td>Digital</td></tr>
+  <tr><td>Exigência do Cumprimento de Obrigação</td><td>Sem Retorno · Digital · Impresso · Vistoria in loco</td><td>Digital</td></tr>
+  <tr><td>Orientação</td><td><strong>só</strong> Sem Retorno</td><td>Sem Retorno (não há escolha)</td></tr>
+</table>
+<p>E o retorno, por sua vez, manda em três campos:</p>
+<ul>
+  <li><strong>Prazo de entrega</strong> — obrigatório em Digital, Impresso e Vistoria;
+      <strong>apagado</strong> em Sem Retorno (o item será verificado em fiscalização futura).</li>
+  <li><strong>Hora da entrega</strong> — só existe em Impresso e Vistoria, que são entrega
+      física ou visita.</li>
+  <li><strong>Tipos de arquivo</strong> — habilitados <strong>somente em Digital</strong>
+      (<code>allowEnableArquivos === DIGITAL</code>, no código do site). Só a entrega digital
+      recebe anexo pelo DET.</li>
+</ul>
+<div class="note stop">
+  <strong>Foram três defeitos reais, não teoria.</strong> Até 22/08/2026 o toolkit montava
+  item de Orientação com retorno digital, mandava tipos de arquivo em item de Vistoria e
+  punha prazo em item Sem Retorno — coisas que a tela do DET jamais deixaria um humano
+  criar, mas que a API aceita de quem monta o payload à mão. Descobertos porque o AFT
+  mandou as telas do site. Hoje <code>montar_payload</code> corrige o retorno para o que o
+  tipo aceita, e <code>revisar_payload</code> barra a combinação forçada.
+</div>
+<div class="note ok">
+  <strong>Fonte única:</strong> <code>config/det-opcoes.json</code> — todas as opções do
+  formulário, as dependências entre elas, os grupos de extensão e os textos de ajuda do
+  próprio DET. Veio do bundle público do site (não precisa de login). Se o DET mudar essa
+  tela, é um arquivo só para atualizar.
+</div>
+
 <h2>4. Revisão em duas camadas</h2>
 <p>
   O pedido foi "um subagente revisor, para que só vá ao DET dado completo". O subagente

--- a/arquitetura/DET criar/arquitetura-det-criar.json
+++ b/arquitetura/DET criar/arquitetura-det-criar.json
@@ -217,7 +217,8 @@
    "causa": "No formulário do site, selecionar o RI faz surgir o campo Abrangência como obrigatório.",
    "correcao": "Mandar tipoAbrangencia no payload (o modelo pode fornecer)."
   },
-  "Procurar um campo `introducao` no payload: ele existe no topo mas vem SEMPRE nulo. Introdução e observações moram na mesma lista `observacoes`, e só o `tipoTexto` (0/1) as separa. Quem gravar a introdução como observação comum a vê no lugar errado da notificação."
+  "Procurar um campo `introducao` no payload: ele existe no topo mas vem SEMPRE nulo. Introdução e observações moram na mesma lista `observacoes`, e só o `tipoTexto` (0/1) as separa. Quem gravar a introdução como observação comum a vê no lugar errado da notificação.",
+  "Supor que os quatro retornos valem para qualquer tipo. Não valem: a lista depende do tipo, e quem monta pela API consegue gravar o que a tela jamais criaria — item de Orientação com retorno digital, arquivo em item de Vistoria, prazo em item Sem Retorno. Foram exatamente os três defeitos corrigidos em 22/08/2026, descobertos porque o AFT mandou as telas do site."
  ],
  "metodo_de_investigacao": {
   "principio": "Não deduzir contrato de API por nome de campo. Confirmar no bundle público e, quando possível, capturar o que o próprio site envia.",
@@ -256,6 +257,10 @@
    "data": "22/08/2026",
    "o_que_provou": "fluxo completo a partir de um .md padrão da skill, com a chamada levando só pasta e arquivo: parâmetros lidos do front-matter, prazo calculado (16 dias), 7 itens, introdução e 2 observações, revisão mecânica sem impedimentos, parecer do subagente e rascunho criado — conferido lendo de volta do DET",
    "achado_do_revisor": "apontou sozinho os itens que mandavam adequar sem pedir documento, o prazo único para exigências de porte muito diferente e dois itens que embutiam duas medidas — o que virou a regra do fecho de comprovação"
+  },
+  {
+   "data": "22/08/2026 (tarde)",
+   "o_que_provou": "com o item 5 pedido como Vistoria e o 6 como Orientação: o 5 saiu sem tipos de arquivo, o 6 teve o retorno corrigido para Sem Retorno e perdeu o prazo, e os demais seguiram digitais com todos os arquivos. Combinações impossíveis forçadas à mão foram barradas pela conferência."
   }
  ],
  "parametros_do_endpoint": {
@@ -316,5 +321,29 @@
   "via_2_alternativa": "extensão Sync DET, para assistente sem navegador",
   "texto_canonico": "config/canal-token-det.md",
   "privacidade": "o token vive só na RAM do painel: nunca em disco, nunca no chat, nunca em argumento de linha de comando (ficaria no histórico do shell)"
+ },
+ "opcoes_do_det": {
+  "fonte_unica": "config/det-opcoes.json — espelha o formulário 'Item Solicitado' do site, com as dependências entre os campos. det_criar.py lê de lá (opcoes(), retornos_permitidos(), retorno_padrao(), aceita_arquivo(), exige_prazo()); nada disso é duplicado em código.",
+  "de_onde_veio": "bundle Angular público do DET (chunk 251), lido em 22/08/2026 — as mesmas tabelas que o formulário usa. Não precisa de login: index.html -> runtime -> o chunk que contém 'Vistoria in loco'.",
+  "tipo_manda_no_retorno": {
+   "0 Solicitação de Documento": [
+    1,
+    2
+   ],
+   "1 Exigência do Cumprimento de Obrigação": [
+    0,
+    1,
+    2,
+    3
+   ],
+   "2 Orientação": [
+    0
+   ]
+  },
+  "prazo": "obrigatório em Digital/Impresso/Vistoria; APAGADO em Sem Retorno",
+  "hora_da_entrega": "só faz sentido em Impresso e Vistoria; o site apaga nos demais",
+  "tipos_de_arquivo": "habilitados SOMENTE em Digital (allowEnableArquivos === DIGITAL no código do site). Padrão do toolkit: todos os grupos marcados",
+  "autocorrecao": "montar_payload usa retorno_padrao(tipo, preferido): se o tipo não aceita o retorno pedido, cai no padrão daquele tipo. É o que impede um item de Orientação de nascer digital só porque digital é o padrão da skill",
+  "barreira": "revisar_payload marca como 'impede' a combinação fora da tabela, o item com arquivo em retorno não-digital e a entrega digital sem nenhum tipo de arquivo"
  }
 }

--- a/config/det-opcoes.json
+++ b/config/det-opcoes.json
@@ -1,0 +1,118 @@
+{
+ "_o_que_e": "Todas as opções do formulário 'Item Solicitado' do DET, com as regras de dependência entre elas. Fonte única do toolkit: det_criar.py lê daqui para montar e conferir o rascunho, e as skills leem daqui para explicar as opções ao AFT. Não repita este conteúdo em nenhum outro lugar.",
+ "_fonte": "Código-fonte do próprio DET (bundle Angular do site, chunk 251), lido em 22/08/2026 — as mesmas tabelas que o formulário usa para montar e validar a tela. Conferido contra as telas reais do site.",
+ "_verificado_em": "2026-08-22",
+ "_quando_reconferir": "Se o DET mudar a tela do item (opção nova, campo novo, comportamento diferente). O bundle é servido sem login: baixe index.html, ache o runtime, e nele o chunk que contém 'Vistoria in loco'.",
+
+ "tipo_do_item": {
+  "campo_no_payload": "tipo",
+  "obrigatorio": true,
+  "opcoes": {
+   "0": {
+    "rotulo": "Solicitação de Documento",
+    "palavras_no_frontmatter": ["solicitacao", "solicitacao_documento", "documento"],
+    "tooltip_do_site": "Solicitar documentos ao empregador",
+    "retornos_permitidos": [1, 2],
+    "retorno_padrao": 1
+   },
+   "1": {
+    "rotulo": "Exigência do Cumprimento de Obrigação",
+    "palavras_no_frontmatter": ["obrigacao", "cumprimento"],
+    "tooltip_do_site": "Exigir o cumprimento de obrigações e a correção de irregularidades e a adoção de medidas que eliminem os riscos para a segurança e saúde dos trabalhadores",
+    "retornos_permitidos": [0, 1, 2, 3],
+    "retorno_padrao": 1
+   },
+   "2": {
+    "rotulo": "Orientação",
+    "palavras_no_frontmatter": ["orientacao"],
+    "tooltip_do_site": "Orientar o empregador, atendidos os critérios administrativos de oportunidade e conveniência, quanto ao cumprimento da legislação trabalhista",
+    "retornos_permitidos": [0],
+    "retorno_padrao": 0
+   }
+  }
+ },
+
+ "retorno_solicitado": {
+  "campo_no_payload": "tipoRetornoSolicitado",
+  "obrigatorio": true,
+  "depende_do_tipo": "As opções da lista mudam conforme o Tipo escolhido — ver `retornos_permitidos` de cada tipo. Combinação fora dessa lista é impossível na tela do site.",
+  "opcoes": {
+   "0": {
+    "rotulo": "Sem Retorno",
+    "palavras_no_frontmatter": ["sem", "sem_retorno"],
+    "tooltip_do_site": "O item notificado será inspecionado em fiscalização futura"
+   },
+   "1": {
+    "rotulo": "Digital",
+    "palavras_no_frontmatter": ["digital"],
+    "tooltip_do_site": "O documento deve ser entregue eletronicamente, via DET, conforme data predeterminada na notificação"
+   },
+   "2": {
+    "rotulo": "Impresso",
+    "palavras_no_frontmatter": ["impresso"],
+    "tooltip_do_site": "O documento deve ser entregue fisicamente ao Auditor Fiscal do Trabalho, em local e data predeterminados na notificação"
+   },
+   "3": {
+    "rotulo": "Vistoria in loco do Auditor",
+    "palavras_no_frontmatter": ["vistoria", "vistoria_in_loco"],
+    "tooltip_do_site": "Indica que o Auditor Fiscal do Trabalho realizará inspeção nos locais de trabalho, a fim de averiguar o cumprimento dos itens notificados"
+   }
+  }
+ },
+
+ "regras_do_formulario": {
+  "_origem": "Reproduzem o que o formulário do site faz sozinho ao AFT trocar Tipo ou Retorno. O toolkit as aplica ao montar o payload, para não gravar item que a tela jamais criaria.",
+  "prazo_de_entrega": {
+   "campo_no_payload": "dataPrazoEntrega",
+   "obrigatorio_quando_retorno_for": [1, 2, 3],
+   "apagado_quando_retorno_for": [0],
+   "observacao": "Sem Retorno não tem prazo: o item será verificado em fiscalização futura."
+  },
+  "hora_da_entrega": {
+   "campo_no_payload": "horaPrazoEntrega",
+   "so_faz_sentido_quando_retorno_for": [2, 3],
+   "observacao": "Hora só existe para entrega física ou visita do auditor; nos demais casos o site apaga."
+  },
+  "tipos_de_arquivo": {
+   "campo_no_payload": "tiposArquivos",
+   "habilitado_somente_quando_retorno_for": [1],
+   "observacao": "Só a entrega Digital recebe arquivo pelo DET. Em Impresso, Vistoria ou Sem Retorno o site apaga a seleção — mandar extensões nesses casos é gravar dado que a tela não mostraria.",
+   "padrao_do_toolkit": "marcar TODOS os grupos, por via das dúvidas (decisão do AFT em 22/08/2026)"
+  },
+  "datas_inicial_e_final": {
+   "campos_no_payload": ["dataPeriodoInicio", "dataPeriodoFim"],
+   "desabilitados_quando": "naoExigeDataInicialFinal = true",
+   "observacao": "São o PERÍODO a que o documento se refere (ex.: AFD de tal data a tal data), não o prazo de entrega."
+  }
+ },
+
+ "tipos_de_arquivo": {
+  "campo_no_payload": "tiposArquivos",
+  "formato": "string única com as extensões separadas por vírgula e espaço, na ordem dos grupos abaixo; null quando nada está marcado",
+  "grupos": {
+   "documentos": {"rotulo": "Documento Texto", "extensoes": [".txt", ".pdf", ".doc", ".docx", ".odt", ".re"]},
+   "planilhas": {"rotulo": "Planilhas", "extensoes": [".xls", ".xlsx", ".ods", ".csv"]},
+   "imagens": {"rotulo": "Imagens", "extensoes": [".jpg", ".jpeg", ".png", ".mp4", ".mpeg4"]},
+   "jornadas": {"rotulo": "Arquivos de Jornada", "extensoes": [".afd", ".afdt", ".acjef", ".aej", ".txt"]},
+   "compactados": {"rotulo": "Arquivo Compactado", "extensoes": [".zip"]}
+  },
+  "todos": ".txt, .pdf, .doc, .docx, .odt, .re, .xls, .xlsx, .ods, .csv, .jpg, .jpeg, .png, .mp4, .mpeg4, .afd, .afdt, .acjef, .aej, .txt, .zip",
+  "observacao_do_txt_repetido": "O .txt aparece DUAS vezes de propósito: o site concatena os grupos sem remover repetição (ele está em Documento Texto e em Arquivos de Jornada). Reproduzir igual é o que faz a tela reconhecer a seleção.",
+  "como_o_site_le_de_volta": "Ao reabrir o item, o site marca cada grupo procurando uma extensão-chave na string: .doc, .xls, .jpg, .afd, .zip."
+ },
+
+ "texto_da_notificacao": {
+  "campo_no_payload": "observacoes",
+  "observacao": "NÃO existe campo `introducao`: os dois blocos da tela moram nesta mesma lista, separados por tipoTexto.",
+  "tipo_texto": {
+   "0": {"rotulo": "Introdução", "onde_aparece": "antes dos itens"},
+   "1": {"rotulo": "Observação", "onde_aparece": "depois dos itens"}
+  }
+ },
+
+ "outros_enums": {
+  "status_da_notificacao": {"0": "Em Elaboração", "1": "Confirmada", "2": "Cancelada"},
+  "status_do_item": {"0": "Inicial", "1": "Recebido", "2": "Rejeitado", "3": "Dispensado"},
+  "tipo_ni": {"0": "CNPJ", "1": "CPF"}
+ }
+}

--- a/novidades/2026-08-22-03-det-opcoes-dependencia.md
+++ b/novidades/2026-08-22-03-det-opcoes-dependencia.md
@@ -1,0 +1,29 @@
+## 22/08/2026
+<!-- commit: det-opcoes-dependencia -->
+
+**O toolkit aprendeu as regras da tela do DET — e parou de montar item que o
+site não deixaria você criar.** As opções de "Retorno Solicitado" não são as
+mesmas sempre: elas mudam conforme o tipo do item. **Solicitação de Documento**
+só aceita Digital ou Impresso. **Orientação** só aceita Sem Retorno. Só a
+**Exigência do Cumprimento de Obrigação** tem as quatro opções. O toolkit não
+sabia disso e aceitava combinações impossíveis; agora ele conhece a tabela e a
+respeita.
+
+Três consequências que você vai sentir:
+
+- **Item de Orientação nasce certo.** Se você marcar um item como orientação, o
+  retorno vira Sem Retorno sozinho — mesmo que o padrão da notificação seja
+  digital —, e o item deixa de ter prazo, porque orientação sem retorno é
+  verificada em fiscalização futura.
+- **Tipos de arquivo só onde fazem sentido.** O DET só aceita anexo na entrega
+  **Digital**. Em Impresso, Vistoria in loco ou Sem Retorno, o site descarta a
+  seleção — então o toolkit também deixou de mandá-la.
+- **Sem Retorno não leva mais prazo**, que é como o próprio site se comporta.
+
+Tudo isso ficou registrado num arquivo de referência com **todas as opções do
+DET** e os textos de ajuda do próprio sistema (por exemplo: "Sem Retorno — o
+item notificado será inspecionado em fiscalização futura"). É de lá que a skill
+tira o que oferecer a você, e é de lá que a conferência tira o que barrar. Se um
+dia o DET mudar essa tela, é um arquivo só para atualizar.
+
+---


### PR DESCRIPTION
## O problema

As opções de **Retorno Solicitado** do DET dependem do **Tipo do item** — e o toolkit não sabia disso. Lido do bundle público do site (a mesma tabela que o formulário usa):

| Tipo | Retornos que o DET oferece |
|---|---|
| Solicitação de Documento | Digital · Impresso |
| Exigência do Cumprimento de Obrigação | Sem Retorno · Digital · Impresso · Vistoria in loco |
| Orientação | **só** Sem Retorno |

E mais duas regras que o formulário aplica sozinho: **tipos de arquivo habilitados somente em Digital** (`allowEnableArquivos === DIGITAL`) e **prazo apagado em Sem Retorno**.

## Três defeitos corrigidos

Todos gravavam item que a tela do DET jamais criaria — a API aceita de quem monta o payload à mão, e o site descarta em silêncio:

1. item de Orientação nascia com retorno digital;
2. tipos de arquivo iam em item de Impresso/Vistoria;
3. item Sem Retorno levava prazo.

## Como ficou

`config/det-opcoes.json` vira a **fonte única**: enums, dependências entre campos, grupos de extensão e os textos de ajuda do próprio DET. O `det_criar.py` lê de lá e não duplica nada em código.

- `montar_payload` **corrige** o retorno para o que o tipo aceita (item marcado como orientação vira Sem Retorno sozinho, mesmo com o padrão digital da skill);
- `revisar_payload` **barra** a combinação forçada à mão, com mensagem que diz o que aquele tipo aceita.

## Testado

Na TN-NCO de uma OS real, pedindo um item como Vistoria e outro como Orientação: o de Vistoria saiu sem tipos de arquivo, o de Orientação teve o retorno corrigido e perdeu o prazo, os demais seguiram digitais com todos os arquivos. Combinações impossíveis forçadas à mão foram barradas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)