### PR TITLE
chore: registra aft-cnpjs-endereco no indice de skills oficiais

### DIFF
--- a/_scripts/skills_oficiais.txt
+++ b/_scripts/skills_oficiais.txt
@@ -17,6 +17,7 @@ aft-autos-pdf-reunidos
 aft-cat-trabalhador
 aft-cipa-nr05-dimensionamento
 aft-cnae-grau-risco-nr04
+aft-cnpjs-endereco
 aft-consulta
 aft-det-630
 aft-det-baixar


### PR DESCRIPTION
Linha gerada pelo `publicar.py` e deixada sem commit por outra sessão. Sem ela, o publicar recusa rodar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)