### PR TITLE
checar_rt_autos: aceitar RT em PDF e falhar com mensagem util

### DIFF
--- a/_scripts/checar_rt_autos.py
+++ b/_scripts/checar_rt_autos.py
@@ -69,10 +69,82 @@ def eh_legenda(texto):
     return bool(RE_LEGENDA.match(texto))
 
 
+RE_IRREG_PDF = re.compile(r"IRREGULARIDADE(?:S)?\s*:?", re.IGNORECASE)
+RE_FATOR_PDF = re.compile(r"FATOR(?:ES)?\s+DE\s+RISCO", re.IGNORECASE)
+RE_RODAPE_PDF = re.compile(r"^T\.\s*(Interdi|Embargo)", re.IGNORECASE)
+
+
+def ler_secao4_rt_pdf(rt_path):
+    """Mesma leitura, para RT em PDF.
+
+    No Modo B da skill (Termo ja lavrado, so faltam os autos) o RT quase nunca e
+    o .docx que o montar_rt.py gerou: e o PDF impresso pelo Sistema Auditor, que
+    e o que o AFT tem em maos. Antes desta funcao o script chamava
+    docx.Document() direto no PDF e morria com PackageNotFoundError -- traceback
+    cru, ticket automatico, e a conferencia RT x autos simplesmente nao rodava
+    justamente no caso mais comum.
+
+    Sem camada de texto (PDF escaneado), devolve (None, None): quem chama ja
+    trata isso como "nao encontrei o bloco de irregularidades".
+    """
+    try:
+        import pdfplumber
+    except ImportError:
+        print("AVISO: RT em PDF exige a biblioteca pdfplumber "
+              "(pip install pdfplumber). Conferencia nao realizada.",
+              file=sys.stderr)
+        return None, None
+
+    with pdfplumber.open(rt_path) as pdf:
+        linhas = []
+        for pagina in pdf.pages:
+            for linha in (pagina.extract_text() or "").splitlines():
+                linha = linha.strip()
+                # o rodape se repete em toda pagina e traz o numero do termo,
+                # que o CODE_RE confundiria com codigo de ementa
+                if linha and not RE_RODAPE_PDF.match(linha):
+                    linhas.append(linha)
+
+    inicios = [i for i, t in enumerate(linhas) if RE_IRREG_PDF.fullmatch(t)]
+    if not inicios:
+        return None, None
+
+    itens, textos = [], []
+    for ini in inicios:
+        buffer = ""
+        for t in linhas[ini + 1:]:
+            if RE_FATOR_PDF.search(t):
+                break
+            textos.append(t)
+            # no PDF a ementa quebra em varias linhas; um item novo comeca
+            # sempre por um codigo XXXXXX-X no inicio da linha
+            if CODE_RE.match(t):
+                if buffer:
+                    itens.append(buffer.strip())
+                buffer = t
+            elif buffer:
+                buffer += " " + t
+        if buffer:
+            itens.append(buffer.strip())
+
+    itens = [t for t in itens if t and not eh_legenda(t)]
+    # ementa repetida entre objetos rende UM auto so (regra 7.1 da skill)
+    vistos, unicos = set(), []
+    for t in itens:
+        m = CODE_RE.search(t)
+        chave = m.group(0) if m else t
+        if chave not in vistos:
+            vistos.add(chave)
+            unicos.append(t)
+    return unicos, "\n".join(textos)
+
+
 def ler_secao4_rt(rt_path):
     """Retorna (itens_de_irregularidade, texto_dos_blocos_de_irregularidade).
 
-    Aceita os tres layouts de RT:
+    Aceita RT em .docx e em .pdf (ver ler_secao4_rt_pdf).
+
+    Nos .docx, aceita os tres layouts de RT:
       - topico atual: os titulos usam numeracao AUTOMATICA do Word, entao o
         texto e so "IRREGULARIDADE(S):" (sem o "4.") e as irregularidades sao
         paragrafos de prosa ANTES do bloco fixo da metodologia da NR-3;
@@ -85,8 +157,19 @@ def ler_secao4_rt(rt_path):
     Em todos, as tabelas 3.1/3.2/3.3 ficam de fora: doc.paragraphs nao inclui o
     conteudo de tabelas.
     """
+    if os.path.splitext(rt_path)[1].lower() == ".pdf":
+        return ler_secao4_rt_pdf(rt_path)
+
     import docx
-    doc = docx.Document(rt_path)
+    try:
+        doc = docx.Document(rt_path)
+    except Exception as e:
+        # arquivo que nao e um .docx valido (RT salvo com outro formato, arquivo
+        # truncado): mensagem util em vez de traceback do python-docx
+        print(f"ERRO: nao consegui abrir o RT como .docx: {e}", file=sys.stderr)
+        print("Formatos aceitos: .docx (gerado pelo montar_rt.py) e .pdf "
+              "(impresso pelo Sistema Auditor).", file=sys.stderr)
+        return None, None
     paras = doc.paragraphs
 
     def eh_titulo_irregularidade(t):
@@ -163,7 +246,7 @@ def ler_autos(autos_path):
 
 def main():
     if len(sys.argv) != 3:
-        print("uso: python checar_rt_autos.py <RT.docx> <autos.md>", file=sys.stderr)
+        print("uso: python checar_rt_autos.py <RT.docx|RT.pdf> <autos.md>", file=sys.stderr)
         sys.exit(2)
     rt_path, autos_path = sys.argv[1], sys.argv[2]
     for p in (rt_path, autos_path):


### PR DESCRIPTION
O verificador so lia RT em .docx. No fluxo em que o Termo de Interdicao ja esta lavrado e faltam apenas os autos (Modo B da skill /aft-embargo-interdicao), o RT que o auditor tem em maos e o PDF impresso pelo Sistema Auditor -- nao o .docx que o montar_rt.py gerou. Nesse caso o script chamava docx.Document() sobre o PDF e morria com PackageNotFoundError: traceback cru, ticket de erro automatico, e a conferencia RT x autos deixando de rodar justamente no caso mais comum.

Mudancas:

- ler_secao4_rt_pdf(): le o RT em PDF com pdfplumber, junta as linhas de cada ementa (que o PDF quebra em varias), descarta o rodape repetido de cada pagina -- ele traz o numero do termo, que o CODE_RE confundiria com codigo de ementa -- e deduplica ementa repetida entre objetos, mantendo a regra 7.1 da skill (uma ementa = um auto). Sem pdfplumber instalado, avisa e devolve (None, None) em vez de quebrar; PDF sem camada de texto cai no mesmo caminho.
- ler_secao4_rt(): despacha por extensao e envolve docx.Document() em try, para que arquivo invalido produza mensagem dizendo os formatos aceitos, em vez de traceback.
- linha de uso atualizada para <RT.docx|RT.pdf>.

Testes (dados ficticios; nenhum dado de fiscalizacao):

- RT em PDF de 4 paginas com 2 ementas x autos.md com 2 autos -> exit 0, sem divergencia, sem traceback.
- Regressao no caminho .docx: RT gerado pelo montar_rt.py (formato topico, 2 ementas) x autos.md com 2 autos -> exit 0.
- Regressao negativa: mesmo RT .docx x autos.md com 1 auto -> exit 1, acusando "Contagem divergente: RT=2 x autos=1".
- Arquivo que nao e .docx valido -> mensagem dos formatos aceitos, exit 2.
- PDF sem bloco de irregularidades -> "nao encontrei bloco", exit 2.