### PR TITLE
NAD preliminar: itens do modelo do DET e PDF para levar impresso

### DIFF
--- a/_scripts/det_criar.py
+++ b/_scripts/det_criar.py
@@ -80,14 +80,25 @@ def recuperar_crua(token: str, codigo: str) -> dict:
     return json.loads(det_baixar._requisicao(token, f"/notificacoes/{uid}").decode("utf-8"))
 
 
-def listar_modelos(token: str, id_modelo=None, cif=None) -> list[dict]:
+def listar_modelos(token: str, id_modelo=None, cif=None, autoria="T") -> list[dict]:
     """POST /modelos-notificacao com filtro (mesmo corpo do site) — devolve a
     lista de modelos. `id_modelo` é a Identificação que o AFT vê; `cif` filtra
-    por auditor (modelo de equipe). Leitura pura."""
+    por auditor (modelo de equipe). Leitura pura.
+
+    `autoria` é o mesmo seletor dos três botões da tela de pesquisa:
+      "M" somente meus modelos · "P" somente públicos · "T" todos os cadastrados.
+    O padrão aqui é **"T"**, e isso é uma decisão, não um detalhe: o AFT usa
+    modelo de COLEGA (identificação + CIF de outro auditor) como se fosse
+    canônico da equipe. Até 22/08/2026 este código mandava "M" — copiado do
+    filtro PADRÃO do site — e por isso só achava modelo do próprio auditor:
+    modelo de colega voltava "não encontrado", sem explicação. Nem todo modelo
+    compartilhado é "público": no teste, nem o do AFT nem o do colega apareciam
+    em "P", e só "T" alcançava os dois."""
     filtro = {"isPesquisaPadrao": False,
               "idModelo": int(id_modelo) if id_modelo else None,
               "cifAuditor": str(cif) if cif else None,
-              "tituloModelo": None, "tituloNotificacao": None, "autoria": "M"}
+              "tituloModelo": None, "tituloNotificacao": None,
+              "autoria": autoria}
     r = json.loads(det_baixar._requisicao(
         token, "/modelos-notificacao", corpo=filtro, metodo="POST").decode("utf-8"))
     return r if isinstance(r, list) else (r.get("modelos") or [])
@@ -113,6 +124,29 @@ def recuperar_modelo(token: str, id_modelo, cif=None) -> dict:
         return alvo
     return json.loads(det_baixar._requisicao(
         token, f"/modelos-notificacao/{uid}").decode("utf-8"))
+
+
+def itens_do_modelo(token: str, id_modelo, cif=None) -> list[dict]:
+    """Os itens que um modelo do DET carrega — a lista padrão de documentos que
+    o AFT (ou um colega) consagrou. Leitura pura.
+
+    Ficam em `modelositem` (minúsculas, como todo o detalhe do modelo), e o
+    texto vem SEM o formato canônico da TN-NCO: são frases inteiras, do jeito
+    que o auditor as escreveu. Devolve o essencial de cada um, já com os nomes
+    que o resto deste módulo usa."""
+    modelo = recuperar_modelo(token, id_modelo, cif=cif)
+    saida = []
+    for it in (modelo.get("modelositem") or []):
+        desc = (it.get("descricao") or "").strip()
+        if not desc:
+            continue
+        saida.append({"descricao": desc,
+                      "tipo": it.get("tipo"),
+                      "retorno": it.get("tipoRetornoSolicitado"),
+                      "tiposArquivos": it.get("tiposArquivos"),
+                      "preAssinalado": it.get("preAssinalado"),
+                      "grupo": it.get("nmgrupo") or it.get("grupo")})
+    return saida
 
 
 def recuperar_detalhe_ri(token: str, ri: str) -> dict:
@@ -167,12 +201,56 @@ def auditor_do_token(token: str) -> dict:
             "nome": d.get("name") or "", "cif": str(d.get("sit_cif") or "")}
 
 
+RE_CABECALHO = re.compile(r"^#{1,6}\s*(.+?)\s*$")
+
+
+def _indice_secao(linhas: list[str], prefixo: str) -> int | None:
+    """Índice do cabeçalho markdown cujo nome começa por `prefixo` (sem acento,
+    minúsculas). None se o arquivo não tiver esse cabeçalho."""
+    for i, ln in enumerate(linhas):
+        m = RE_CABECALHO.match(ln.strip())
+        if m and _sem_acento(m.group(1)).lower().startswith(prefixo):
+            return i
+    return None
+
+
+def _fim_da_secao(linhas: list[str], inicio: int) -> int:
+    """Onde termina a seção que começa em `inicio`: no próximo cabeçalho."""
+    for i in range(inicio + 1, len(linhas)):
+        if RE_CABECALHO.match(linhas[i].strip()):
+            return i
+    return len(linhas)
+
+
 def itens_da_tn_nco(texto: str) -> list[dict]:
-    """Extrai os itens de uma TN-NCO (.md). Cada linha "*Título* - norma:
-    texto [ementa]" vira um item. Devolve [{titulo, ementa, descricao}] na
-    ordem do arquivo; `descricao` é a linha INTEIRA (texto do item no DET)."""
+    """Extrai os itens de um .md de notificação (TN-NCO ou NAD).
+
+    Dois formatos, e o explícito manda:
+
+    1. **Seção `## Itens`** — cada parágrafo dela é um item, siga ou não o
+       formato canônico. É o que permite gravar no arquivo os itens que vieram
+       de um MODELO do DET, cujo texto é frase corrida ("Carta com nomes,
+       telefones e e-mails dos prepostos..."), sem título nem ementa.
+    2. **Sem essa seção** — vale a regra de sempre: cada linha no formato
+       "*Título* - norma: texto [ementa]" é um item. É o que mantém válidos os
+       arquivos gerados antes de 22/08/2026.
+
+    Devolve [{titulo, ementa, descricao}] na ordem do arquivo; `descricao` é o
+    texto INTEIRO do item, como vai para o DET."""
+    _, corpo = separar_frontmatter(texto)
+    linhas = corpo.splitlines()
+    i = _indice_secao(linhas, "itens")
+    if i is not None:
+        trecho = linhas[i + 1:_fim_da_secao(linhas, i)]
+        itens = []
+        for p in _paragrafos(trecho):
+            m = RE_ITEM_TN.match(p)
+            itens.append({"titulo": m.group("titulo").strip() if m else None,
+                          "ementa": m.group("ementa") if m else None,
+                          "descricao": p})
+        return itens
     itens = []
-    for linha in texto.splitlines():
+    for linha in linhas:
         linha = linha.strip()
         m = RE_ITEM_TN.match(linha)
         if m:
@@ -358,6 +436,13 @@ def parametros_do_md(texto: str) -> dict:
         p["preassinalado"] = _verdadeiro(simples["preassinalado"])
     if simples.get("arquivos"):
         p["arquivos"] = simples["arquivos"]
+    # o modelo do DET que originou a notificação (identificação e, se for de
+    # colega, a CIF dele) — fica no arquivo para a criação não depender da
+    # conversa nem do aft-config.md de quem rodar
+    if simples.get("modelo"):
+        p["modelo"] = re.sub(r"\D", "", simples["modelo"]) or None
+    if simples.get("cif"):
+        p["cif"] = re.sub(r"\D", "", simples["cif"]) or None
     if excecoes:
         limpas = {}
         for ordem, campos in excecoes.items():
@@ -398,6 +483,19 @@ def secoes_da_tn_nco(texto: str) -> dict:
     """
     _, corpo = separar_frontmatter(texto)   # a configuração não é introdução
     linhas = corpo.splitlines()
+    # Com a seção "## Itens" explícita, ela é a fronteira: o que vem antes é
+    # introdução, o que vem depois é observação. É o mesmo recorte de sempre,
+    # só que declarado em vez de deduzido.
+    i = _indice_secao(linhas, "itens")
+    if i is not None:
+        antes, depois = linhas[:i], linhas[_fim_da_secao(linhas, i):]
+        for j, ln in enumerate(depois):
+            m = RE_CABECALHO.match(ln.strip())
+            if m and _sem_acento(m.group(1)).lower().startswith("observa"):
+                depois = depois[j + 1:]
+                break
+        return {"introducao": [p for p in _paragrafos(antes) if p],
+                "observacoes": _blocos_rotulados(depois)}
     idx_itens = [i for i, ln in enumerate(linhas) if RE_ITEM_TN.match(ln.strip())]
     if not idx_itens:
         return {"introducao": [], "observacoes": []}
@@ -529,8 +627,17 @@ def enriquecer(payload: dict, token: str, ri: str,
                 payload["textosInformativosPadraoAtivos"] = txt
             if modelo.get("tipoAbrangencia") is not None:
                 payload["tipoAbrangencia"] = modelo["tipoAbrangencia"]
-            if modelo.get("titulo") and not manter_titulo:
-                payload["titulo"] = modelo["titulo"]
+            # ATENÇÃO ao nome do campo: o DETALHE do modelo devolve as chaves em
+            # MINÚSCULAS e com outro nome — `titulonotificacao`, `titulomodelo`,
+            # `modelositem` —, diferente do JSON de uma notificação (`titulo`,
+            # `itens`). Procurar `titulo` aqui nunca achava nada, e a notificação
+            # saía com o título genérico do toolkit em vez do título do modelo
+            # (numa NAD, "Notificação para Apresentação de Documentos").
+            titulo_do_modelo = modelo.get("titulonotificacao") or modelo.get("titulo")
+            if titulo_do_modelo and not manter_titulo:
+                payload["titulo"] = titulo_do_modelo
+            relato["titulo_do_modelo"] = titulo_do_modelo
+            relato["itens_no_modelo"] = len(modelo.get("modelositem") or [])
             relato.update(modelo=bool(modelo), observacoes=len(obs), textos=len(txt))
         except Exception as e:
             relato["modelo_erro"] = str(e)[:150]
@@ -585,8 +692,10 @@ def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo=None,
     bruto = alvo.read_text(encoding="utf-8")
     itens = itens_da_tn_nco(bruto)
     if not itens:
-        raise RuntimeError(f"nenhum item reconhecido em {arquivo_tn} "
-                           "(formato esperado: *Título* - norma: texto [ementa])")
+        raise RuntimeError(
+            f"nenhum item reconhecido em {arquivo_tn} — esperado uma seção "
+            "'## Itens' (um parágrafo por item) ou linhas no formato "
+            "'*Título* - norma: texto [ementa]'")
     ri, cnpj = ids_do_memory((pasta_os / "memory.md").read_text(encoding="utf-8"))
     if not ri:
         raise RuntimeError("RI não encontrado no memory.md da OS")
@@ -598,6 +707,8 @@ def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo=None,
         return do_md.get(chave, padrao)
 
     titulo = escolher(titulo, "titulo", "Termo de Notificação")
+    id_modelo = escolher(id_modelo, "modelo", None)
+    cif = escolher(cif, "cif", None)
     tipo = escolher(tipo, "tipo", TIPO_CUMPRIMENTO_OBRIGACAO)
     retorno = escolher(retorno, "retorno", RETORNO_DIGITAL)
     preassinalado = escolher(preassinalado, "preassinalado", True)
@@ -787,10 +898,9 @@ def revisar_payload(payload: dict) -> list[dict]:
             anota("impede", onde,
                   "entrega digital sem nenhum tipo de arquivo aceito — a empresa "
                   "não teria como anexar")
-        if not RE_ITEM_TN.match(desc):
-            anota("aviso", onde,
-                  "fora do formato *Título* - norma: exigência [ementa] "
-                  "(pode ser item sem ementa, que é legítimo)")
+        # (não se confere aqui o FORMATO do texto do item: um item vindo de
+        # modelo do DET é frase corrida, sem título nem ementa, e é legítimo.
+        # Julgar a redação é trabalho do subagente revisor, que lê o .md.)
 
     obs = payload.get("observacoes") or []
     intro = [o for o in obs if o.get("tipoTexto") == 0]
@@ -817,6 +927,41 @@ def revisar_payload(payload: dict) -> list[dict]:
 
 def _impedimentos(achados: list[dict]) -> list[dict]:
     return [a for a in achados if a["gravidade"] == "impede"]
+
+
+# Linhas em branco que o DET acrescenta ao PDF de um rascunho, para o AFT
+# preencher itens à mão no local. É o padrão do próprio site (0 a 100).
+LINHAS_PDF_RASCUNHO = 5
+
+
+def baixar_pdf_rascunho(token: str, uid: str, codigo: str, pasta_os: Path,
+                        linhas: int = LINHAS_PDF_RASCUNHO) -> Path:
+    """Baixa o PDF de uma notificação EM ELABORAÇÃO e grava no pacote da OS.
+
+    É o "Gerar PDF da Notificação para download" do site:
+    GET /notificacoes/{uid}/pdf?numeroDeLinhas=N. No rascunho o site pergunta o
+    N (padrão 5) — são linhas em branco para o AFT completar itens à mão na
+    empresa; na notificação já lavrada ele manda 0 sem perguntar.
+
+    O arquivo sai como `notificacao-<CODIGO>-rascunho.pdf`, e o sufixo NÃO é
+    enfeite: o `det_baixar` grava a versão lavrada como
+    `notificacao-<CODIGO>.pdf` e PULA o download quando o arquivo já existe.
+    Mesmo nome faria o rascunho ocupar o lugar do documento definitivo, para
+    sempre e em silêncio."""
+    linhas = max(0, min(int(linhas), 100))
+    # rascunho recém-criado pode voltar sem código; o uid sempre existe e serve
+    # de nome, para o arquivo nunca virar "notificacao-None-rascunho.pdf"
+    codigo = (codigo or uid or "").strip() or uid
+    destino = det_baixar.pasta_do_pacote(pasta_os, codigo) / \
+        f"notificacao-{codigo}-rascunho.pdf"
+    destino.parent.mkdir(parents=True, exist_ok=True)
+    bruto = det_baixar._requisicao(token, f"/notificacoes/{uid}/pdf",
+                                   params={"numeroDeLinhas": linhas},
+                                   timeout=det_baixar.TIMEOUT_BLOB)
+    if not bruto:
+        raise RuntimeError("o DET devolveu um PDF vazio")
+    destino.write_bytes(bruto)
+    return destino
 
 
 def _put_rascunho(token: str, uid: str, corpo: dict) -> dict:

--- a/_scripts/servir_painel.py
+++ b/_scripts/servir_painel.py
@@ -899,6 +899,16 @@ class Handler(BaseHTTPRequestHandler):
             if not p.get("confirmar"):
                 return self._json(200, {"ok": True, "previa": True, "resumo": resumo})
             res = det_criar.criar_rascunho(token, payload)
+            # PDF do rascunho, para o AFT levar impresso e assinar na empresa
+            # (é a NAD preliminar). Só quando pedido: gera arquivo na pasta.
+            if p.get("pdf"):
+                try:
+                    caminho = det_criar.baixar_pdf_rascunho(
+                        token, res["uid"], res["codigo"], alvo,
+                        linhas=p.get("pdf_linhas", det_criar.LINHAS_PDF_RASCUNHO))
+                    res["pdf"] = str(caminho)
+                except Exception as e:
+                    res["pdf_erro"] = f"{type(e).__name__}: {e}"
             self._json(200, {"ok": True, "previa": False, "resumo": resumo, **res})
         except det_baixar.TokenExpirado as e:
             _DET_TOKEN["token"] = None

--- a/aft-NAD/SKILL.md
+++ b/aft-NAD/SKILL.md
@@ -49,10 +49,32 @@ Guarde: `PASTA_OS`, `EMPREGADOR`.
 
 ---
 
+## FASE 0.5 — O modelo do DET (a lista que o AFT já consagrou)
+
+Quase todo AFT tem, no DET, um **modelo de notificação** com a lista de documentos que ele sempre pede no início da fiscalização — e pode adotar o modelo de um colega. Puxar esses itens evita reescrever o que já está pronto.
+
+1. **Ache o número do modelo**, nesta ordem:
+   - o campo `modelo_nad_det` do `aft-config.md` (e `cif_modelo_nad`, a CIF do dono do modelo);
+   - **sem esses campos, use o modelo canônico do toolkit: identificação `11301`, CIF `358070`** — a "Primeira notificação", com a lista que serve a qualquer início de fiscalização (contato dos prepostos, relação de prestadores de serviço, PGR com inventário e plano de ação, relação de máquinas do item 12.18.1 da NR-12). Diga ao AFT qual modelo está usando, e que ele pode trocar pelo dele gravando os dois campos no `aft-config.md`.
+   - se ele disser que não quer modelo nenhum, siga sem — a skill funciona igual.
+
+> **Modelo de outro auditor funciona, e não precisa ser "público".** A busca usa o filtro "todos os modelos cadastrados"; basta a identificação e a CIF do dono. Nunca peça ao colega para marcar o modelo como público.
+2. **Puxe os itens** (precisa do painel no ar e do token — `~/.claude/skills/config/canal-token-det.md`):
+   ```bash
+   python ~/.claude/skills/_scripts/det_criar.py   # itens_do_modelo(token, id_modelo, cif)
+   ```
+   Na prática, quem chama é o painel; sem token, ofereça abrir o DET no seu navegador para o AFT logar.
+3. **Mostre os itens do modelo ao AFT** e deixe-o riscar o que não quer. Eles entram como estão — texto do modelo é do AFT, não se reescreve.
+
+> **Sem token ou sem modelo, não trave.** Diga em uma linha que a lista virá só da FASE 1 e siga.
+
+---
+
 ## FASE 1 — Coletar os documentos a solicitar
 
-A fonte é **contexto da sessão + lista colada** (a skill detecta):
+A fonte é **os itens do modelo (FASE 0.5) + contexto da sessão + lista colada** (a skill detecta):
 
+0. **Do modelo:** os itens aprovados na FASE 0.5 entram primeiro, na ordem do modelo.
 1. **Encadeada:** se a sessão já contém um checklist de documentos aprovado pelo AFT (saída de `/aft-preparacao-acao-fiscal`), reaproveite-o direto.
 2. **Colada:** se o AFT colou uma lista de documentos no prompt, use-a.
 3. **Standalone sem lista:** pergunte ao AFT quais documentos solicitar. Pode oferecer um catálogo comum como ponto de partida (PGR, PCMSO, ASOs, controles de jornada — AFD/AEJ, atas da CIPA, certificados de treinamento NR-XX, folha de pagamento, contratos de trabalho, laudo/AET), mas **não presuma** — o AFT decide o que pedir. **Nunca** ofereça "livro/ficha de registro de empregados": o registro é feito no eSocial, e livro/ficha não existem mais.
@@ -185,14 +207,68 @@ Dúvidas:
 ```
 ````
 
-Em seguida, **salve o documento completo** (introdução + todos os itens em sequência + observações, sem os rótulos "📋 ITEM N") na pasta da OS:
+Em seguida, **salve o documento completo** na pasta da OS:
 
 ```bash
 PATH_MD="$PASTA_OS/nad-$(date +%Y-%m-%d).md"
 # Se já existe arquivo do mesmo dia, adicione sufixo -2, -3...
 ```
 
-Confirme ao AFT: arquivo salvo + nº de itens. Se não houver pasta de OS resolvida, pergunte onde salvar.
+O arquivo tem **quatro partes**, nesta ordem — é o formato que permite criar a notificação no DET depois, sem depender da conversa:
+
+````markdown
+---
+det:
+  titulo: Notificação para Apresentação de Documentos
+  prazo_dias: 16          # ou prazo: dd/mm/aaaa
+  tipo: solicitacao       # a NAD é Solicitação de Documento
+  retorno: digital        # a empresa anexa pelo DET
+  preassinalado: sim
+  arquivos: todos
+  modelo: 11301           # só se veio de modelo (FASE 0.5)
+  cif: 358070             # a CIF do DONO do modelo
+---
+
+# Notificação para Apresentação de Documentos
+
+<introdução, copiada literalmente>
+
+## Itens
+
+<um parágrafo por item — os do modelo entram com o texto do modelo,
+ os redigidos aqui entram no formato *Título* - base legal: Apresentar... [ementa]>
+
+## Observações
+
+<os blocos "Rótulo:" + linhas ">">
+````
+
+> **Por que a seção `## Itens` existe.** Item vindo de modelo do DET é frase corrida, sem título nem ementa — não casa com o formato canônico. Com a seção declarada, o motor lê **cada parágrafo** dela como um item, venha do modelo ou da sua redação. Arquivos antigos, sem a seção, continuam valendo pela regra de sempre.
+
+Confirme ao AFT, em uma linha cada: arquivo salvo + nº de itens (dizendo quantos vieram do modelo); **a data de prazo que ficou**, e que ela pode ser alterada direto no DET. Se não houver pasta de OS resolvida, pergunte onde salvar.
+
+---
+
+## FASE 4.5 — Criar o rascunho no DET (ofereça)
+
+Com o painel local no ar e o **RI** no `memory.md`, ofereça criar o rascunho da notificação no DET a partir do `.md` — em segundos, sem digitar item por item no site.
+
+1. **Token:** siga `~/.claude/skills/config/canal-token-det.md`. Sem token, **ofereça abrir o DET no navegador do assistente** para o AFT logar (via principal) ou peça o Sincronizar da extensão.
+2. **Prévia primeiro:** `POST /api/det-criar` sem `confirmar` — devolve o que seria gravado, com a conferência automática já aplicada.
+3. **Revisor:** chame a tool `Agent` com `subagent_type: "aft-revisor-notificacao"`, passando o caminho do `.md` e o JSON da prévia. Mostre o parecer.
+4. **Só com o "sim" do AFT**, repita com `confirmar: true`.
+5. **Sem RI no `memory.md`**, diga isso em uma linha e não ofereça — OS recém-criada pode ainda não ter o número.
+
+> O toolkit **nunca lavra**. O rascunho fica "Em Elaboração" no DET; conferir, lavrar e transmitir são atos do AFT, no site.
+
+### O PDF para levar impresso (só na NAD preliminar)
+
+Quando a notificação vai ser **entregue em mãos na empresa** — o caso da NAD preliminar, gerada na preparação, antes da visita —, acrescente `"pdf": true` à chamada de criação. O PDF do **rascunho** é baixado para o pacote da OS, em `NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/notificacao-<CODIGO>-rascunho.pdf`.
+
+- **5 linhas em branco** ao final, o padrão do próprio DET (`pdf_linhas`, de 0 a 100): são para o AFT completar itens à mão, no local.
+- O PDF sai **sem número de notificação** ("NOTIFICAÇÃO Nº." em branco) — é rascunho, o número só existe depois da lavratura. **É o esperado neste fluxo**: o AFT entrega o papel na empresa e colhe a assinatura durante a inspeção física.
+- **Só neste caso.** Nas demais NADs, a notificação é transmitida pelo DET e não há o que imprimir; o PDF definitivo vem depois, pela `/aft-det-baixar`.
+- O sufixo `-rascunho` no nome **não é enfeite**: a `/aft-det-baixar` grava a versão lavrada como `notificacao-<CODIGO>.pdf` e pula o download se o arquivo já existir. Mesmo nome faria o rascunho tomar o lugar do documento definitivo, em silêncio.
 
 ---
 
@@ -210,7 +286,7 @@ Não bloqueie o fluxo se o `memory.md` não existir. Não toque em outras seçõ
 
 - **Origem natural:** ao final de `/aft-preparacao-acao-fiscal`, quando o checklist de documentos a solicitar for aprovado pelo AFT.
 - **Também standalone**, a qualquer momento: quando o AFT quer pedir mais documentos durante uma fiscalização já em andamento.
-- Depois de gerar, o AFT cola os blocos manualmente no DET (o toolkit não automatiza o preenchimento do DET).
+- **Criar o rascunho no DET** (FASE 4.5): com o painel no ar e o RI conhecido, o toolkit monta a notificação a partir do `.md`, sempre com o `aft-revisor-notificacao` passando antes e com a lavratura ficando para o AFT. Sem painel, ele cola os blocos à mão — por isso a FASE 4 continua entregando cada bloco pronto para copiar.
 - **Depois de lavrada no DET:** ofereça `/aft-email` para redigir o e-mail que avisa a empresa (ou o advogado) da notificação nova.
 - Não confundir com `/aft-tn-nco` (verbo "Corrigir", para irregularidade já constatada).
 

--- a/aft-preparacao-acao-fiscal/SKILL.md
+++ b/aft-preparacao-acao-fiscal/SKILL.md
@@ -443,6 +443,22 @@ A partir da denúncia, dos temas e das **ementas da OS** (FASE 1.1), monte uma l
    - **Sim** → encadeie a skill `/aft-NAD` passando a lista aprovada (ela faz a busca de ementa e monta o texto — não duplique essa lógica aqui).
    - **Não/depois** → apenas registre a lista aprovada no `preparacao.md` como pendência, para rodar `/aft-NAD` mais tarde.
 
+### A NAD preliminar (a notificação que se leva em mãos)
+
+**Ofereça sempre aqui, no fim da preparação — nunca no começo.** A NAD preliminar é a notificação que o AFT leva impressa, entrega na empresa e tem assinada durante a inspeção física. Ela precisa existir **antes** da visita, e só neste ponto da skill se sabe o que aquela OS pede: CNAE, grau de risco, histórico de acidentes, temas da denúncia e o checklist da FASE 5 já estão levantados. Perguntar no início seria pedir uma decisão sem essa informação.
+
+Ao oferecer, diga com essas palavras — "a notificação que o senhor leva em mãos e entrega assinada na empresa" —, porque é o que faz o AFT entender por que vale gastar dois minutos agora.
+
+**Aceito, o roteiro é este:**
+
+1. **Login.** Sem token do DET, **abra o site no navegador do assistente** e peça o login do AFT (via principal — `~/.claude/skills/config/canal-token-det.md`). Nunca peça a senha, nunca a guarde. Sem navegador próprio, peça o **Sincronizar** da extensão.
+2. **Itens.** Encadeie a `/aft-NAD`: ela puxa os itens do **modelo canônico** (identificação `11301`, CIF `358070`, ou o que estiver no `aft-config.md`) e o checklist desta preparação acrescenta o que for específico daquela OS. O AFT risca o que não quiser.
+3. **Prévia + revisor**, e só com o "sim" dele a criação (FASE 4.5 da `/aft-NAD`).
+4. **PDF do rascunho** (`"pdf": true`, 5 linhas em branco) gravado no pacote da OS, para ele imprimir e levar.
+5. **Sem RI no `memory.md`**, diga em uma linha que a criação fica para quando o número existir — e siga: o `.md` continua servindo para colar à mão.
+
+> **Por que o PDF é do rascunho, e não da lavrada.** Neste fluxo o papel é entregue **em mãos** e assinado no local; a notificação ainda não foi transmitida, então sai sem número ("NOTIFICAÇÃO Nº." em branco). É o esperado — e é o único caso em que se imprime rascunho. A lavratura continua sendo ato do AFT, no site, depois da visita.
+
 ---
 
 ## FASE 6 — Gravar o preparacao.md
@@ -650,7 +666,7 @@ Próximos passos:
 - Chama `/aft-relatorio-acidentes` (FASE 4.5) para o histórico de CATs do CNPJ — o script dela processa tudo localmente e grava em `Acidentes/`; a preparação usa só os agregados.
 - Chama `/aft-cnpjs-endereco` (FASE 4.6) para descobrir outros CNPJs no CEP do local e os indícios de grupo econômico — só o CEP vai ao site de busca; o cruzamento é local.
 - Usa a biblioteca `modelo_docx.py` (`/aft-modelo-docx`) para o `preparacao.docx` (FASE 7) — o padrão visual do toolkit, com o cabeçalho institucional da lotação do AFT.
-- Encadeia `/aft-NAD` (FASE 5) quando o AFT aprova gerar a notificação já na preparação.
+- Encadeia `/aft-NAD` (FASE 5) quando o AFT aprova gerar a notificação já na preparação — é a **NAD preliminar**, que ele leva em mãos e entrega assinada na empresa. Aquela skill puxa os itens do modelo do DET e, com o RI conhecido, oferece criar o rascunho no site; a lavratura continua sendo ato do AFT.
 - Delega à `/aft-consulta` toda dúvida técnica, pesquisa de ementa e enquadramento — esta skill não consulta NotebookLM. Se o AFT pedir aprofundamento em um tema durante a preparação, aponte a `/aft-consulta` (ou chame-a, se ele quiser na hora).
 - Sucede naturalmente para `/aft-inspecao-fisica` depois da visita (fora do escopo desta skill).
 - Não confundir com `/aft-inspecao-fisica` (relato do que já foi constatado, DEPOIS da visita).

--- a/arquitetura/DET criar/arquitetura-det-criar.json
+++ b/arquitetura/DET criar/arquitetura-det-criar.json
@@ -261,6 +261,10 @@
   {
    "data": "22/08/2026 (tarde)",
    "o_que_provou": "com o item 5 pedido como Vistoria e o 6 como Orientação: o 5 saiu sem tipos de arquivo, o 6 teve o retorno corrigido para Sem Retorno e perdeu o prazo, e os demais seguiram digitais com todos os arquivos. Combinações impossíveis forçadas à mão foram barradas pela conferência."
+  },
+  {
+   "data": "22/08/2026 (fim da tarde)",
+   "o_que_provou": "NAD criada a partir de modelo de OUTRO auditor (9 itens) e a partir do modelo canônico (4 itens), ambas lidas de volta do DET; PDF do rascunho baixado pelo painel com as 5 linhas em branco conferidas no texto extraído do PDF."
   }
  ],
  "parametros_do_endpoint": {
@@ -345,5 +349,25 @@
   "tipos_de_arquivo": "habilitados SOMENTE em Digital (allowEnableArquivos === DIGITAL no código do site). Padrão do toolkit: todos os grupos marcados",
   "autocorrecao": "montar_payload usa retorno_padrao(tipo, preferido): se o tipo não aceita o retorno pedido, cai no padrão daquele tipo. É o que impede um item de Orientação de nascer digital só porque digital é o padrão da skill",
   "barreira": "revisar_payload marca como 'impede' a combinação fora da tabela, o item com arquivo em retorno não-digital e a entrega digital sem nenhum tipo de arquivo"
+ },
+ "modelos_de_notificacao": {
+  "busca": "POST /modelos-notificacao com {idModelo, cifAuditor, autoria}. autoria: M meus · P públicos · T todos os cadastrados. O toolkit usa SEMPRE 'T' — com 'M' (o filtro padrão do site, copiado por engano) o modelo de colega nunca era encontrado.",
+  "modelo_de_colega": "funciona sem ser público: nem o do AFT nem o do colega apareciam em 'P', e 'T' alcançava os dois. Basta identificação + CIF do dono.",
+  "chaves_em_minusculas": "o DETALHE do modelo usa outros nomes que o JSON de uma notificação: `modelositem` (não `itens`), `titulonotificacao` (não `titulo`), `titulomodelo`. Procurar `itens`/`titulo` ali não acha nada — e o toolkit passou semanas sem ver que modelo carrega itens.",
+  "o_que_o_modelo_carrega": "itens (texto corrido, com tipo/retorno/tiposArquivos/preAssinalado próprios), observações (introdução tipoTexto 0 + observações tipoTexto 1) e o título da notificação",
+  "modelo_canonico_do_toolkit": "identificação 11301, CIF 358070 — a 'Primeira notificação'. Padrão de fábrica da NAD preliminar, trocável em aft-config.md (modelo_nad_det e cif_modelo_nad). É diferente de número embutido em skill: o AFT troca sem tocar em código."
+ },
+ "pdf_do_rascunho": {
+  "endpoint": "GET /notificacoes/{uid}/pdf?numeroDeLinhas=N",
+  "numeroDeLinhas": "0 a 100; o site pergunta (padrão 5) quando a notificação está EM ELABORAÇÃO e manda 0 quando já lavrada. São linhas em branco para o AFT completar itens à mão.",
+  "quando_usar": "SÓ na NAD preliminar, que é entregue em mãos e assinada na inspeção física. Sai sem número de notificação (o número só existe após a lavratura) — e isso é o esperado nesse fluxo.",
+  "nome_do_arquivo": "notificacao-<CODIGO>-rascunho.pdf, dentro do pacote NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/. O sufixo é ESSENCIAL: det_baixar grava a lavrada como notificacao-<CODIGO>.pdf e pula o download se o arquivo existir — mesmo nome faria o rascunho tomar o lugar do definitivo, em silêncio.",
+  "como_pedir": "POST /api/det-criar com confirmar:true e pdf:true (pdf_linhas opcional)"
+ },
+ "itens_no_md": {
+  "secao_itens": "o .md aceita uma seção '## Itens' em que CADA PARÁGRAFO é um item, siga ou não o formato canônico. Existe porque item vindo de modelo é frase corrida, sem título nem ementa.",
+  "compatibilidade": "sem a seção, vale a regra antiga (linhas '*Título* - norma: texto [ementa]') — os .md gerados antes de 22/08/2026 continuam válidos, conferido nos arquivos reais que existiam.",
+  "fronteira": "com a seção declarada, ela também separa introdução (antes) de observações (depois), no lugar da dedução por posição.",
+  "decisao_do_aft": "os itens do modelo são GRAVADOS no .md, não puxados na hora: o arquivo vira o registro completo, o AFT pode riscar itens antes de criar, e a criação não depende de o modelo continuar existindo no DET."
  }
 }

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -964,6 +964,10 @@ const ARCH = {
   {
    "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
    "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
+  },
+  {
+   "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
+   "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
   }
  ],
  "diferencas": [

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -831,6 +831,10 @@
   {
    "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
    "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
+  },
+  {
+   "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
+   "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
   }
  ],
  "diferencas": [

--- a/novidades/2026-08-22-04-nad-preliminar-modelo-e-pdf.md
+++ b/novidades/2026-08-22-04-nad-preliminar-modelo-e-pdf.md
@@ -1,0 +1,34 @@
+## 22/08/2026
+<!-- commit: nad-preliminar-modelo-e-pdf -->
+
+**A notificação que você leva em mãos agora sai pronta da preparação da ação
+fiscal — com PDF para imprimir.** Ao final da `/aft-preparacao-acao-fiscal`, o
+toolkit passa a oferecer a **NAD preliminar**: aquela que você entrega na empresa
+e tem assinada durante a inspeção física. A oferta é no fim, e não no começo, de
+propósito — só depois de levantar CNAE, grau de risco, acidentes e os temas da
+denúncia dá para saber se aquela OS pede algum documento além do padrão.
+
+Aceitando, o caminho é curto: se faltar acesso ao DET, o assistente **abre o site
+no navegador dele e pede o seu login** (a senha continua sendo só sua, e nunca é
+guardada). Em seguida ele monta a notificação, mostra a prévia com o parecer do
+revisor, e só cria depois do seu "sim". No fim, grava na pasta da OS o **PDF do
+rascunho, com 5 linhas em branco** ao final — as mesmas que o DET oferece, para
+você completar itens à mão no local. Como é rascunho, o papel sai sem número de
+notificação: é o esperado quando a entrega é presencial, e a lavratura continua
+sendo o seu clique, depois da visita.
+
+**A lista de documentos já vem pronta do seu modelo do DET.** O toolkit passou a
+ler os itens do modelo de notificação — coisa que ele nunca tinha conseguido
+fazer —, então a sua "primeira notificação" de sempre aparece inteira, e o
+checklist da preparação só acrescenta o que for específico daquela fiscalização.
+De fábrica vem o modelo 11301 (contato dos prepostos, relação de prestadores de
+serviço, PGR com inventário e plano de ação, relação de máquinas da NR-12); para
+usar o seu, basta gravar `modelo_nad_det` e `cif_modelo_nad` no `aft-config.md`.
+
+**Modelo de colega funciona — e não precisa ser "público".** A busca por modelos
+estava limitada a "somente meus modelos", herança de um filtro padrão do site: o
+modelo de outro auditor simplesmente não era encontrado, sem explicação. Agora a
+busca é em "todos os modelos cadastrados". Basta a identificação do modelo e a
+CIF de quem o criou; nada precisa ser marcado como público.
+
+---


### PR DESCRIPTION
## O que o AFT ganha

Ao final da `/aft-preparacao-acao-fiscal`, o toolkit passa a oferecer a **NAD preliminar** — a notificação que ele entrega em mãos na empresa e tem assinada durante a inspeção física.

**A oferta é no fim, não no começo**, e o motivo está escrito na skill: só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão.

Fluxo: abre o DET no navegador do assistente para o AFT logar → puxa os itens do modelo → prévia → subagente revisor → criação → **PDF do rascunho com 5 linhas em branco** na pasta da OS.

## Dois defeitos corrigidos

Os dois invisíveis até alguém testar com o modelo de **outro** auditor:

1. **`autoria: "M"`** — `listar_modelos` mandava "somente meus modelos", copiado do filtro *padrão* do site. Modelo de colega nunca era encontrado, sem explicação. Agora manda `"T"`. **Modelo compartilhado não precisa ser público**: no teste, nem o do AFT nem o do colega apareciam em `"P"`, e só `"T"` alcançava os dois.
2. **Chaves do modelo em minúsculas** — o detalhe do modelo usa `modelositem` (não `itens`) e `titulonotificacao` (não `titulo`). O código procurava as segundas: o título nunca era aplicado e **os itens do modelo eram invisíveis**. O modelo canônico tem 4; o do colega, 9.

## Novidades técnicas

- `itens_do_modelo()` lê a lista de documentos do modelo;
- o `.md` aceita uma seção `## Itens` em que **cada parágrafo é um item**, siga ou não o formato canônico (item de modelo é frase corrida). Sem a seção, vale a regra antiga — os `.md` anteriores continuam válidos, conferido nos arquivos reais;
- `baixar_pdf_rascunho()`: `GET /notificacoes/{uid}/pdf?numeroDeLinhas=5`, gravado como `notificacao-<CODIGO>-rascunho.pdf`. **O sufixo é essencial**: a `/aft-det-baixar` grava a lavrada como `notificacao-<CODIGO>.pdf` e pula o download se o arquivo existir — mesmo nome faria o rascunho tomar o lugar do definitivo, em silêncio;
- modelo canônico de fábrica `11301`/`358070`, trocável por `modelo_nad_det` e `cif_modelo_nad` no `aft-config.md`.

## Testado

NAD criada a partir do modelo de outro auditor (9 itens) e do modelo canônico (4 itens), ambas lidas de volta do DET. PDF baixado pelo painel e as 5 linhas em branco conferidas no texto extraído do PDF. O toolkit **nunca lavra**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)