### PR TITLE
Baixar so as notificacoes do DET, e a regra anti-improvisacao do token

### DIFF
--- a/_scripts/det_baixar.py
+++ b/_scripts/det_baixar.py
@@ -325,6 +325,50 @@ def _salvar(destino: Path, conteudo: bytes) -> bool:
     return True
 
 
+def baixar_so_notificacao(pasta_os: Path, token: str, codigo: str) -> dict:
+    """Baixa SÓ o documento da notificação (o PDF), sem os arquivos que o
+    empregador entregou, sem o Relatório de Atendimento e sem o canal.
+
+    Serve para ler o que foi notificado sem puxar megabytes de anexos — o caso
+    de quem quer o histórico de notificações de uma empresa, não o conteúdo das
+    entregas.
+
+    **Não registra a visualização no DET, de propósito.** O download completo
+    faz as mesmas leituras que o site faz ao abrir a notificação, e com isso
+    apaga o triângulo amarelo de "atualização pendente". Aqui não: o AFT não
+    olhou o que a empresa entregou, então o alerta tem de continuar na tela
+    dele. Apagar o aviso sem ter visto o conteúdo seria mentir para o próprio
+    auditor."""
+    codigo = (codigo or "").strip().upper()
+    if not re.fullmatch(r"[A-Z0-9]{6,}", codigo):
+        raise ValueError(f"código de notificação inválido: {codigo!r}")
+    r = {"ok": True, "codigo": codigo, "pasta": pasta_os.name,
+         "so_notificacao": True, "baixados": 0, "ja_existiam": 0, "erros": []}
+    n = pesquisar_por_codigo(token, codigo)
+    if not n:
+        raise RuntimeError(f"notificação {codigo} não encontrada no DET "
+                           "(confira o código)")
+    uid = n.get("uid")
+    if not uid:
+        raise RuntimeError(f"notificação {codigo} veio sem uid na pesquisa")
+    raiz = pasta_do_pacote(pasta_os, codigo)
+    destino = raiz / f"notificacao-{codigo}.pdf"
+    r["pacote"] = str(raiz)
+    if destino.exists() and destino.stat().st_size > 0:
+        r["ja_existiam"] = 1
+        return r
+    raiz.mkdir(parents=True, exist_ok=True)
+    # numeroDeLinhas=0 é o que o próprio site passa no download direto
+    bruto = _requisicao(token, f"/notificacoes/{uid}/pdf",
+                        params={"numeroDeLinhas": 0}, timeout=TIMEOUT_BLOB)
+    if not bruto:
+        raise RuntimeError("o DET devolveu um PDF vazio")
+    destino.write_bytes(bruto)
+    r["baixados"] = 1
+    r["arquivo"] = str(destino)
+    return r
+
+
 def baixar_notificacao(pasta_os: Path, token: str, codigo: str) -> dict:
     """Baixa os 2 PDFs e os arquivos de todos os itens para a pasta da OS.
     Um arquivo com erro não derruba os demais; token vencido derruba tudo
@@ -605,13 +649,14 @@ def _registrar_no_memory(pasta_os: Path, r: dict) -> None:
         r["erros"].append(f"registro no memory.md: {e}")
 
 
-def via_painel(pasta: str, codigo: str, porta: int = 8347) -> dict:
+def via_painel(pasta: str, codigo: str, porta: int = 8347,
+               so_notificacao: bool = False) -> dict:
     """POST /api/det-baixar no servidor local do painel (o token mora lá).
     `pasta` pode ser o caminho completo ou só o nome da pasta da OS.
     Devolve o JSON da resposta — inclusive o 409 de token vencido, para o
     chamador orientar o Sincronizar sem tratar exceção."""
-    corpo = json.dumps({"pasta": Path(pasta).name,
-                        "codigo": codigo}).encode("utf-8")
+    corpo = json.dumps({"pasta": Path(pasta).name, "codigo": codigo,
+                        "so_notificacao": bool(so_notificacao)}).encode("utf-8")
     req = urllib.request.Request(
         f"http://127.0.0.1:{porta}/api/det-baixar", data=corpo,
         headers={"Content-Type": "application/json"}, method="POST")
@@ -632,15 +677,21 @@ def via_painel(pasta: str, codigo: str, porta: int = 8347) -> dict:
 if __name__ == "__main__":
     if hasattr(sys.stdout, "reconfigure"):  # console Windows é cp1252
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-    if len(sys.argv) == 4 and sys.argv[1] == "--via-painel":
-        print(json.dumps(via_painel(sys.argv[2], sys.argv[3]),
+    argv = [a for a in sys.argv[1:] if a != "--so-notificacao"]
+    so_notif = "--so-notificacao" in sys.argv
+    if len(argv) == 3 and argv[0] == "--via-painel":
+        print(json.dumps(via_painel(argv[1], argv[2], so_notificacao=so_notif),
                          ensure_ascii=False, indent=2))
-    elif len(sys.argv) == 4:
-        print(json.dumps(baixar_notificacao(Path(sys.argv[1]), sys.argv[3],
-                                            sys.argv[2]),
+    elif len(argv) == 3:
+        motor = baixar_so_notificacao if so_notif else baixar_notificacao
+        print(json.dumps(motor(Path(argv[0]), argv[2], argv[1]),
                          ensure_ascii=False, indent=2))
     else:
-        print("uso: python det_baixar.py --via-painel \"<pasta da OS>\" <CODIGO>\n"
-              "     python det_baixar.py \"<pasta da OS>\" <CODIGO> <token>",
+        print("uso: python det_baixar.py [--so-notificacao] --via-painel "
+              "\"<pasta da OS>\" <CODIGO>\n"
+              "     python det_baixar.py [--so-notificacao] \"<pasta da OS>\" "
+              "<CODIGO> <token>\n\n"
+              "  --so-notificacao: baixa só o PDF do documento — sem os arquivos\n"
+              "  entregues pelo empregador, e sem apagar o alerta amarelo do DET",
               file=sys.stderr)
         sys.exit(1)

--- a/_scripts/servir_painel.py
+++ b/_scripts/servir_painel.py
@@ -1107,7 +1107,11 @@ class Handler(BaseHTTPRequestHandler):
                                         "erro": "sem token do DET — abra a aba do DET "
                                                 "e clique em Sincronizar; depois tente "
                                                 "de novo (vale 25 min)"})
-            r = det_baixar.baixar_notificacao(alvo, token, p.get("codigo") or "")
+            # so_notificacao: só o PDF do documento, sem os anexos do
+            # empregador e sem registrar a visualização (ver det_baixar)
+            motor = (det_baixar.baixar_so_notificacao if p.get("so_notificacao")
+                     else det_baixar.baixar_notificacao)
+            r = motor(alvo, token, p.get("codigo") or "")
             self._json(200, r)
         except det_baixar.TokenExpirado as e:
             _DET_TOKEN["token"] = None

--- a/aft-NAD/SKILL.md
+++ b/aft-NAD/SKILL.md
@@ -59,12 +59,15 @@ Quase todo AFT tem, no DET, um **modelo de notificação** com a lista de docume
    - se ele disser que não quer modelo nenhum, siga sem — a skill funciona igual.
 
 > **Modelo de outro auditor funciona, e não precisa ser "público".** A busca usa o filtro "todos os modelos cadastrados"; basta a identificação e a CIF do dono. Nunca peça ao colega para marcar o modelo como público.
-2. **Puxe os itens** (precisa do painel no ar e do token — `~/.claude/skills/config/canal-token-det.md`):
-   ```bash
-   python ~/.claude/skills/_scripts/det_criar.py   # itens_do_modelo(token, id_modelo, cif)
-   ```
-   Na prática, quem chama é o painel; sem token, ofereça abrir o DET no seu navegador para o AFT logar.
+
+2. **Puxe os itens** (precisa do painel no ar e do token — `~/.claude/skills/config/canal-token-det.md`). Na prática quem chama é o painel; sem token, ofereça abrir o DET no seu navegador para o AFT logar.
 3. **Mostre os itens do modelo ao AFT** e deixe-o riscar o que não quer. Eles entram como estão — texto do modelo é do AFT, não se reescreve.
+
+> **Faltou token do DET? Não improvise.** O `canal-token-det.md` diz como obtê-lo
+> **nesta sessão** (com ou sem navegador do assistente) e, sobretudo, o que NÃO
+> tentar: a página do DET **não** consegue falar com o painel local, e quem tenta
+> esse caminho conclui, errado, que a via principal não funciona. Falta de token
+> nunca justifica inventar caminho novo nem dizer ao AFT que o toolkit quebrou.
 
 > **Sem token ou sem modelo, não trave.** Diga em uma linha que a lista virá só da FASE 1 e siga.
 

--- a/aft-det-baixar-notificacoes/SKILL.md
+++ b/aft-det-baixar-notificacoes/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: aft-det-baixar-notificacoes
+model: sonnet
+effort: low
+description: >
+  Use quando o AFT quiser baixar do DET SÓ os documentos das notificações de
+  uma empresa — o PDF de cada notificação, SEM os arquivos que o empregador
+  entregou. Dispare com /aft-det-baixar-notificacoes, "baixa as notificações do
+  DET dessa empresa", "só as notificações, não os arquivos enviados", "quero os
+  PDFs das notificações da empresa X", "traz o histórico de notificações do
+  DET". Aceita CNPJ, nome do empregador ou código de notificação; sem
+  argumento, pergunta de qual empresa. Para o pacote COMPLETO (com o Relatório
+  de Atendimento, o canal de comunicação e os arquivos entregues), a skill é
+  /aft-det-baixar.
+---
+
+# aft-det-baixar-notificacoes — só os documentos das notificações
+**AFT Toolkit**
+
+> **Onde ficam as pastas das OS.** Nunca presuma o caminho: resolva **uma vez,
+> no início**, e use o que voltar onde este texto disser `<OS_ATIVAS>`.
+>
+> ```bash
+> python ~/.claude/skills/_scripts/pasta_aft.py --os-ativas
+> ```
+>
+> No Windows, invoque o Python pelo `python_path` do `aft-config.md`.
+
+## O que esta skill faz (e o que não faz)
+
+Baixa **apenas o PDF de cada notificação** — o documento que o AFT lavrou e o
+empregador recebeu. Serve para ler o que foi notificado, montar o histórico de
+uma empresa ou conferir o texto de uma notificação antiga, **sem puxar os
+anexos** que o empregador enviou (que podem ser centenas de megabytes).
+
+Não baixa: os arquivos entregues, o Relatório de Atendimento, o histórico dos
+itens nem o canal de comunicação. Para isso, use a **`/aft-det-baixar`**.
+
+> **Não apaga o alerta amarelo do DET, de propósito.** O download completo faz
+> as mesmas leituras que o site faz ao abrir a notificação, e por isso apaga o
+> aviso "Existe atualização pendente". Aqui não: o AFT **não olhou** o que a
+> empresa entregou, então o alerta continua na tela dele. Apagar o aviso sem ter
+> visto o conteúdo seria mentir para o próprio auditor. Diga isso ao AFT quando
+> ele perguntar por que o triângulo continua lá.
+
+## Passo 0 — Servidor do painel no ar
+
+```bash
+curl -s http://127.0.0.1:8347/api/ping
+```
+
+Sem resposta: suba com
+`python ~/.claude/skills/_scripts/instalar_servidor_painel.py reiniciar`.
+
+O token do DET chega por uma de duas vias, descritas em
+`~/.claude/skills/config/canal-token-det.md` — **leia esse arquivo quando faltar
+token**, e não repita o procedimento aqui. O token nunca passa por esta conversa.
+
+> **Faltou token do DET? Não improvise.** Siga o `~/.claude/skills/config/canal-token-det.md`: ele diz como obter o token **nesta sessão** (com ou sem navegador do assistente) e, sobretudo, o que NÃO tentar. Em particular, a página do DET **não** consegue falar com o painel local — quem tenta esse caminho conclui, errado, que a via principal não funciona. Falta de token nunca justifica inventar caminho novo nem dizer ao AFT que o toolkit está quebrado.
+
+## Passo 1 — Resolver (pasta da OS, códigos)
+
+- **CNPJ ou nome do empregador** → ache a pasta em `<OS_ATIVAS>`; os códigos são
+  as linhas checkbox da seção `## Notificações DET` do `memory.md`.
+- **Código de notificação** (alfanumérico maiúsculo) → ache em qual `memory.md`
+  ele aparece.
+- **Sem argumento** → pergunte de qual empresa se trata.
+
+**Mostre a lista antes de baixar** e confirme com o AFT, dizendo quantas são.
+Notificação marcada `CANCELADA no DET` fica de fora, salvo pedido expresso.
+Ausente da ficha: peça uma sincronização com o DET e tente de novo.
+
+## Passo 2 — Baixar (uma chamada por código)
+
+```bash
+python ~/.claude/skills/_scripts/det_baixar.py --so-notificacao --via-painel "<pasta da OS>" <CODIGO>
+```
+
+Leia o JSON: `baixados`, `ja_existiam`, `pacote`. Cada PDF vai para
+`NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/notificacao-<CODIGO>.pdf`, o mesmo pacote que
+a `/aft-det-baixar` usa — se depois o AFT quiser o conteúdo completo daquela
+notificação, tudo se acumula na mesma pasta, sem duplicar.
+
+- `token_expirado: true` → renove conforme o `canal-token-det.md` e repita.
+- `painel_fora: true` → volte ao Passo 0.
+- Outro erro → registre e **siga para o próximo código**; nunca trave o lote.
+
+## Passo 3 — Relatório final
+
+Uma mensagem só, com o caminho de verdade da pasta:
+
+```
+Notificações DET — <EMPREGADOR>
+
+Baixadas (N): <CODIGO> (X páginas) · ...
+Já existiam (N): ...
+Falhas (N): <código — erro em linguagem simples>
+```
+
+Se o AFT quiser o que a empresa entregou em alguma delas, ofereça a
+`/aft-det-baixar` para aquele código.
+
+## Regras
+
+- **Nunca** exponha token ou senha do DET no chat, em log ou em arquivo.
+- Pasta da OS sempre via `pasta_aft.py` — nunca presuma o caminho.
+- Um código com erro não interrompe os demais.
+- Esta skill não julga documento nenhum: baixar é o fim dela. A análise do que
+  foi notificado é `/aft-auditoria-geral`.
+
+## Diário de atividades (automático)
+
+Ao concluir, registre o dia trabalhado na OS — sem perguntar nada ao AFT (o
+script deduplica por data+letra; repetir é inofensivo):
+
+```bash
+python ~/.claude/skills/_scripts/diario_registrar.py "<pasta da OS>" --tipos D --detalhe "notificações do DET baixadas"
+```

--- a/aft-det-baixar/SKILL.md
+++ b/aft-det-baixar/SKILL.md
@@ -37,8 +37,16 @@ sessão do DET. Ele chega por uma de duas vias — **1) o navegador do próprio
 assistente** (principal) ou **2) a extensão Chrome "Sync DET"** (alternativa) —
 descritas em `~/.claude/skills/config/canal-token-det.md`. **Leia esse arquivo
 quando faltar token**; não repita o procedimento aqui. Esta skill só dispara o
-download pelo servidor — o token nunca passa por esta conversa. O que chega vai todo para o pacote da notificação, dentro de
-`NOTIFICACOES/` (a raiz da OS fica limpa):
+download pelo servidor — o token nunca passa por esta conversa.
+
+> **Faltou token do DET? Não improvise.** O `canal-token-det.md` diz como obtê-lo
+> **nesta sessão** (com ou sem navegador do assistente) e, sobretudo, o que NÃO
+> tentar: a página do DET **não** consegue falar com o painel local, e quem tenta
+> esse caminho conclui, errado, que a via principal não funciona. Falta de token
+> nunca justifica inventar caminho novo nem dizer ao AFT que o toolkit quebrou.
+
+O que chega vai todo para o pacote da notificação, dentro de `NOTIFICACOES/`
+(a raiz da OS fica limpa):
 
 ```
 <OS>/NOTIFICACOES/<CODIGO> <dd-mm-aaaa>/   ← data do primeiro download
@@ -138,3 +146,7 @@ e, depois, `/aft-auditoria-geral`.
 - Pasta da OS sempre via `pasta_aft.py` — nunca presuma o caminho.
 - Um código com erro não interrompe os demais.
 - Esta skill não julga documento nenhum: baixar é o fim dela.
+- **Só os documentos das notificações**, sem os arquivos que o empregador
+  entregou (para ler o que foi notificado sem puxar os anexos): é a
+  `/aft-det-baixar-notificacoes`. Ofereça-a quando o AFT disser que não quer as
+  entregas, ou quando o lote for grande e ele só quiser o histórico.

--- a/aft-nova-auditoria/SKILL.md
+++ b/aft-nova-auditoria/SKILL.md
@@ -111,7 +111,7 @@ Pergunte em uma única mensagem (deixe claro o que é opcional):
 
 > Trabalhadores/CNAE/grau de risco quase nunca são conhecidos ao abrir a OS — são **opcionais** aqui. Se o AFT não informar, deixe vazios: as skills `/aft-auditoria-geral` e `/aft-inspecao-fisica` os coletam depois (dos documentos ou perguntando uma vez).
 >
-> **Sem RI, avise o AFT** (uma frase, sem bloquear o cadastro): *"Sem o RI, o sync automático do DET (extensão Chrome) não vai importar as notificações desta auditoria — você pode informar agora ou completar depois no memory.md."* Se o AFT não souber o RI ainda (comum ao abrir a OS antes da 1ª notificação), siga sem — o `det_sync.py` adota sozinho o RI da primeira notificação confirmada e grava no front-matter, então o aviso é só para quem já tem o RI em mãos e esqueceria de informar.
+> **Sem RI, avise o AFT** (uma frase, sem bloquear o cadastro): *"Sem o RI, a sincronização com o DET não vai importar as notificações desta auditoria — você pode informar agora ou completar depois no memory.md."* Se o AFT não souber o RI ainda (comum ao abrir a OS antes da 1ª notificação), siga sem — o `det_sync.py` adota sozinho o RI da primeira notificação confirmada e grava no front-matter, então o aviso é só para quem já tem o RI em mãos e esqueceria de informar.
 
 > Se o AFT ainda não notificou nada pelo DET, deixe a seção de DET vazia — dá para
 > acrescentar depois (basta editar o `memory.md` ou rodar `/aft-det-630`/`/aft-nova-auditoria` de novo).

--- a/aft-painel/SKILL.md
+++ b/aft-painel/SKILL.md
@@ -181,6 +181,8 @@ python ~/.claude/skills/_scripts/servir_painel.py "<OS_ATIVAS>" --abrir
   **a extensão Chrome "Sync DET"** (alternativa, com o botão flutuante **Sincronizar** no
   site) —, descritas em `~/.claude/skills/config/canal-token-det.md`.
 
+> **Faltou token do DET? Não improvise.** Siga o `~/.claude/skills/config/canal-token-det.md`: ele diz como obter o token **nesta sessão** (com ou sem navegador do assistente) e, sobretudo, o que NÃO tentar. Em particular, a página do DET **não** consegue falar com o painel local — quem tenta esse caminho conclui, errado, que a via principal não funciona. Falta de token nunca justifica inventar caminho novo nem dizer ao AFT que o toolkit está quebrado.
+
 ## Passo 4 — (Opcional) Publicar na aba Artefatos
 
 Este passo é **opt-in**: só execute se o AFT pedir ("publica o painel", "atualiza o

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -395,6 +395,8 @@ Não bloqueie o fluxo se o `memory.md` não existir. Não toque em outras seçõ
 - Sem o painel, o AFT cola os blocos manualmente no DET.
 - **Depois de lavrada no DET:** ofereça `/aft-email` para redigir o e-mail que avisa a empresa (ou o advogado) da notificação nova.
 
+> **Faltou token do DET? Não improvise.** Siga o `~/.claude/skills/config/canal-token-det.md`: ele diz como obter o token **nesta sessão** (com ou sem navegador do assistente) e, sobretudo, o que NÃO tentar. Em particular, a página do DET **não** consegue falar com o painel local — quem tenta esse caminho conclui, errado, que a via principal não funciona. Falta de token nunca justifica inventar caminho novo nem dizer ao AFT que o toolkit está quebrado.
+
 ---
 
 ## Regras

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -134,10 +134,10 @@
 const ARCH = {
  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
  "repo": "github.com/ryckardo42/aft-toolkit",
- "data": "2026-08-23",
+ "data": "2026-08-24",
  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
  "stats": {
-  "skills": 51,
+  "skills": 52,
   "scripts": 42,
   "dados": 6,
   "commit": "ver `git log -1` — atualizado em 23/08/2026"
@@ -295,6 +295,11 @@ const ARCH = {
      "nome": "/aft-det-baixar",
      "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da OS. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
      "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
+    },
+    {
+     "nome": "/aft-det-baixar-notificacoes",
+     "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da /aft-det-baixar, então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
+     "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
     },
     {
      "nome": "/aft-nova-skill",

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -1,10 +1,10 @@
 {
  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
  "repo": "github.com/ryckardo42/aft-toolkit",
- "data": "2026-08-23",
+ "data": "2026-08-24",
  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
  "stats": {
-  "skills": 51,
+  "skills": 52,
   "scripts": 42,
   "dados": 6,
   "commit": "ver `git log -1` — atualizado em 23/08/2026"
@@ -162,6 +162,11 @@
      "nome": "/aft-det-baixar",
      "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da OS. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
      "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
+    },
+    {
+     "nome": "/aft-det-baixar-notificacoes",
+     "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da /aft-det-baixar, então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
+     "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
     },
     {
      "nome": "/aft-nova-skill",

--- a/config/canal-token-det.md
+++ b/config/canal-token-det.md
@@ -18,17 +18,32 @@ Vale quando o assistente tem navegador próprio (é o caso do Claude Code no app
 de desktop). **É a via preferida**: não depende de extensão aprovada em loja
 nenhuma, não exige instalação e a entrega é instantânea.
 
+> **Antes de começar, confira se você tem ferramenta de navegador** (algo como
+> `javascript_tool`/`navigate` na sua lista de ferramentas). **Não tendo, vá
+> direto para a Via 2** e diga ao AFT, em uma frase, que nesta sessão o token
+> vem pelo Sincronizar da extensão. Não anuncie falha nem tente contornar: é
+> diferença de ambiente, não defeito. Idem se a execução de JavaScript no
+> navegador estiver bloqueada por permissão — uma tentativa, e siga para a Via 2.
+
 1. Abra (ou peça ao AFT que abra) `https://auditor-det.sit.trabalho.gov.br` no
    navegador do assistente e confirme que ele está **logado**. O login é sempre
    do AFT: o assistente não digita senha nem preenche credencial.
 2. Leia o token do armazenamento da própria página:
    `sessionStorage.getItem('token')` — é onde o site do DET o guarda (não é
    `localStorage`).
-3. Entregue ao painel **pela entrada padrão**, nunca como argumento de comando:
+3. Entregue ao painel **pelo terminal**, com o token na entrada padrão e nunca
+   como argumento de comando:
 
    ```bash
    printf '%s' "<token>" | python ~/.claude/skills/_scripts/det_token.py --gravar
    ```
+
+   > **Nunca tente fazer a PÁGINA do DET chamar o painel.** Uma página servida em
+   > `https://` não alcança `http://127.0.0.1` — o navegador barra, e nem um
+   > `GET /api/ping` passa (política de rede privada). É por isso que a extensão
+   > da Via 2 precisa de um *service worker*: aquele contexto não sofre a
+   > restrição, a página sofre. Quem tenta esse caminho conclui, errado, que a
+   > Via 1 não funciona — **a entrega é feita pelo terminal, e funciona**.
 
 4. Confira quanto tempo resta, quando precisar:
 

--- a/novidades/2026-08-24-01-baixar-so-notificacoes.md
+++ b/novidades/2026-08-24-01-baixar-so-notificacoes.md
@@ -1,0 +1,23 @@
+## 24/08/2026
+<!-- commit: baixar-so-notificacoes -->
+
+**Agora dá para baixar só as notificações do DET, sem os arquivos que a empresa
+enviou.** A skill nova `/aft-det-baixar-notificacoes` traz apenas o PDF de cada
+notificação — o documento que você lavrou —, sem o Relatório de Atendimento, sem
+o canal de comunicação e sem os anexos do empregador, que podem somar centenas de
+megabytes. Serve para ler o que foi notificado, montar o histórico de uma empresa
+ou conferir o texto de uma notificação antiga. Peça com "baixa só as notificações
+dessa empresa" ou "só as notificações, não os arquivos enviados". Para o pacote
+completo, a skill continua sendo a `/aft-det-baixar`.
+
+Os PDFs vão para a mesma pasta de sempre (`NOTIFICACOES/<código> <data>/`), então
+se depois você quiser o conteúdo completo daquela notificação, tudo se acumula no
+mesmo lugar, sem duplicar.
+
+**Uma diferença de propósito:** este modo **não apaga** o alerta amarelo de
+"atualização pendente" no DET. O download completo apaga, porque faz as mesmas
+leituras que o site faz quando você abre a notificação. Aqui não faria sentido:
+você não olhou o que a empresa entregou, então o aviso continua na sua tela. O
+toolkit não vai limpar um alerta que você ainda precisa ver.
+
+---


### PR DESCRIPTION
## Skill nova: `/aft-det-baixar-notificacoes`

Baixa **só o PDF de cada notificação** — sem os arquivos entregues pelo empregador, sem Relatório de Atendimento e sem canal. Para ler o que foi notificado ou montar o histórico de uma empresa sem puxar anexos de centenas de MB.

Motor: `det_baixar.py --so-notificacao`. Grava no **mesmo** pacote `NOTIFICACOES/<COD> <dd-mm-aaaa>/` da irmã completa, então o download completo depois se acumula sem duplicar.

**Decisão central:** este modo **não registra a visualização** no DET — o triângulo amarelo continua na tela. O AFT não olhou o que a empresa entregou; apagar o aviso seria o toolkit mentir para o próprio auditor. Foi isso que ditou a forma: função separada, para não herdar os passos de registro de visualização.

## Correção da causa-raiz de um caso real

Uma sessão tentou fazer a **página** do DET chamar o painel local, foi barrada pelo navegador (política de rede privada) e concluiu **ao AFT** que "a Via 1 não é viável" e que só a extensão funciona. A via principal estava intacta — a entrega é feita **pelo terminal**.

A omissão era do texto: dizia *o que* fazer sem dizer *de onde*. O `config/canal-token-det.md` ganhou:

- aviso explícito de **nunca** fazer a página falar com o painel, com o porquê (é por isso que a extensão precisa de um *service worker*);
- **passo zero**: conferir se a sessão tem ferramenta de navegador e, não tendo, ir direto para a Via 2 **sem anunciar fracasso** (Codex/Antigravity não têm).

E as **seis** skills que acessam o DET passaram a trazer a mesma regra curta — *faltou token, não improvise* —, como ponteiro e advertência, nunca cópia do procedimento.

## Testado

Modo novo em duas OS reais: ~4,4 s por notificação, idempotente (repetiu e respondeu "já existia"). Via 1 provada de ponta a ponta nesta sessão, do painel sem token até o download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)