### PR TITLE
feat(pgrtr): nova skill /aft-PGRTR-analise (NR-31, trabalho rural)

### DIFF
--- a/aft-PGRTR-analise/SKILL.md
+++ b/aft-PGRTR-analise/SKILL.md
@@ -1,0 +1,951 @@
+---
+name: aft-PGRTR-analise
+model: opus
+description: >
+  Use quando o AFT pedir para analisar, auditar ou revisar um Programa de
+  Gerenciamento de Riscos do Trabalho Rural (PGRTR) à luz da NR-31. Acione com
+  "analisar PGRTR", "auditar PGRTR", "PGRTR da fazenda/empresa", "PGRTR
+  apresentado", trabalho rural, fazenda, produtor rural, os códigos de ementa
+  231084-8 a 231148-8, ou ao anexar PDF de PGRTR de estabelecimento rural.
+  Varre a base fixa de ementas de NR-31 e oferece a redação dos autos. NÃO
+  confundir com /aft-PGR-analise (PGR sob a NR-01, ambiente geral/urbano).
+---
+
+# PGRTR-analise — Análise de PGRTR (NR-31, trabalho rural)
+**AFT Toolkit**
+
+> **Onde ficam as pastas das OS.** O AFT pode ter mudado a pasta de trabalho de
+> lugar (HD externo, nuvem, outro disco). Nunca presuma `~/Documents/AFT`:
+> resolva **uma vez, no início**, e use o que voltar onde este texto disser
+> `<OS_ATIVAS>` (a pasta que contém as OS) ou `<PASTA_AFT>` (a pasta acima dela).
+>
+> **Nas mensagens ao AFT, escreva o caminho de verdade** — nunca ecoe
+> `<OS_ATIVAS>`/`<PASTA_AFT>` na tela: ele precisa saber onde abrir a pasta.
+>
+> ```bash
+> python ~/.claude/skills/_scripts/pasta_aft.py --os-ativas   # -> <OS_ATIVAS>
+> python ~/.claude/skills/_scripts/pasta_aft.py --path        # -> <PASTA_AFT>
+> ```
+
+## Objetivo
+
+Analisar um Programa de Gerenciamento de Riscos do Trabalho Rural (PGRTR) — e, quando
+disponíveis, o PCMSO, os Atestados de Saúde Ocupacional (ASO), as Fichas de Fornecimento
+de EPI e a Análise Ergonômica Preliminar/do Trabalho (AEP/AET) — sob a ótica da NR-31,
+identificando irregularidades enquadráveis na base fixa de ementas ao final deste skill.
+O resultado é uma análise ementa por ementa, com citação de página e confronto com os
+achados da inspeção física, e a oferta de redigir os autos de infração (formato
+`/aft-gera-ai`) e uma carta de recomendação para o produtor rural.
+
+**Não confundir com `/aft-PGR-analise`** (PGR sob a NR-01, ambiente geral/urbano): são
+normas, documentos e ementas completamente diferentes.
+
+---
+
+## Fluxo de execução
+
+### Etapa 1: Receber e registrar o contexto da inspeção física (obrigatório)
+
+> **Princípio:** o PGRTR não é auditado no vácuo. É um documento que deve refletir a
+> realidade do estabelecimento rural. Todo risco e toda irregularidade que o AFT
+> constatou in loco é evidência direta para esta análise: se o PGRTR não identifica, não
+> avalia ou não trata um risco que existe de fato na propriedade, isso configura
+> irregularidade nas ementas correspondentes. Por isso, **a captura do contexto de campo
+> antecede a leitura do PGRTR.**
+
+**Localize a pasta da OS.** Determine a pasta da empresa/fazenda em `<OS_ATIVAS>/`. Se o
+AFT já citou o empregador rural, a fazenda ou o CNPJ/CPF na conversa, use-a; senão,
+pergunte qual OS (ou liste as candidatas).
+
+**Procure o `inspecao-fisica.md` antes de perguntar.** Esse arquivo é a fonte primária
+do contexto de campo:
+
+```bash
+ls "<OS_ATIVAS>"/"<PASTA_EMPRESA>"/inspecao-fisica.md
+```
+
+- **Encontrado:** leia-o e use seu conteúdo como a lista de achados de campo (modo
+  confronto). Apresente um resumo ao AFT e confirme: *"Carreguei o contexto de campo de
+  `inspecao-fisica.md`: [resumo dos achados]. Confirma que uso isso para confrontar o
+  PGRTR?"*
+- **Não encontrado:** caia para a pergunta padrão abaixo.
+
+**Caso contrário, comece perguntando** ao AFT pelo contexto da inspeção física — salvo
+se ele já o tiver descrito na conversa. Nesse caso, reaproveite o que já está no
+contexto e apenas confirme.
+
+Pergunta padrão (se não houver `inspecao-fisica.md` e o contexto ainda não foi
+fornecido):
+
+> "Antes de analisar o PGRTR, preciso do contexto da sua inspeção física. Liste os
+> achados e irregularidades constatados in loco — por exemplo: aplicação de agrotóxicos,
+> máquinas e implementos agrícolas sem proteção, trabalho com animais, frentes de
+> trabalho sem área de vivência ou sanitários, alojamento precário, trabalho sob calor
+> extremo, transporte irregular de trabalhadores, terrenos acidentados, condição de
+> risco grave e iminente / interdição lavrada, etc. Se não houve inspeção física e esta
+> é uma análise puramente documental (ex: PGRTR entregue via DET), me diga apenas
+> 'documental'."
+
+**Registre os achados** numa lista interna de trabalho. Para cada achado anote: (a) o
+risco/condição observado, (b) o setor/atividade/frente de trabalho onde foi visto. Essa
+lista é a **lente de confronto** usada na Etapa 4.
+
+**Modo de execução** — defina conforme a resposta:
+
+- **Modo confronto (padrão):** houve inspeção física e o AFT forneceu achados. A análise
+  de cada ementa será confrontada com a lista de campo (Etapa 4).
+- **Modo documental:** o AFT respondeu "documental" (ou equivalente). Prossiga
+  normalmente, mas **marque o relatório** no topo com o aviso: `⚠️ Análise documental
+  apenas — sem confronto com inspeção in loco. Riscos reais não declarados no PGRTR
+  podem não ter sido detectados.` Nesse modo a análise se baseia só no que os documentos
+  trazem.
+
+Não avance para a Etapa 2 sem resolver explicitamente qual é o modo.
+
+---
+
+### Etapa 2: Localizar os documentos e coletar os dados do caso
+
+**Procure os documentos sozinho antes de perguntar**, na pasta da OS inteira
+(`NOTIFICACOES/`, subpastas de resposta ao DET, e raiz), por nome de arquivo
+(case-insensitive):
+
+| Documento | Padrões de nome a procurar |
+|---|---|
+| PGRTR (obrigatório) | contém "PGRTR" ou "PGR" + "rural" |
+| PCMSO | contém "PCMSO" |
+| Atestados de Saúde Ocupacional (ASO) | contém "ASO" ou "atestado" + "saude"/"ocupacional" |
+| Ficha de Fornecimento de EPI | contém "EPI" + "ficha"/"fornecimento" |
+| Análise Ergonômica Preliminar / do Trabalho | contém "AEP", "AET" ou "ergonom" |
+
+Um anexo/texto fornecido explicitamente pelo AFT no chat tem **precedência** sobre a
+busca na pasta. **Prefira sempre o arquivo na pasta da OS:** documento arrastado para o
+chat entra inteiro no contexto da conversa e anula a economia da Etapa 3. Se o AFT
+anexar um PGRTR grande, grave-o na pasta da OS e siga por lá.
+
+Se o PGRTR não for localizado nem fornecido, **não prossiga** — peça-o ao AFT (é o único
+documento obrigatório; os demais são opcionais e enriquecem a análise).
+
+**Notificação (NAD):** não reextraia o código do PDF — leia a seção
+`## Notificações DET` do `memory.md` da OS e use o código e a data de lá. Só procure o
+PDF diretamente se o `memory.md` não tiver notificação cadastrada.
+
+**Dados a coletar antes de perguntar** (procure no `memory.md`, na capa do PGRTR, ou no
+RI/SFIT-WEB antes de perguntar ao AFT; pergunte só o que faltar, numa única mensagem):
+
+- Data de início da fiscalização.
+- Atividade desenvolvida no estabelecimento rural.
+- Nome da fazenda/propriedade e coordenadas GPS (costumam constar no RI do SFIT-WEB,
+  campo "Coordenadas GPS", ou no `memory.md`).
+- Se o empregador rural tem CIPATR ou SESTR.
+- Se os EPIs e dispositivos de proteção pessoal foram fornecidos (confira também a Ficha
+  de Fornecimento de EPI, se localizada).
+
+**Eco de confirmação (uma única mensagem):** antes de iniciar a leitura, mostre o que
+foi encontrado/coletado e pergunte se falta algo ou se pode iniciar:
+
+```
+Documentos identificados para <EMPREGADOR RURAL>:
+  PGRTR: <nome do arquivo ou "não identificado/enviado">
+  PCMSO: <nome do arquivo ou "não identificado/enviado">
+  Atestados de Saúde (ASO): <nome(s) do(s) arquivo(s) ou "não identificado/enviado">
+  Ficha de Fornecimento de EPI: <nome do arquivo ou "não identificado/enviado">
+  AEP/AET: <nome do arquivo ou "não identificado/enviado">
+  Notificação (NAD): <código, se localizado no memory.md, ou "não localizada">
+
+  Data de início da fiscalização: <data ou "a confirmar">
+  Atividade desenvolvida: <atividade ou "a confirmar">
+  Fazenda/coordenadas: <dados ou "a confirmar">
+  CIPATR/SESTR: <resposta ou "a confirmar">
+  EPIs fornecidos: <resposta ou "a confirmar">
+  Contexto de campo: <modo confronto (resumo) ou modo documental>
+
+Está correto? Posso iniciar a análise, ou você quer enviar/apontar mais algum arquivo
+ou corrigir algum dado?
+```
+
+---
+
+### Etapa 3: Leitura do PGRTR — delegue ao agente extrator
+
+PGRTR costuma passar de cem páginas. Lido direto na conversa, ele consome o contexto e o
+limite de uso do AFT, e é **recobrado a cada turno** da análise — o que estoura o plano
+no meio do trabalho. Por isso a leitura é feita fora da conversa, por um agente próprio.
+
+**Antes de medir, veja se o extrato já existe.** Se
+`<OS_ATIVAS>/[PASTA_EMPRESA]/pgrtr-extrato.md` já estiver na pasta, a extração já foi
+feita — por uma execução anterior deste skill, ou por um fluxo que extraiu os documentos
+numa triagem inicial. Confira que ele cobre os blocos do roteiro abaixo e **siga direto
+para "Analise sobre o extrato"**: não meça o PDF nem delegue de novo. Extrair duas vezes
+o mesmo PGRTR é o desperdício mais caro deste skill. Só refaça a extração se o extrato
+estiver vazio, truncado ou visivelmente fora do roteiro e, nesse caso, diga ao AFT em
+uma linha por que está refazendo.
+
+Descubra primeiro o tamanho do documento:
+
+```bash
+"<python_path>" ~/.claude/skills/_scripts/pdf_texto_paginado.py "<caminho do PGRTR>" --so-resumo
+```
+
+- **Mais de 20 páginas** (o caso comum): **delegue ao agente `aft-extrator-documento`**,
+  passando no prompt o tipo de documento (PGRTR, NR-31), o caminho do PGRTR, o caminho
+  de saída `<OS_ATIVAS>/[PASTA_EMPRESA]/pgrtr-extrato.md`, o `python_path` e —
+  obrigatoriamente — o **roteiro de extração**, que são os blocos temáticos da base de
+  ementas deste skill:
+
+  1. **Existência, estrutura e custeio do PGRTR** (itens 31.3.1 e 31.3.3.2 da NR-31):
+     quem elaborou (nome, formação, registro profissional), vigência, se há inventário
+     de riscos e Plano de Ação formalizados, responsáveis e prazos das ações, uso da
+     ferramenta digital da SEPRT (até 50 empregados), custeio.
+  2. **Processo de gerenciamento de riscos** (item 31.3.3 e alíneas): levantamento
+     preliminar de perigos, avaliação/classificação dos riscos (matriz, severidade x
+     probabilidade, gradação), medidas de prevenção com prioridades e cronograma,
+     hierarquia de controle (eliminação, coletiva, administrativa, EPI),
+     acompanhamento/verificação dos controles, procedimento de investigação de
+     acidentes e doenças.
+  3. **Inventário de riscos** (itens 31.3.2 e 31.3.3.2.1): cobertura dos cinco grupos
+     de riscos (físicos, químicos, biológicos, ergonômicos, de acidentes), abrangência
+     por função/atividade/frente de trabalho, classificação para fins de plano de ação.
+  4. **Medidas específicas do meio rural** (item 31.3.5, alíneas a-f): trabalho com
+     animais, condições climáticas extremas, organização do trabalho para esforço
+     físico e terrenos acidentados, trânsito interno de trabalhadores e veículos,
+     eliminação de resíduos, faixas de segurança de linhas elétricas.
+  5. **Saúde ocupacional** (itens 31.3.6, 31.3.7 e subitens): planejamento das ações de
+     saúde frente às peculiaridades rurais, exames admissional/periódico/retorno/
+     mudança de risco/demissional, exames complementares conforme riscos e NR-07,
+     exames quando exposição acima do nível de ação, uso dos parâmetros dos Anexos da
+     NR-09 nas avaliações de exposição.
+  6. **CAT, afastamento e acesso à saúde** (itens 31.3.11 e 31.3.12): procedimentos
+     para emissão de CAT, afastamento da exposição e encaminhamento à Previdência
+     diante de doença ocupacional ou alteração biológica; acesso a vacinação e
+     profilaxia de endemias.
+  7. **Comunicação e supervisão** (item 31.2.3 e 31.3.1.3): instruções compreensíveis,
+     treinamentos, supervisão do trabalho, cientificação dos trabalhadores sobre os
+     riscos do inventário e as medidas do plano de ação.
+
+  O agente lê o documento inteiro no contexto dele e devolve um extrato fiel,
+  organizado por esses blocos, com transcrição literal e número de página.
+- **Até 20 páginas:** leia direto, sem delegar — o ganho não compensa a ida e volta.
+- **Documento sem camada de texto** (escaneado; o script avisa em destaque): **delegue
+  mesmo que seja curto.** Sem texto, cada página precisa ser lida como imagem, o que
+  pesa na conversa muito mais do que o número de páginas sugere. Avise o AFT em uma
+  linha, porque muda o que ele pode esperar do resultado:
+
+  > "Este documento veio escaneado, sem texto pesquisável. Vou lê-lo página por página,
+  > o que demora mais; o que ficar ilegível fica sinalizado no extrato para você
+  > conferir no original."
+
+Avise o AFT em uma linha antes de delegar (é uma etapa que demora):
+
+> "O PGRTR tem [N] páginas. Vou extraí-lo em segundo plano antes de analisar, para não
+> estourar o limite da sua conversa. Um instante."
+
+**Documentos adicionais (PCMSO, ASOs, ficha de EPI, AEP/AET):** aplique a mesma régua de
+20 páginas a cada um. Os curtos, leia direto; um PCMSO longo pode ser delegado ao mesmo
+agente (saída `pcmso-extrato.md`), com roteiro restrito ao bloco 5 acima.
+
+#### Analise sobre o extrato
+
+Feita a extração, **a análise das ementas corre sobre o `pgrtr-extrato.md`**, não sobre
+o PDF. O extrato traz a transcrição literal e a página de cada trecho, que é o que a
+citação obrigatória exige.
+
+Duas regras ao usar o extrato:
+
+- **O extrato não julga.** "LOCALIZADO" ali significa apenas que o documento trata do
+  assunto — nunca que o tratamento é adequado. O juízo de cada ementa continua sendo
+  seu, sobre as transcrições.
+- **Volte ao original quando for decisivo.** Se um ponto ficar limítrofe, ou se o
+  extrato registrar incerteza na seção "Limites desta extração", abra **aquelas
+  páginas** do PDF com o Read (parâmetro `pages`) antes de concluir. O extrato é o
+  padrão; o original continua ao alcance.
+
+Se o extrato apontar páginas sem texto extraível que sustentem alguma ementa,
+confira-as visualmente antes de concluir por infração.
+
+**Citação de página:** cite a página do PDF no formato `(pág. X)`, como vem no extrato.
+Se o documento trouxer numeração própria impressa ("Folha X/Y", "Página X") divergente
+da página física do PDF, cite as duas na análise (`pág. X do PDF / Folha Y`) — o auto
+usará a referência que a empresa consegue localizar. Não pergunte nada ao AFT sobre
+paginação: resolva pelo que o documento mostra.
+
+---
+
+### Etapa 4: Análise sequencial pela base de ementas (NR-31)
+
+**Princípio da análise sequencial:** percorra a base de ementas fixa (seção "Base de
+ementas NR-31" ao final) **uma a uma, na ordem em que aparecem**. Para cada ementa:
+
+1. Leia o `o_que_verificar`, a `situacao_comum_de_nao_conformidade` e a
+   `fundamentacao_tecnica_essencial` daquela ementa.
+2. Audite o(s) extrato(s)/documento(s) contra esse guia — considere também as respostas
+   coletadas na Etapa 2 (CIPATR/SESTR, EPIs) como evidência complementar, especialmente
+   para ementas sobre supervisão, comunicação e fornecimento de EPI.
+3. **Confronte com o campo** (modo confronto — ver abaixo).
+4. Se encontrar evidência (ou omissão) que corresponda à irregularidade descrita,
+   registre a não conformidade no formato da Etapa 5.
+5. Senão, siga silenciosamente para a próxima ementa. Ao final, se nenhuma ementa
+   apontou irregularidade, declare isso explicitamente — nunca force enquadramento.
+
+#### Confronto obrigatório campo x PGRTR (modo confronto)
+
+No modo confronto, **cada achado de campo da Etapa 1 deve ser rastreado contra o
+PGRTR** antes de fechar cada ementa. Use este mapeamento como roteiro:
+
+| Achado in loco | Pergunta de confronto | Ementa(s) afetada(s) |
+|---|---|---|
+| Qualquer risco real observado (agrotóxico, máquina agrícola, animal, calor, poeira, terreno) | O risco está no inventário, com o grupo correspondente? | 231107-0 |
+| Risco observado presente mas sem avaliação/gradação | O risco foi avaliado e classificado (severidade x probabilidade)? | 231109-7, 231121-6 |
+| Irregularidade concreta que o plano de ação não trata ou trata sem prazo | Há medida com prioridade e cronograma para isso? | 231110-0, 231116-0 |
+| EPI como única resposta a risco que admitia proteção coletiva | A hierarquia de controle foi respeitada/justificada? | 231111-9 |
+| Proteção existente removida/degradada, controle abandonado | O PGRTR prevê acompanhamento dos controles? | 231112-7 |
+| Condições precárias de vivência, refeição, ferramenta, conforto | O dever geral de condições/higiene/conforto está cumprido? | 231084-8 |
+| Trabalhador sem orientação/supervisão perceptível em campo | Há instrução compreensível e supervisão? Trabalhadores conhecem os riscos? | 231086-4, 231106-2 |
+| Manejo de animais improvisado, sem contenção/imunização | O PGRTR traz medidas para trabalho com animais? | 231124-0 |
+| Trabalho sob intempérie/calor extremo sem regra de parada | Há procedimento para condições climáticas extremas e organização do esforço? | 231125-9, 231126-7 |
+| Tráfego interno perigoso, resíduos acumulados, rede elétrica sobre lavoura | O PGRTR trata trânsito interno, resíduos, faixas de linha elétrica? | 231127-5, 231128-3, 231129-1 |
+| Acidente/doença ocorrido sem investigação | Há procedimento e registros de análise de acidentes? | 231085-6, 231113-5 |
+| ASO vencido/ausente relatado ou constatado | Os exames do 31.3.7 estão em dia? | 231131-3 a 231135-6 |
+
+**Regra de ouro:** se um risco existe de fato no estabelecimento (você o viu) e o PGRTR
+não o identifica, não o avalia ou não o trata, a ausência é evidência **positiva** de
+irregularidade — mais forte do que uma lacuna meramente documental. Cite o achado de
+campo como elemento de convicção ao lado do trecho (ou da ausência) no PGRTR.
+
+**Achados sem correspondência na base de ementas:** alguns achados de campo são
+infrações autônomas de outros itens da NR-31 ou de outras NRs e não dizem respeito ao
+conteúdo do PGRTR. Esta skill é especialista em **PGRTR/NR-31 (gestão de riscos e saúde
+ocupacional rural) e permanece estritamente nesse escopo** — não enquadra, não comenta e
+não gera autos fora dele (para isso, use `/aft-auditoria-geral`). Use esses achados
+apenas, quando couber, como contexto de que o ambiente tem riscos relevantes que o PGRTR
+deveria refletir.
+
+**Análise do PCMSO dentro do PGRTR (item 31.3.7):** se um arquivo de PCMSO for
+fornecido, analise-o especificamente em relação às ementas 231131-3 a 231138-0 (exames
+admissional, periódico, retorno, mudança de risco, demissional, complementares). Se o
+PCMSO não for fornecido, verifique se o próprio PGRTR contempla essa temática antes de
+declarar omissão.
+
+**Princípio da análise exaustiva:** a primeira resposta com a auditoria já deve ser o
+produto final e completo — nunca entregue um relatório parcial ou preliminar. Percorra
+**todas** as ementas da base antes de compilar e apresentar o relatório.
+
+#### Etapa 4.5: Consulta complementar ao ementário oficial
+
+Depois de concluir a análise pela base fixa, faça **uma consulta complementar** ao
+ementário oficial para checar se existe alguma ementa de NR-31 relevante ao caso
+concreto que não esteja na base fixa. Escreva a pergunta num arquivo (evita problema de
+acento no shell), descrevendo em 1-2 frases a situação de fato mais relevante encontrada
+na auditoria que não teve correspondência exata na base fixa, e consulte pelo script do
+toolkit (nunca fixe ID de notebook):
+
+```bash
+python ~/.claude/skills/_scripts/notebooklm_consulta.py nr-31 --prompt-file pergunta.txt
+```
+
+Se precisar de cobertura mais ampla, some uma consulta à key `ementario-sst`. Se a
+consulta apontar uma ementa fora da base fixa, **nunca a use silenciosamente**:
+apresente ao AFT como achado adicional ("A base fixa desta skill não cobre isso, mas o
+ementário oficial aponta a ementa <código> para esta situação — confirma o uso?") e só
+inclua no relatório após confirmação. Se o NotebookLM não estiver configurado ou não
+responder, avise em uma linha e siga só com a base fixa (não é bloqueante).
+
+---
+
+### Etapa 5: Registro, consolidação e salvamento
+
+Cada não conformidade encontrada na Etapa 4 é registrada assim:
+
+```
+### Ementa [código] - [descrição da ementa]
+
+Situação: Não Conforme
+
+Confronto com o campo: [achado in loco relevante e como ele sustenta ou afasta a
+irregularidade; ou "sem achado de campo aplicável" / "modo documental — não aplicável"]
+
+Evidência (trecho do documento analisado): [cite o trecho exato que comprova a
+irregularidade; se for omissão, declare: "Omissão: o documento [nome] não aborda ou
+não contém o requisito obrigatório referente a esta ementa"]
+Localização no documento: [página(s), no formato da Etapa 3, ou justificativa da
+omissão]
+
+Requisito normativo: [item/subitem da NR-31 descumprido, conforme a capitulação legal
+da ementa]
+
+Fundamentação técnica: [explicação de por que a evidência/omissão constitui não
+conformidade, baseada na fundamentação técnica essencial da ementa]
+```
+
+Quando o documento atender ao requisito de uma ementa, **não a inclua no relatório**
+(silêncio = conforme).
+
+Compile todas as não conformidades num único relatório, com cabeçalho:
+
+```
+# Relatório de Auditoria do PGRTR — <EMPREGADOR RURAL>
+
+CNPJ/CPF: <identificador>
+Fazenda/propriedade: <nome> — coordenadas: <se houver>
+Atividade desenvolvida: <atividade>
+Profissional que elaborou o PGRTR: <nome, formação, registro — conforme consta no documento>
+Período de vigência: <datas, se constarem>
+Data de início da fiscalização: <data>
+Notificação (NAD): <código, se houver>
+CIPATR/SESTR: <resposta>
+EPIs fornecidos: <resposta>
+Modo da análise: <confronto com inspeção física de dd/mm/aaaa | documental>
+Documentos analisados: <lista>
+```
+
+Se, após percorrer todas as ementas (fixas + eventual complemento do ementário
+confirmado), nenhuma não conformidade for encontrada, declare isso claramente no lugar
+das seções de ementa.
+
+Salve o relatório completo em `<OS_ATIVAS>/[PASTA_EMPRESA]/analise-PGRTR.md`. Se o
+arquivo já existir de uma análise anterior, faça backup antes de sobrescrever:
+
+```bash
+python ~/.claude/skills/_scripts/backup_arquivo.py "<OS_ATIVAS>/[PASTA_EMPRESA]/analise-PGRTR.md"
+```
+
+---
+
+## Pós-análise: ofertas ao AFT
+
+Ao terminar, faça uma pergunta única:
+
+> "Deseja que eu (1) redija os autos de infração das ementas não conformes (formato
+> pronto para o `/aft-gera-ai`, com o PGRTR como anexo), (2) escreva uma carta de
+> recomendação geral para envio ao produtor rural, ou (3) ambos?"
+
+### 1) Redação dos autos de infração (formato /aft-gera-ai)
+
+Para cada ementa não conforme, gere um bloco no formato consumido pelo `/aft-gera-ai`.
+A linha `Ementa:` usa o código com hífen exatamente como está na base (ex.: `231105-4`)
+— o `/aft-gera-ai` remove o hífen no cod_3.
+
+```
+=== AUTO DE INFRAÇÃO #[N] ===
+Ementa: [código com hífen, ex: 231105-4] - [descrição curta da ementa]
+
+I - DA FISCALIZAÇÃO:
+
+Trata-se de fiscalização mista, realizada nos termos do art. 30, § 3º,
+do Decreto nº 4.552/2002, iniciada em [data_inspecao] no estabelecimento
+rural do empregador acima qualificado, localizado na Fazenda
+[nome_fazenda][, coordenadas [coordenadas_gps]], que desenvolve a
+atividade de [atividade_desenvolvida].
+
+II - IRREGULARIDADE:
+
+[Conteúdo específico da ementa, com base na análise — ver regras abaixo]
+
+ELEMENTOS DE CONVICÇÃO:
+Análise documental do PGRTR apresentado pelo AUTUADO[, elaborado por
+<nome/profissão/registro do responsável técnico>][; PCMSO apresentado][;
+Atestados de Saúde Ocupacional apresentados][; Ficha de Fornecimento de
+EPI apresentada]; inspeção in loco.
+```
+
+> **Não escreva o Subtítulo 3 (OBSERVAÇÕES).** Ele é único, fixo e injetado pelo
+> `/aft-gera-ai` (de `config/blocos_auto.md`) entre o Subtítulo 2 e os ELEMENTOS DE
+> CONVICÇÃO. O template termina, de propósito, no Subtítulo 2 + ELEMENTOS DE CONVICÇÃO.
+
+**Regras de redação do subtítulo 2:**
+
+- **Estruture em parágrafos temáticos — nunca em um bloco único.** Separe com linha em
+  branco: um parágrafo para o enquadramento normativo (conduta + item da NR-31 violado,
+  com a fundamentação técnica essencial da ementa como base), um parágrafo por **grupo
+  temático de constatações relacionadas** (incorpore as citações de página da análise e,
+  no modo confronto, o achado de campo correspondente), e a conclusão jurídica e o
+  parágrafo de dano coletivo sempre isolados, cada um no seu próprio parágrafo, nesta
+  ordem: conclusão jurídica logo após o enquadramento; dano coletivo fechando o bloco. A
+  linha em branco no `autos-pgrtr.md` é o que o `/aft-gera-ai` converte em quebra de
+  linha real (`#13#10`) no Sistema Auditor — um bloco II sem nenhuma quebra interna sai
+  como um único parágrafo gigante e ilegível. Alvo prático: 3 a 6 parágrafos.
+- Descreva os **fatos concretos** com precisão técnica e tom oficial.
+- Cite o **dispositivo da NR-31** violado (item exato e a capitulação da ementa, com o
+  art. 18 da Lei nº 5.889/73).
+- Cite o **profissional responsável pelo PGRTR** (nome, formação, registro — ex.:
+  "Engenheiro de Segurança do Trabalho, CREA/UF 9999") quando constar no documento.
+- **Incorpore as citações de página** geradas na análise (`pág. X`). Não economize
+  palavras: a empresa precisa localizar cada evidência citada.
+- **Conclusão jurídica logo após o enquadramento normativo** (parágrafo próprio):
+  *"Sendo assim, incorreu o empregador na infração ementada supracitada."*
+- Feche o bloco II com o **parágrafo de dano coletivo** (PGRTR é SST), último parágrafo
+  antes de ELEMENTOS DE CONVICÇÃO. Texto canônico:
+
+```
+Dano de natureza coletiva. Conforme a Portaria MTP nº 667/2021, a citação
+nominal do empregado só é necessária quando imprescindível à
+caracterização da infração ou quando a multa se baseia no quantitativo
+de trabalhadores prejudicados. Nas infrações que atingem a coletividade,
+tais como as relativas ao meio ambiente de trabalho (SST), dispensa-se a
+individualização, dado o caráter difuso ou coletivo do bem jurídico
+tutelado (Orientação Técnica SIT nº 2/2022). Contudo, citam-se como
+exemplos de trabalhadores prejudicados [NOME 1], [função], e [NOME 2],
+[função].
+```
+
+  **Exemplo de trabalhador prejudicado (frase final "Contudo, ..."):** se o contexto da
+  fiscalização (inspeção física, narrativa do AFT) identificar trabalhador exposto, cite
+  esse(s). Senão, procure na pasta da OS uma relação de vínculos ativos (ex.:
+  `ImprimirVinculosAtivos*.pdf`) e cite **pelo menos dois** empregados com função
+  compatível com a exposição. Nome em capitalização normal, podendo abreviar (primeiro
+  nome + um sobrenome); função em minúsculas; **nunca cite CPF**. Com um só nome, use o
+  singular ("cita-se como exemplo de trabalhador prejudicado..."). Sem nenhum nome
+  disponível (exceção), encerre em "...(Orientação Técnica SIT nº 2/2022).", sem a
+  frase final.
+- **Dado de saúde individualizado nunca entra no auto.** Quando a evidência vier de
+  ASO, prontuário ou monitoramento biológico, descreva por função/setor ("operador de
+  motosserra do setor de silvicultura"), sem nome, sem CPF e sem dado clínico
+  individual — o exemplo nominal do parágrafo de dano coletivo vem da relação de
+  vínculos/da exposição, nunca do dado clínico.
+- Tom: sóbrio, formal, impessoal, terceira pessoa. Sem travessões.
+- **Acentuação completa e obrigatória.** Escreva o subtítulo 2 em português com TODOS
+  os acentos (ç ã õ á é í ó ú â ê ô à). O TXT final do Sistema Auditor é gravado em
+  ISO-8859-1 (latin-1), que **suporta todos os acentos do português** — acento não é
+  problema de encoding e **jamais** deve ser removido. O que o latin-1 não aceita é
+  apenas travessão (—), aspas curvas e emojis.
+- O subtítulo 3 é **fixo e literal** — não altere. O parágrafo de dano coletivo é
+  imutável — reproduza-o literalmente.
+- Autos de PGRTR não levam trabalhadores nominados nas **linhas tipo 4** do TXT
+  (infração coletiva) — o exemplo de trabalhador prejudicado do parágrafo de dano
+  coletivo é só texto do bloco II, não gera linha tipo 4.
+
+**Salvar e handoff:** salve todos os blocos em
+`<OS_ATIVAS>/[PASTA_EMPRESA]/autos-pgrtr.md` e exiba:
+
+```
+✅ N autos de PGRTR redigidos — salvos em autos-pgrtr.md
+
+▶ Próximo passo — empacotar no TXT do Sistema Auditor:
+  1) Rode /aft-gera-ai e responda que os autos estão (b) na sessão.
+  2) Quando ele tratar de anexos, informe o(s) PDF(s) do PGRTR/PCMSO/ASOs como
+     documentos prontos.
+  3) O limite de 10 MB é por auto (soma dos anexos daquele auto) — se o documento não
+     couber em todos, o /aft-gera-ai comprime com o script do toolkit.
+```
+
+### 2) Carta de recomendação geral para o produtor rural
+
+Quando solicitado, redija um texto resumido, dirigido ao empregador rural, no formato:
+
+```
+RELATÓRIO DE RECOMENDAÇÃO PARA ADEQUAÇÃO DO PGRTR
+À [Nome da Empresa/Propriedade]
+Assunto: Recomendações para Adequação do Programa de Gerenciamento de Riscos do
+Trabalho Rural (PGRTR) à NR-31.
+
+Prezados,
+
+Em recente análise documental do PGRTR deste(a) empregador(a), foram identificadas
+oportunidades de melhoria e pontos de não conformidade com a Norma Regulamentadora 31.
+
+Os principais problemas encontrados incluem, mas não se limitam a:
+[3 a 5 pontos principais, resumindo as irregularidades de forma geral]
+
+A manutenção de um PGRTR completo e em conformidade com a legislação é fundamental
+para a prevenção de acidentes e doenças ocupacionais e para a promoção de um ambiente
+de trabalho seguro e saudável.
+
+Diante do exposto, recomenda-se que o empregador busque assessoria técnica
+especializada para realizar uma revisão completa do seu Programa de Gerenciamento de
+Riscos do Trabalho Rural, a fim de sanar as irregularidades apontadas e garantir o
+pleno atendimento aos requisitos da NR-31 e demais normas aplicáveis.
+
+Atenciosamente,
+[Nome do Auditor-Fiscal do Trabalho]
+```
+
+Tom técnico, direto, sem linguagem jurídica de auto — o destinatário é o empregador
+rural. Salve como `recomendacao-geral-PGRTR.md` na pasta da OS.
+
+---
+
+## Registro no memory.md e diário
+
+Depois de qualquer etapa que produza resultado (análise concluída, autos redigidos,
+recomendação escrita), atualize o `memory.md` da OS:
+
+- Se autos foram redigidos: acrescente uma seção em `## Autos de Infração` (mesmo
+  padrão usado pelas demais skills de lavratura — data, arquivo gerado, ementas,
+  elementos de convicção).
+- Sempre: acrescente uma linha em `## Anotações da auditoria` resumindo o que a análise
+  encontrou (quantas ementas não conformes, se autos foram gerados).
+
+Ao final, registre o dia trabalhado no diário — sem perguntar nada ao AFT (o script
+deduplica por data+letra; repetir é inofensivo):
+
+```bash
+python ~/.claude/skills/_scripts/diario_registrar.py "<pasta da OS>" --tipos D --detalhe "via /aft-PGRTR-analise"
+```
+
+---
+
+## Regras gerais
+
+- Texto técnico, oficial, em terceira pessoa. Sem informalidades.
+- **Acentuação completa** (ç ã õ á é í ó ú â ê ô à). Nunca remova acentos: o latin-1 do
+  TXT final os suporta integralmente.
+- **Não usar travessões** (—), aspas curvas nem emojis em texto destinado ao Sistema
+  Auditor. Substitua por dois pontos, vírgulas, parênteses ou hífen simples.
+- **Não invente dados.** Se uma informação não estiver no documento, declare a
+  ausência. Não force enquadramento: se a ementa não estiver presente com base no
+  documento, declare isso explicitamente.
+- **Nunca use ementa fora da base fixa** sem antes consultar o ementário (Etapa 4.5) e
+  confirmar com o AFT.
+- **Privacidade de dados de saúde:** PCMSO, ASOs e prontuários contêm dados sensíveis
+  de saúde do trabalhador. Nunca ecoe CPF ou dado clínico individualizado no chat, no
+  relatório ou no `memory.md` — refira-se por função/setor, ou pelo token `[[TRAB_NN]]`
+  se a OS já tiver mapa de-para. Isso vale mesmo quando a evidência vem de um ASO ou
+  entrevista específica.
+- **Denunciante/entrevista de trabalhador em campo:** se a evidência vier de entrevista
+  com trabalhador (ex.: ementa 231086-4, sobre orientação e supervisão), nunca cite o
+  nome do entrevistado — refira-se como "trabalhador(es) entrevistado(s) em campo".
+- Mantenha a separação entre ementas: não misture irregularidades de uma ementa na
+  análise de outra.
+- Os textos fixos (parágrafo de dano coletivo, subtítulo 3) são imutáveis. Reproduza-os
+  literalmente quando aplicáveis.
+
+---
+
+## Base de ementas NR-31 (fixa)
+
+> Base curada a partir do prompt "Analista de PGRTR" validado em uso real por AFT.
+> Códigos, capitulações e gradações conferidos contra o ementário oficial (NotebookLM,
+> key nr-31) em 24/08/2026. Os títulos são resumos de trabalho; o texto literal da
+> ementa vem sempre do ementário na hora do auto. Percorra a base sequencialmente na
+> Etapa 4. Não edite estas ementas sem o AFT pedir.
+
+### 231086-4 — Deixar de assegurar instruções compreensíveis, direitos/deveres e supervisão ao trabalho seguro
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.2.3, alínea "c", da NR-31, com redação da Portaria SEPRT/ME nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se existem registros de treinamentos, ordens de serviço ou informativos de segurança fornecidos aos trabalhadores em linguagem clara, simples e adaptada ao nível de escolaridade do público-alvo.
+- Entrevistar os trabalhadores em campo para confirmar se receberam orientações sobre seus direitos, deveres, riscos ocupacionais específicos e medidas de proteção recomendadas.
+- Observar in loco se há supervisores, encarregados ou técnicos orientando e acompanhando diretamente a execução das atividades cotidianas para garantir práticas seguras de trabalho.
+**Situação comum de não conformidade:** Trabalhadores safristas são integrados diretamente à colheita manual sem receber qualquer treinamento prévio ou material informativo em linguagem acessível sobre os riscos das ferramentas cortantes e posturas ergonômicas, atuando sem qualquer monitoramento ou supervisão em campo.
+**Fundamentação técnica essencial:** O fornecimento de instruções compreensíveis e a supervisão contínua são as bases de uma cultura preventiva eficaz. No meio rural, a ausência de diretrizes claras e o abandono operacional dos trabalhadores potencializam acidentes severos, visto que a percepção do risco individual é insuficiente sem o suporte instrutivo e o monitoramento técnico da chefia.
+
+### 231084-8 — Deixar de cumprir/fazer cumprir disposições de SST rural garantindo condições, higiene e conforto adequados
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.2.3, alínea "a", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Inspecionar as frentes de trabalho rurais, verificando se máquinas, tratores e ferramentas manuais apresentam as devidas proteções físicas e condições mecânicas seguras de operação.
+- Avaliar as instalações de vivência, sanitários de frente de trabalho e áreas de refeição quanto aos critérios mínimos de higiene, conforto térmico e proteção contra intempéries.
+- Analisar se o PGRTR está implementado na prática e se as medidas mitigadoras listadas no cronograma foram efetivamente executadas.
+**Situação comum de não conformidade:** O estabelecimento rural mantém trabalhadores em frentes de trabalho distantes realizando suas refeições sentados no chão, sob sol pleno, sem abrigos ou mesas disponíveis, além de permitir o uso de ferramentas desgastadas e sem manutenção protetiva.
+**Fundamentação técnica essencial:** Esta alínea constitui o dever geral de prevenção e tutela patronal em SST no ambiente rural. Negligenciar as condições básicas de higiene, conforto e proteção mecânica agride diretamente a integridade física e a dignidade humana do trabalhador, consolidando cenários propícios ao adoecimento crônico e a sinistros graves.
+
+### 231085-6 — Deixar de adotar procedimentos e análise de causas quando da ocorrência de acidentes/doenças do trabalho
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.2.3, alínea "b", da NR-31, com redação da Portaria SEPRT/ME nº 22.677, de 22/10/2020.
+**Gradação:** I4
+**O que verificar:**
+- Solicitar o livro, sistema ou relatórios formais de investigação e análise de acidentes e doenças ocupacionais ocorridos no estabelecimento rural nos últimos 12 meses.
+- Verificar se os relatórios analíticos identificaram detalhadamente os fatores causais (raiz) estruturais, humanos ou de maquinário, indo além da mera descrição do fato.
+- Verificar se as recomendações e contramedidas dessas análises foram integradas ao plano de ação do PGRTR e efetivamente colocadas em prática.
+**Situação comum de não conformidade:** Após um acidente grave com tombamento de trator agrícola que feriu o operador, a empresa limita-se a emitir a CAT eletrônica e prestar socorro hospitalar, sem realizar qualquer investigação interna ou mapeamento de falhas.
+**Fundamentação técnica essencial:** A análise pós-evento de acidentes e agravos à saúde é ferramenta indispensável para retroalimentar o sistema de gestão de riscos. Tratar os sinistros com passividade perpetua falhas latentes e condena o empreendimento à reincidência sob as mesmas causas.
+
+### 231105-4 — Deixar de elaborar/implementar/custear o PGRTR
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.1 da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I4
+**O que verificar:**
+- Solicitar o documento físico ou digital do PGRTR específico para o estabelecimento rural avaliado.
+- Verificar se o programa contempla o inventário de riscos completo e o plano de ação com cronograma de execução, cobrando evidências de que as medidas propostas foram implantadas.
+- Para estabelecimentos com até 50 empregados, verificar se o empregador optou pela ferramenta digital oficial da SEPRT e se gerou o relatório metodológico correspondente.
+- Confirmar se todos os custos de elaboração e execução do programa foram assumidos integralmente pelo empregador.
+**Situação comum de não conformidade:** O produtor rural possui fazenda com 65 funcionários registrados e não apresenta nenhum documento de gestão de riscos de SST, alegando usar um PGR geral unificado de outra empresa do grupo ou que os custos inviabilizariam a safra.
+**Fundamentação técnica essencial:** O PGRTR é a espinha dorsal da gestão de SST no meio rural. A ausência, falta de implementação ou repasse de custos desse programa deixa o estabelecimento desprovido de política estruturada de prevenção, operando às cegas frente aos riscos biológicos, físicos, químicos e ergonômicos do campo.
+
+### 231106-2 — Deixar de comunicar trabalhadores sobre riscos do inventário e medidas do plano de ação do PGRTR
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.1.3 da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Buscar evidências documentais de que os trabalhadores foram formalmente cientificados sobre os riscos do inventário (atas de integração, listas de presença, termos de ciência assinados).
+- Entrevistar amostra de trabalhadores em campo sobre se conhecem os riscos de suas funções e as medidas de prevenção do plano de ação do PGRTR.
+- Verificar existência de sinalizações, quadros informativos ou cartilhas acessíveis nas frentes de trabalho expondo as diretrizes do PGRTR.
+**Situação comum de não conformidade:** A fazenda possui PGRTR robusto elaborado por consultoria técnica, mas o documento fica arquivado na gaveta da administração e nenhum tratorista/operador foi informado sobre os riscos ergonômicos e químicos mapeados para suas rotinas.
+**Fundamentação técnica essencial:** A gestão de riscos só se torna efetiva quando o executor compreende o perigo ao qual está exposto e a utilidade das defesas implementadas. Falhar na transmissão das informações anula o propósito preventivo do programa, transformando-o em burocracia.
+
+### 231145-3 — Deixar de emitir CAT quando constatada doença ocupacional ou alteração biológica com significado clínico
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.11, alínea "a", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I4
+**O que verificar:**
+- Cruzar relatórios médicos de exames complementares e resultados de monitoramento biológico com o histórico de emissão de CATs da empresa.
+- Verificar em prontuários/relatórios do médico coordenador se há diagnósticos, agravos ou indicadores biológicos alterados que não geraram abertura de CAT no prazo legal.
+- Avaliar se o monitoramento biológico de expostos a defensivos agrícolas ou poeiras vegetais apresentou desvios críticos reportados via CAT.
+**Situação comum de não conformidade:** Exames periódicos de aplicadores de defensivos agrícolas indicam redução severa da colinesterase plasmática; o laboratório alerta a alteração crônica, mas a empresa não emite CAT sob o argumento de os trabalhadores estarem assintomáticos.
+**Fundamentação técnica essencial:** A emissão da CAT diante de doenças do trabalho ou alterações biológicas significativas cumpre função de vigilância epidemiológica e proteção jurídica. Sua ausência mascara falhas graves de proteção e retarda a intervenção precoce.
+
+### 231146-1 — Deixar de afastar o trabalhador da exposição quando constatada doença ocupacional ou alteração biológica clínica
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.11, alínea "b", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I4
+**O que verificar:**
+- Identificar, pelo controle médico, quais colaboradores apresentaram piora em exames clínicos/complementares ou monitoramento de indicadores biológicos.
+- Verificar se os trabalhadores identificados continuam exercendo as mesmas atividades ou permanecem expostos ao agente agressor.
+- Verificar se há ordens de serviço, relatórios de remanejamento ou laudos médicos que comprovem o afastamento imediato.
+**Situação comum de não conformidade:** Um operador de motosserra apresenta agravamento severo de PAIR; apesar da restrição médica recomendando afastamento do ruído, a gerência o mantém na mesma função por falta de mão de obra.
+**Fundamentação técnica essencial:** Manter um trabalhador exposto a agente que já demonstrou desestabilizar seus indicadores biológicos acelera a evolução da patologia. O afastamento imediato é bloqueio emergencial obrigatório.
+
+### 231147-0 — Deixar de encaminhar o trabalhador à Previdência Social quando constatada doença ocupacional ou alteração biológica clínica
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.11, alínea "c", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I4
+**O que verificar:**
+- Verificar comprovantes de agendamento de perícia junto ao INSS e guias de encaminhamento previdenciário.
+- Cruzar dados de empregados com agravamentos detectados nos exames com a documentação de suporte pericial enviada ao órgão oficial.
+- Analisar se a empresa forneceu tempestivamente laudos, relatórios ambientais e informações exigidas pela Previdência para a avaliação técnica.
+**Situação comum de não conformidade:** Um trabalhador rural desenvolve LER/DORT na colheita manual; o serviço médico constata o nexo, mas a administração o afasta só informalmente, sem encaminhá-lo à Previdência Social.
+**Fundamentação técnica essencial:** O encaminhamento formal assegura ao trabalhador o direito de ter sua capacidade avaliada oficialmente, com reconhecimento do nexo e acesso aos benefícios. Omitir esse trâmite desampara o indivíduo.
+
+### 231148-8 — Deixar de possibilitar acesso aos órgãos de saúde para profilaxia de doenças endêmicas ou vacinação
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.12, alíneas "a" e "b", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se o empregador concede dispensa justificada, flexibilidade de horários ou transporte para comparecimento a postos de saúde para imunização e tratamentos preventivos.
+- Verificar cartões de vacinação/prontuários quanto à regularidade de vacinas essenciais ao meio rural (antitetânica, febre amarela, hepatite B).
+- Entrevistar trabalhadores para checar se há impedimentos, punições ou descontos salariais quando precisam se afastar para vacinação/profilaxia.
+**Situação comum de não conformidade:** Propriedade em região de alta incidência de febre amarela impede que trabalhadores se ausentem durante o expediente para atualizar vacinação contra tétano e endemias, sob ameaça de desconto do dia.
+**Fundamentação técnica essencial:** O trabalhador rural está em constante exposição a riscos biológicos agressivos. Facilitar o acesso à imunização e ações preventivas do sistema público de saúde é barreira imunológica elementar contra infecções agudas fatais e endemias.
+
+### 231107-0 — Deixar de contemplar no PGRTR os riscos químicos/físicos/biológicos/de acidentes/ergonômicos
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.2 da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Analisar o inventário de riscos do PGRTR para confirmar se os cinco grupos de perigos (físicos, químicos, biológicos, ergonômicos e de acidentes) foram mapeados.
+- Inspecionar rotinas de campo (aplicação de agrotóxicos, operação de tratores, colheita manual) e confrontar se riscos manifestos (calor, poeira orgânica, vibração, posturas forçadas, ferramentas afiadas) foram omitidos.
+- Avaliar se a abrangência do PGRTR cobre todas as funções e etapas produtivas, sem lacunas setoriais.
+**Situação comum de não conformidade:** O PGRTR de uma fazenda produtora de grãos lista só riscos de acidentes com maquinário, ignorando ruído/vibração (físicos), névoa de defensivos (químicos) e esforço repetitivo na carga de sacarias (ergonômicos).
+**Fundamentação técnica essencial:** A ausência de qualquer dimensão de risco invalida a integridade do diagnóstico de segurança. Riscos não catalogados são perigos invisíveis à gestão, impedindo salvaguardas e deixando trabalhadores vulneráveis.
+
+### 231108-9 — Deixar de incluir no PGRTR o levantamento preliminar de perigos ou sua eliminação, quando possível
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3, alínea "a", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar no PGRTR a existência de registros, relatórios ou planilhas que evidenciem a fase de levantamento preliminar de perigos.
+- Buscar evidências de que a empresa estudou alternativas de engenharia/processo para eliminação imediata de perigos antes da avaliação detalhada.
+- Confirmar se o levantamento preliminar considerou histórico de acidentes, quase-acidentes e percepções dos trabalhadores.
+**Situação comum de não conformidade:** A consultoria elabora o PGRTR iniciando direto nas medições quantitativas e matrizes de risco, sem documento que ateste o mapeamento macro e triagem inicial para eliminação na fonte.
+**Fundamentação técnica essencial:** O levantamento preliminar é a triagem da gestão preventiva. Negligenciá-lo viola a hierarquia fundamental de segurança: eliminar o perigo antecede monitorá-lo ou mitigá-lo.
+
+### 231109-7 — Deixar de incluir no PGRTR a avaliação dos riscos que não puderam ser completamente eliminados
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3, alínea "b", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Examinar as matrizes de risco do PGRTR, certificando-se de que os riscos residuais passaram por avaliação estruturada.
+- Verificar se a metodologia aplicou critérios claros para cruzar severidade das lesões com probabilidade de ocorrência.
+- Checar se os resultados classificaram o nível de criticidade para subsidiar a ordem de urgência das intervenções.
+**Situação comum de não conformidade:** O PGRTR enumera perigos inevitáveis na lida com gado bovino (coices, prensamentos), mas omite classificação/gradação, impossibilitando priorizar riscos.
+**Fundamentação técnica essencial:** A avaliação dos riscos residuais dimensiona a magnitude real das ameaças. Sem qualificar severidade e probabilidade, a empresa não consegue planejar proteções proporcionais.
+
+### 231110-0 — Deixar de incluir no PGRTR medidas de prevenção com prioridades e cronograma
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3, alínea "c", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Inspecionar o Plano de Ação do PGRTR e atestar existência de medidas de engenharia, administrativas ou de EPI propostas.
+- Verificar se as medidas estão vinculadas a ordem de prioridade técnica e cronograma físico detalhado.
+- Exigir datas explícitas para cada ação preventiva, descartando termos vagos como "contínuo" ou "quando necessário".
+**Situação comum de não conformidade:** O PGRTR contém inventário detalhado de riscos ergonômicos na colheita de café, mas o plano de ação traz só orientações teóricas abertas, sem prazos ou prioridades.
+**Fundamentação técnica essencial:** O estabelecimento de medidas com cronogramas converte o diagnóstico em ações tangíveis. A falta de prazos anula a evolução dinâmica do programa, tornando-o cartorial.
+
+### 231111-9 — Deixar de incluir no PGRTR a implementação das medidas conforme ordem de prioridade (hierarquia de controle)
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3, alínea "d", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se a implementação segue a ordem de prioridade normativa: eliminação na fonte, proteção coletiva, medidas administrativas, e por último EPI.
+- Analisar justificativas técnicas quando a empresa optou diretamente por EPI, checando comprovação de inviabilidade das medidas coletivas.
+- Confrontar cronograma de execução com ações de campo para garantir que barreiras coletivas antecedam/justifiquem o EPI.
+**Situação comum de não conformidade:** Em vez de isolar acusticamente uma casa de bombas, o produtor adota de imediato protetores auriculares como primeira e única medida.
+**Fundamentação técnica essencial:** A hierarquia de controle visa mitigar o perigo na origem, evitando transferir toda responsabilidade ao trabalhador. Barreiras coletivas protegem continuamente; EPI tem maior taxa de falha.
+
+### 231112-7 — Deixar de incluir no PGRTR a etapa de acompanhamento do controle dos riscos
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3, alínea "e", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Buscar no PGRTR a descrição do método e periodicidade das inspeções para verificar se as medidas de controle continuam ativas e eficazes.
+- Solicitar evidências (relatórios de vistoria, checklists, auditorias internas) de acompanhamento sistemático.
+- Verificar gatilhos de revisão quando houver mudanças de processo, novas tecnologias ou agravos à saúde.
+**Situação comum de não conformidade:** Proteções são instaladas em colhedoras de cana, mas o PGRTR não prevê rotina de checagem; meses depois as proteções são removidas para manutenção e não recolocadas.
+**Fundamentação técnica essencial:** O gerenciamento de riscos é um ciclo dinâmico (PDCA). O acompanhamento certifica que os controles não sofram obsolescência ou degradação pelo uso.
+
+### 231113-5 — Deixar de incluir no PGRTR a investigação e análise de acidentes e doenças ocupacionais
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3, alínea "f", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I4
+**O que verificar:**
+- Confirmar a existência de procedimento estruturado para investigação de incidentes, acidentes e doenças do trabalho.
+- Verificar se as análises de acidentes passados constam documentadas conforme o procedimento previsto, identificando causas estruturais.
+- Verificar se o plano de ação é revisado quando uma investigação aponta falhas nas barreiras pré-existentes.
+**Situação comum de não conformidade:** O PGRTR tem inventários e planos preventivos detalhados, mas omite qualquer diretriz sobre como investigar causas raiz em caso de acidente ou adoecimento.
+**Fundamentação técnica essencial:** Um acidente demonstra empiricamente que as defesas falharam. A etapa de investigação garante que a empresa aprenda com os desvios e implemente correções definitivas.
+
+### 231114-3 — Deixar de adotar os parâmetros dos Anexos da NR-09 para avaliação de exposição a agentes físicos/químicos/biológicos
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3.1 da NR-31, com redação da Portaria SEPRT nº 22.677/2020, alterada pela Portaria MTP nº 698/2022.
+**Gradação:** I3
+**O que verificar:**
+- Revisar laudos técnicos e avaliações quantitativas anexados ao PGRTR (ruído, calor, vibração, névoas químicas).
+- Confrontar metodologias de amostragem, tempos de medição, limites de tolerância e níveis de ação com os anexos da NR-09 e as NHOs da Fundacentro.
+- Verificar se os equipamentos de medição têm certificados de calibração válidos e se os dados foram interpretados conforme as equações normativas.
+**Situação comum de não conformidade:** A avaliação do calor na colheita manual de cana é feita com termômetros comuns de parede, desconsiderando o cálculo do IBUTG e a taxa metabólica exigidos.
+**Fundamentação técnica essencial:** A adoção dos parâmetros da NR-09 garante rigor científico. Avaliações que ignoram os limites oficiais geram laudos nulos, subdimensionando riscos severos.
+
+### 231116-0 — Deixar de documentar o PGRTR com plano de ação
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3.2, alínea "b", da NR-31, com redação da Portaria SEPRT/ME nº 22.677/2020.
+**Gradação:** I3
+**O que verificar:**
+- Exigir a apresentação documental integral do PGRTR e atestar a presença do "Plano de Ação" como seção/documento formalizado.
+- Verificar se o plano elenca explicitamente medidas de prevenção a introduzir/aprimorar/manter, com base nas inconformidades do inventário.
+- Confirmar se as ações têm responsáveis designados e prazos de conclusão inteligíveis.
+**Situação comum de não conformidade:** O gestor apresenta só o inventário de riscos, sem Plano de Ação, alegando resolver os problemas verbalmente conforme surgem.
+**Fundamentação técnica essencial:** O Plano de Ação é o componente operativo do PGRTR. Sem ele, o programa perde poder de execução, virando listagem estática.
+
+### 231121-6 — Deixar de contemplar no inventário a avaliação/classificação de riscos para fins de plano de ação
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.3.2.1, alínea "e", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se o inventário adota matriz de risco ou metodologia que associe severidade e probabilidade.
+- Checar se há classificação explícita do nível de risco (baixo, médio, alto, crítico) para cada perigo listado.
+- Confirmar se essa gradação foi usada para priorizar a ordem de execução das medidas do plano de ação.
+**Situação comum de não conformidade:** O produtor apresenta tabela estática de riscos sem cruzá-los em matriz ou atribuir criticidade, listando correções de forma aleatória.
+**Fundamentação técnica essencial:** A classificação dos riscos é a inteligência analítica que direciona investimentos de proteção. Sem hierarquizar, o plano de ação perde o critério técnico de urgência.
+
+### 231124-0 — Deixar de estabelecer no PGRTR medidas para trabalhos com animais
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.5, alínea "a", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se o PGRTR possui procedimentos, regras de segurança e treinamentos específicos para manejo de animais.
+- Solicitar comprovação da carteira de vacinação dos trabalhadores expostos (raiva, brucelose, tétano).
+- Inspecionar se estruturas de contenção (troncos, bretes, mangueiros) são seguras e se há descarte adequado de carcaças/secreções/excreções.
+**Situação comum de não conformidade:** Vaqueiros realizam vacinação e contenção de gado de forma improvisada, sem bretes adequados, e o empregador não mantém registro de imunização nem rotina para descarte de dejetos.
+**Fundamentação técnica essencial:** O trabalho com animais de grande porte combina risco agudo de trauma físico (coices, chifradas) com risco biológico crônico (zoonoses). Protocolos de aproximação e imunização são barreiras indispensáveis.
+
+### 231125-9 — Deixar de estabelecer no PGRTR medidas para condições climáticas extremas
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.5, alínea "b", da NR-31, com redação da Portaria SEPRT nº 22.677/2020, alterada pela Portaria MTP nº 698/2022.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se o PGRTR formaliza diretrizes especificando quais condições meteorológicas (raios, ventania, calor extremo) justificam paralisação das atividades.
+- Exigir registros de treinamento sobre rotas de evacuação e abrigos seguros.
+- Entrevistar trabalhadores para atestar se conhecem as regras de interrupção e dispõem de autonomia para o direito de recusa.
+**Situação comum de não conformidade:** Trabalhadores permanecem cortando cana manualmente sob forte tempestade elétrica, pois a fazenda não possui procedimento instruindo a parada do trabalho.
+**Fundamentação técnica essencial:** O ambiente rural aberto é vulnerável a eventos meteorológicos extremos. Definir critérios de interrupção imediata preserva vidas.
+
+### 231126-7 — Deixar de estabelecer no PGRTR medidas de organização do trabalho para esforço físico e terrenos acidentados
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.5, alínea "c", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Analisar ordens de serviço/programações diárias no PGRTR quanto à adequação de horários de atividades de alta sobrecarga física.
+- Cruzar horários de maior incidência de calor com as tarefas de campo, aferindo se atividades pesadas foram alocadas em períodos mais frescos.
+- Verificar se o programa estipula controles para trabalho em terrenos acidentados (pausas, técnicas ergonômicas, calçados antiderrapantes).
+**Situação comum de não conformidade:** Fazenda de café em montanha exige colheita e carregamento de sacos entre 11h30 e 14h, sob forte calor, sem escala de revezamento ou pausas.
+**Fundamentação técnica essencial:** Esforço físico extremo combinado com estresse térmico eleva a taxa de exaustão e desidratação. Terrenos íngremes ampliam o risco de quedas e lesões na coluna.
+
+### 231127-5 — Deixar de estabelecer no PGRTR condições seguras de trânsito interno de trabalhadores e veículos
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.5, alínea "d", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar existência de regras explícitas de velocidade, fluxo e segregação segura entre máquinas e transeuntes no plano de tráfego interno.
+- Inspecionar visualmente a presença de sinalização visível, advertências e indicações de perigo nas vias internas.
+- Mapear áreas com relevo crítico (barrancos, pontes, margens de represas) e atestar defesas físicas contra quedas/capotamentos.
+**Situação comum de não conformidade:** Caminhões e tratores circulam em alta velocidade por estradas internas de terra que margeiam canais profundos, sem placa de velocidade máxima nem barreira protetora.
+**Fundamentação técnica essencial:** A circulação de maquinário pesado combinada ao transporte de pessoas em estradas sem pavimentação apresenta risco severo de colisão e capotamento. Sinalização e isolamento físico são obrigatórios.
+
+### 231128-3 — Deixar de estabelecer no PGRTR medidas para eliminação de resíduos dos processos produtivos
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.5, alínea "e", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar no PGRTR o plano de gerenciamento, destinação e descarte de resíduos industriais, biológicos e operacionais.
+- Inspecionar postos de trabalho, galpões e vivências quanto ao acúmulo inadequado de sucatas cortantes, arames, madeira ou rejeitos orgânicos.
+- Confirmar se depósitos temporários de resíduos têm isolamento, sinalização e estão afastados das rotas de circulação.
+**Situação comum de não conformidade:** Oficina e pátio de insumos acumulam peças metálicas cortantes, pneus com água parada e embalagens de óleo jogadas nas vias de passagem.
+**Fundamentação técnica essencial:** O acúmulo de resíduos degrada condições de ordem e segurança, obstrui passagens, e serve de foco para animais peçonhentos e vetores de doença.
+
+### 231129-1 — Deixar de estabelecer no PGRTR medidas para trabalho em faixa de segurança de linhas de energia elétrica
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.5, alínea "f", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se o PGRTR mapeia as linhas de distribuição de energia que cortam a propriedade e estabelece distâncias mínimas de segurança.
+- Checar procedimentos escritos orientando operadores de equipamentos de grande porte sobre risco de indução/contato elétrico.
+- Inspecionar sinalização de advertência quanto à altura máxima permitida sob redes elétricas.
+**Situação comum de não conformidade:** Propriedade com redes de alta tensão cruzando lavouras permite tráfego de colhedoras diretamente sob os cabos, sem o PGRTR mencionar o risco.
+**Fundamentação técnica essencial:** A aproximação de maquinário com redes energizadas representa risco crítico de arcos elétricos e eletrocussão. Medidas específicas normatizam rotas seguras e treinamento.
+
+### 231130-5 — Desconsiderar peculiaridades das atividades rurais no planejamento das ações de saúde ocupacional
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.6 da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Confrontar o planejamento de saúde ocupacional com os riscos identificados no inventário do PGRTR.
+- Verificar se o plano médico contempla os agravos específicos do ambiente rural (agrotóxicos, poeiras vegetais, zoonoses, intempéries).
+- Checar se os exames complementares obrigatórios para funções específicas (toxicologia, espirometria) estão sendo realizados.
+**Situação comum de não conformidade:** O médico do trabalho executa monitoramento padronizado e burocrático, sem solicitar controle de indicadores biológicos (colinesterase) para manuseadores semanais de defensivos.
+**Fundamentação técnica essencial:** As ações de saúde no meio rural devem ser responsivas aos perigos de campo. Ignorar peculiaridades anula a eficácia da medicina ocupacional.
+
+### 231131-3 — Deixar de garantir a realização de exame médico admissional antes do início das atividades
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7, alínea "a", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Cruzar datas de admissão/início efetivo (contrato ou eSocial) com a data de emissão do ASO admissional.
+- Verificar se todos os trabalhadores ativos possuem ASO admissional assinado.
+- Confirmar se a data do exame é anterior ou concomitante ao primeiro dia trabalhado.
+**Situação comum de não conformidade:** Trabalhadores safristas iniciam o corte de cana numa segunda-feira, com os exames admissionais realizados só no final daquela semana.
+**Fundamentação técnica essencial:** O exame admissional atesta a aptidão do trabalhador frente às exigências rurais. Permitir início antes do exame expõe o indivíduo e gera vulnerabilidade jurídica.
+
+### 231132-1 — Deixar de garantir a realização de exame médico periódico
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7, alínea "b", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Revisar os ASOs periódicos e rastrear exames com validade vencida (mais de 12 meses ou prazo menor fixado pelo médico/convenção).
+- Confrontar a listagem de funcionários ativos com o cronograma de exames clínicos/laboratoriais.
+- Verificar se os intervalos foram reduzidos para expostos a riscos críticos elevados, conforme critério médico ou norma coletiva.
+**Situação comum de não conformidade:** Vaqueiros e tratoristas trabalham com exames admissionais/periódicos vencidos há mais de um ano e meio, sob alegação de rotina operacional.
+**Fundamentação técnica essencial:** O exame periódico é o instrumento de vigilância continuada para identificar precocemente patologias ocupacionais silenciosas. A falha impede intervenções oportunas.
+
+### 231133-0 — Deixar de garantir exame de retorno ao trabalho após afastamento igual/superior a 30 dias
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7, alínea "c", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Identificar trabalhadores afastados por 30 dias ou mais por doença ou acidente (ocupacional ou não).
+- Exigir o ASO de Retorno ao Trabalho e certificar se a data coincide com o primeiro dia útil de retorno.
+- Verificar se restrições/recomendações do ASO de retorno foram cumpridas em campo.
+**Situação comum de não conformidade:** Tratorista afastado por 40 dias (fratura no braço) retorna à fazenda e reassume o comando de maquinário pesado sem passar por avaliação médica.
+**Fundamentação técnica essencial:** A reintrodução após afastamento prolongado exige validação clínica da recuperação funcional. O exame evita agravamento de condição remanescente e novos acidentes.
+
+### 231134-8 — Deixar de garantir exame de mudança de risco ocupacional antes da mudança
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7, alínea "d", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Identificar transferências internas de cargo por registros funcionais/eSocial.
+- Cruzar a data efetiva da transferência com a data de emissão do ASO de Mudança de Risco.
+- Verificar se o novo risco exigia exames complementares específicos realizados antes do início da nova atividade.
+**Situação comum de não conformidade:** Trabalhador da capina manual é promovido a aplicador de defensivos, assumindo o manuseio de tóxicos semanas antes da avaliação médica e exames toxicológicos.
+**Fundamentação técnica essencial:** O exame antes da mudança estabelece linha de base clínica e atesta aptidão para o novo perigo. Sem ele, o trabalhador é exposto sem salvaguardas.
+
+### 231135-6 — Deixar de garantir exame demissional em até 10 dias do término do contrato
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7, alínea "e", da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Cruzar datas de rescisão com as datas de realização do exame demissional.
+- Contar o prazo em dias corridos para verificar se o limite de 10 dias foi extrapolado.
+- Verificar se a dispensa do exame cumpre o critério normativo (exame clínico recente há menos de 90 dias) e eventuais restrições de convenção coletiva.
+**Situação comum de não conformidade:** Empresa dispensa trabalhadores temporários ao fim da safra sem encaminhá-los ao exame demissional no prazo, alegando que o contrato temporário desobrigaria a avaliação.
+**Fundamentação técnica essencial:** O exame demissional atesta as condições de saúde no momento da saída. O prazo de 10 dias evita mascaramento de agravos manifestados logo após o desligamento.
+
+### 231136-4 — Deixar de subsidiar exames médicos com exame clínico/complementares conforme os riscos e parâmetros da NR-07
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7.1 da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Verificar se os exames solicitados estão correlacionados aos riscos físicos, químicos, biológicos e ergonômicos do PGRTR.
+- Verificar se as avaliações e exames complementares seguem os parâmetros de periodicidade, amostragem e interpretação técnica dos Anexos da NR-07.
+- Garantir que os ASOs detalhem os exames complementares realizados, conforme o perfil de risco da atividade.
+**Situação comum de não conformidade:** Trabalhadores expostos a elevada poeira vegetal passam só por anamnese rápida, sem espirometrias ou radiografias de tórax preconizadas.
+**Fundamentação técnica essencial:** O exame médico ocupacional deve ser guiado pela matriz de exposição do trabalhador. Ignorar os riscos e a NR-07 anula a capacidade diagnóstica precoce.
+
+### 231138-0 — Deixar de realizar exames complementares quando há exposição acima do nível de ação (Anexos da NR-09/PGRTR)
+**Capitulação legal:** Art. 18 da Lei nº 5.889/73 c/c item 31.3.7.1.1, parte final, da NR-31, com redação da Portaria SEPRT nº 22.677, de 22/10/2020.
+**Gradação:** I3
+**O que verificar:**
+- Inspecionar as medições ambientais do PGRTR e identificar postos/funções cujos níveis ultrapassaram o "Nível de Ação".
+- Selecionar amostra de prontuários/ASOs de trabalhadores desses postos.
+- Verificar se os exames complementares cabíveis foram solicitados, realizados e laudados periodicamente.
+**Situação comum de não conformidade:** Operadores de colhedoras de algodão expostos a 82 dB(A) (acima do nível de ação de 80 dB(A)) não são submetidos a audiometrias periódicas.
+**Fundamentação técnica essencial:** O nível de ação sinaliza potencial latente de dano. Ativar o monitoramento médico nessa fase é crucial para rastrear disfunções precoces antes de atingir o limite de tolerância.

--- a/agents/aft-extrator-documento.md
+++ b/agents/aft-extrator-documento.md
@@ -2,8 +2,8 @@
 name: aft-extrator-documento
 description: >
   Extrator isolado de documentos longos entregues pela empresa fiscalizada (PGR, AET,
-  laudo de adequacao a NR-12). Invocado pelas skills /aft-PGR-analise,
-  /aft-aet-auditoria e /aft-auditoria-AR-NR12 para ler o documento inteiro fora da
+  laudo de adequacao a NR-12, PGRTR). Invocado pelas skills /aft-PGR-analise,
+  /aft-PGRTR-analise, /aft-aet-auditoria e /aft-auditoria-AR-NR12 para ler o documento inteiro fora da
   conversa principal e devolver um extrato fiel, organizado pelo roteiro que a skill
   chamadora manda, com transcricao literal e numero de pagina. Nao julga, nao enquadra,
   nao redige auto: so levanta o que o documento diz e, sobretudo, o que ele NAO diz.
@@ -22,6 +22,7 @@ no prompt:
 | Skill | Documento | Roteiro |
 |---|---|---|
 | `/aft-PGR-analise` | PGR (NR-01) | 7 ementas de PGR |
+| `/aft-PGRTR-analise` | PGRTR (NR-31, rural) | 7 blocos temáticos da base de ementas NR-31 |
 | `/aft-aet-auditoria` | AET (NR-17) | 5 ementas de ergonomia |
 | `/aft-auditoria-AR-NR12` | laudo de adequação / apreciação de riscos | checklist de 6 blocos (ISO 12100 / NBR 14153) |
 

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -132,936 +132,941 @@
 
 <script>
 const ARCH = {
- "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
- "repo": "github.com/ryckardo42/aft-toolkit",
- "data": "2026-08-24",
- "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
- "stats": {
-  "skills": 52,
-  "scripts": 42,
-  "dados": 6,
-  "commit": "ver `git log -1` — atualizado em 23/08/2026"
- },
- "atores": [
-  {
-   "nome": "AFT colega (novo usuário)",
-   "papel": "Auditor no Windows",
-   "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
+  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
+  "repo": "github.com/ryckardo42/aft-toolkit",
+  "data": "2026-08-24",
+  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+  "stats": {
+    "skills": 53,
+    "scripts": 42,
+    "dados": 6,
+    "commit": "ver `git log -1` — atualizado em 24/08/2026"
   },
-  {
-   "nome": "Claude Code",
-   "papel": "Assistente técnico",
-   "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
-  },
-  {
-   "nome": "Sistema Auditor",
-   "papel": "App oficial do MTE",
-   "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
-  },
-  {
-   "nome": "NotebookLM",
-   "papel": "Fonte de ementas",
-   "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
-  },
-  {
-   "nome": "Ricardo (mantenedor)",
-   "papel": "AFT — SRTE/GO",
-   "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
-  }
- ],
- "fluxo": [
-  {
-   "who": "/aft-preparacao-acao-fiscal",
-   "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
-  },
-  {
-   "who": "/aft-nova-auditoria",
-   "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
-  },
-  {
-   "who": "/aft-painel",
-   "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
-  },
-  {
-   "who": "Visita ao estabelecimento",
-   "act": "Inspeção física presencial."
-  },
-  {
-   "who": "/aft-inspecao-fisica",
-   "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
-  },
-  {
-   "who": "/aft-auditoria-geral",
-   "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
-  },
-  {
-   "who": "/aft-revisa-auto",
-   "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
-  },
-  {
-   "who": "/aft-gera-ai",
-   "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
-  },
-  {
-   "who": "Sistema Auditor",
-   "act": "Botão imp. txt → revisão do AFT → transmissão."
-  },
-  {
-   "who": "/aft-autos-lavrados",
-   "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
-  },
-  {
-   "who": "/aft-relatorio",
-   "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
-  }
- ],
- "instalacao": [
-  {
-   "who": "Instalar o app Claude",
-   "act": "claude.com/claude-code — único passo realmente inicial."
-  },
-  {
-   "who": "Instalar o Git + reiniciar pela bandeja",
-   "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
-  },
-  {
-   "who": "Colar o prompt de instalação no </> Code",
-   "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
-  },
-  {
-   "who": "/aft-setup",
-   "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
-  },
-  {
-   "who": "Codex: dois atalhos (opcional)",
-   "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
-  }
- ],
- "camadas": [
-  {
-   "nome": "Configuração e visão geral",
-   "cor": "accent2",
-   "skills": [
+  "atores": [
     {
-     "nome": "/aft-ajuda",
-     "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
-     "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+      "nome": "AFT colega (novo usuário)",
+      "papel": "Auditor no Windows",
+      "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
     },
     {
-     "nome": "/aft-setup",
-     "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
-     "tech": "winget · pipx · uorgs.csv · model: sonnet"
+      "nome": "Claude Code",
+      "papel": "Assistente técnico",
+      "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
     },
     {
-     "nome": "/aft-doctor",
-     "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
-     "tech": "aft_doctor.py · model: sonnet"
+      "nome": "Sistema Auditor",
+      "papel": "App oficial do MTE",
+      "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
     },
     {
-     "nome": "/aft-erro",
-     "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
-     "tech": "erro_ticket.py · model: sonnet"
+      "nome": "NotebookLM",
+      "papel": "Fonte de ementas",
+      "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
     },
     {
-     "nome": "/aft-atualizar",
-     "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
-     "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-notebooklm-login",
-     "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
-     "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-auditoria",
-     "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
-     "tech": "cria memory.md · model: sonnet"
-    },
-    {
-     "nome": "/aft-organiza-os",
-     "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
-     "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
-    },
-    {
-     "nome": "/aft-painel",
-     "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
-     "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
-    },
-    {
-     "nome": "/aft-agenda-det",
-     "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
-    },
-    {
-     "nome": "/aft-det-baixar",
-     "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da OS. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
-     "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-det-baixar-notificacoes",
-     "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da /aft-det-baixar, então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
-     "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-skill",
-     "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
-     "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+      "nome": "Ricardo (mantenedor)",
+      "papel": "AFT — SRTE/GO",
+      "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
     }
-   ]
-  },
-  {
-   "nome": "Preparação da ação fiscal (antes da visita)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "fluxo": [
     {
-     "nome": "/aft-preparacao-acao-fiscal",
-     "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
-     "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+      "who": "/aft-preparacao-acao-fiscal",
+      "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
     },
     {
-     "nome": "/aft-cnpjs-endereco",
-     "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
-     "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+      "who": "/aft-nova-auditoria",
+      "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
     },
     {
-     "nome": "/aft-NAD",
-     "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
-     "tech": "espelha /aft-tn-nco · model: sonnet"
+      "who": "/aft-painel",
+      "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
     },
     {
-     "nome": "/aft-lre-esocial",
-     "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
-     "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+      "who": "Visita ao estabelecimento",
+      "act": "Inspeção física presencial."
+    },
+    {
+      "who": "/aft-inspecao-fisica",
+      "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
+    },
+    {
+      "who": "/aft-auditoria-geral",
+      "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
+    },
+    {
+      "who": "/aft-revisa-auto",
+      "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
+    },
+    {
+      "who": "/aft-gera-ai",
+      "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
+    },
+    {
+      "who": "Sistema Auditor",
+      "act": "Botão imp. txt → revisão do AFT → transmissão."
+    },
+    {
+      "who": "/aft-autos-lavrados",
+      "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
+    },
+    {
+      "who": "/aft-relatorio",
+      "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
     }
-   ]
-  },
-  {
-   "nome": "Inspeção e lavratura",
-   "cor": "accent",
-   "skills": [
+  ],
+  "instalacao": [
     {
-     "nome": "/aft-inspecao-fisica",
-     "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
-     "tech": "relato → memory.md · model: sonnet"
+      "who": "Instalar o app Claude",
+      "act": "claude.com/claude-code — único passo realmente inicial."
     },
     {
-     "nome": "/aft-consulta",
-     "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
-     "tech": "notebooklm ask · herda o modelo da sessão"
+      "who": "Instalar o Git + reiniciar pela bandeja",
+      "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
     },
     {
-     "nome": "/aft-auditoria-geral",
-     "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
-     "tech": "orquestra consultoras · herda o modelo da sessão"
+      "who": "Colar o prompt de instalação no </> Code",
+      "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
     },
     {
-     "nome": "/aft-informalidade",
-     "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
-     "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+      "who": "/aft-setup",
+      "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
     },
     {
-     "nome": "/aft-PGR-analise",
-     "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-aet-auditoria",
-     "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-auditoria-AR-NR12",
-     "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
-     "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
-    },
-    {
-     "nome": "/aft-det-630",
-     "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
-     "tech": "escreve em ## Notificações DET · model: sonnet"
-    },
-    {
-     "nome": "/aft-tn-nco",
-     "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
-     "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
-    },
-    {
-     "nome": "/aft-email",
-     "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
-     "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
-    },
-    {
-     "nome": "/aft-embargo-interdicao",
-     "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
-     "tech": "template.docx SRTE/GO · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-manutencao",
-     "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
-     "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-levantamento",
-     "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
-     "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
-    },
-    {
-     "nome": "/aft-analise-acidente",
-     "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
-     "tech": "gerar_relatorio_docx.py · model: opus 1M"
+      "who": "Codex: dois atalhos (opcional)",
+      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
     }
-   ]
-  },
-  {
-   "nome": "Consultoras especializadas por NR",
-   "cor": "warn",
-   "skills": [
+  ],
+  "camadas": [
     {
-     "nome": "/aft-NR01",
-     "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
-     "tech": ""
+      "nome": "Configuração e visão geral",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-ajuda",
+          "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
+          "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+        },
+        {
+          "nome": "/aft-setup",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+          "tech": "winget · pipx · uorgs.csv · model: sonnet"
+        },
+        {
+          "nome": "/aft-doctor",
+          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
+          "tech": "aft_doctor.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-erro",
+          "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
+          "tech": "erro_ticket.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-atualizar",
+          "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
+          "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-notebooklm-login",
+          "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
+          "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-auditoria",
+          "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
+          "tech": "cria memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-organiza-os",
+          "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
+          "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
+        },
+        {
+          "nome": "/aft-painel",
+          "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
+          "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
+        },
+        {
+          "nome": "/aft-agenda-det",
+          "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
+        },
+        {
+          "nome": "/aft-det-baixar",
+          "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da OS. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
+          "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-det-baixar-notificacoes",
+          "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da /aft-det-baixar, então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
+          "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-skill",
+          "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
+          "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR12",
-     "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Preparação da ação fiscal (antes da visita)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-preparacao-acao-fiscal",
+          "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
+          "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+        },
+        {
+          "nome": "/aft-cnpjs-endereco",
+          "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
+          "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-NAD",
+          "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
+          "tech": "espelha /aft-tn-nco · model: sonnet"
+        },
+        {
+          "nome": "/aft-lre-esocial",
+          "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
+          "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR18",
-     "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Inspeção e lavratura",
+      "cor": "accent",
+      "skills": [
+        {
+          "nome": "/aft-inspecao-fisica",
+          "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
+          "tech": "relato → memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-consulta",
+          "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
+          "tech": "notebooklm ask · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-auditoria-geral",
+          "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
+          "tech": "orquestra consultoras · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-informalidade",
+          "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
+          "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+        },
+        {
+          "nome": "/aft-PGR-analise",
+          "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-PGRTR-analise",
+          "role": "Auditoria sistemática do PGRTR (NR-31, rural) na base fixa de 30 ementas, com confronto campo × documento, extração delegada e citação de páginas.",
+          "tech": "handoff p/ gera-ai · model: opus"
+        },
+        {
+          "nome": "/aft-aet-auditoria",
+          "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-auditoria-AR-NR12",
+          "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
+          "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
+        },
+        {
+          "nome": "/aft-det-630",
+          "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
+          "tech": "escreve em ## Notificações DET · model: sonnet"
+        },
+        {
+          "nome": "/aft-tn-nco",
+          "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
+          "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
+        },
+        {
+          "nome": "/aft-email",
+          "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
+          "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
+        },
+        {
+          "nome": "/aft-embargo-interdicao",
+          "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
+          "tech": "template.docx SRTE/GO · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-manutencao",
+          "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
+          "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-levantamento",
+          "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
+          "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
+        },
+        {
+          "nome": "/aft-analise-acidente",
+          "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
+          "tech": "gerar_relatorio_docx.py · model: opus 1M"
+        }
+      ]
     },
     {
-     "nome": "/aft-cnae-grau-risco-nr04",
-     "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
-     "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+      "nome": "Consultoras especializadas por NR",
+      "cor": "warn",
+      "skills": [
+        {
+          "nome": "/aft-NR01",
+          "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
+          "tech": ""
+        },
+        {
+          "nome": "/aft-NR12",
+          "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-NR18",
+          "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cnae-grau-risco-nr04",
+          "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
+          "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-dimensionamento-sesmt-nr04",
+          "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
+          "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cipa-nr05-dimensionamento",
+          "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
+          "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-nr24-dimensionamento",
+          "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
+          "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-dimensionamento-sesmt-nr04",
-     "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
-     "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+      "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-jornada-analise",
+          "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
+          "tech": "roteador · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-valida-afd-aej",
+          "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
+          "tech": "validar.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-atestado",
+          "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
+          "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-jornada-auto-afd-aej",
+          "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
+          "tech": "handoff p/ gera-ai · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-cipa-nr05-dimensionamento",
-     "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
-     "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-nr24-dimensionamento",
-     "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
-     "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+      "nome": "Empacotamento, rastreamento e relatórios",
+      "cor": "ok",
+      "skills": [
+        {
+          "nome": "/aft-revisa-auto",
+          "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
+          "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+        },
+        {
+          "nome": "/aft-gera-ai",
+          "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
+          "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-lavrados",
+          "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
+          "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-pdf-reunidos",
+          "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
+          "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio",
+          "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
+          "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio-acidentes",
+          "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
+          "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-cat-trabalhador",
+          "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
+          "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
+        },
+        {
+          "nome": "/aft-modelo-docx",
+          "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
+          "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
+        },
+        {
+          "nome": "/aft-sessoes-os",
+          "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
+          "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+        }
+      ]
     }
-   ]
-  },
-  {
-   "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "scripts": [
     {
-     "nome": "/aft-jornada-analise",
-     "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
-     "tech": "roteador · model: sonnet"
+      "nome": "rehydrate.py",
+      "caminho": "_scripts/rehydrate.py",
+      "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-valida-afd-aej",
-     "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
-     "tech": "validar.py · model: sonnet"
+      "nome": "bloco3_inject.py",
+      "caminho": "_scripts/bloco3_inject.py",
+      "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-atestado",
-     "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
-     "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+      "nome": "validar_txt.py",
+      "caminho": "_scripts/validar_txt.py",
+      "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-auto-afd-aej",
-     "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
-     "tech": "handoff p/ gera-ai · model: sonnet"
+      "nome": "checar_pii.py",
+      "caminho": "_scripts/checar_pii.py",
+      "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_diff.py",
+      "caminho": "_scripts/checar_diff.py",
+      "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivo_aberto.py",
+      "caminho": "_scripts/checar_arquivo_aberto.py",
+      "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "backup_arquivo.py",
+      "caminho": "_scripts/backup_arquivo.py",
+      "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_rt_autos.py",
+      "caminho": "_scripts/checar_rt_autos.py",
+      "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
+      "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
+    },
+    {
+      "nome": "gerar_painel.py",
+      "caminho": "_scripts/gerar_painel.py",
+      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+      "runtime": "Python stdlib (+pdfplumber opcional)"
+    },
+    {
+      "nome": "servir_painel.py",
+      "caminho": "_scripts/servir_painel.py",
+      "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_sync.py",
+      "caminho": "_scripts/det_sync.py",
+      "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_baixar.py",
+      "caminho": "_scripts/det_baixar.py",
+      "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ (convenção do AFT, 21/08/2026 — data do primeiro download, sem o prefixo notificacao- no nome): os 2 PDFs + item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote; legados migram sozinhos (pacote notificacao-<COD> na raiz ou em NOTIFICACOES/ é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro, conta em movidos). Idempotente por existência do arquivo; nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_criar.py",
+      "caminho": "_scripts/det_criar.py",
+      "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_rotina_painel.py",
+      "caminho": "_scripts/instalar_rotina_painel.py",
+      "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_servidor_painel.py",
+      "caminho": "_scripts/instalar_servidor_painel.py",
+      "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "aft_doctor.py",
+      "caminho": "_scripts/aft_doctor.py",
+      "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "fotos_para_pdf.py",
+      "caminho": "_scripts/fotos_para_pdf.py",
+      "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
+      "runtime": "Python · pillow"
+    },
+    {
+      "nome": "comprimir_pdf.py",
+      "caminho": "_scripts/comprimir_pdf.py",
+      "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
+      "runtime": "Python · pikepdf/pypdf"
+    },
+    {
+      "nome": "docx_pack.py / docx_unpack.py",
+      "caminho": "_scripts/docx_*.py",
+      "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "nome": "scan_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
+      "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
+      "runtime": "Python · pypdf"
+    },
+    {
+      "nome": "gera_relacao_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
+      "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
+      "runtime": "Python (python-docx)"
+    },
+    {
+      "nome": "inspecionar_assinatura.py",
+      "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
+      "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
+      "runtime": "Python"
+    },
+    {
+      "nome": "validar.py",
+      "caminho": "aft-jornada-valida-afd-aej/validar.py",
+      "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "gerar_relatorio_docx.py",
+      "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
+      "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "runtime": "Python stdlib",
+      "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
+      "nome": "pasta_aft.py",
+      "caminho": "_scripts/pasta_aft.py"
+    },
+    {
+      "nome": "instalar_agentes.py",
+      "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
+    },
+    {
+      "nome": "erro_ticket.py",
+      "caminho": "_scripts/erro_ticket.py",
+      "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sync_perfil.py",
+      "caminho": "_scripts/sync_perfil.py",
+      "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sessoes_os.py",
+      "caminho": "_scripts/sessoes_os.py",
+      "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_vigia_sessoes.py",
+      "caminho": "_scripts/instalar_vigia_sessoes.py",
+      "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "checar_acentos.py",
+      "caminho": "_scripts/checar_acentos.py",
+      "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivos_internos.py",
+      "caminho": "_scripts/checar_arquivos_internos.py",
+      "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "indenta_quebras.py",
+      "caminho": "_scripts/indenta_quebras.py",
+      "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "ajuda_arquitetura.py",
+      "caminho": "_scripts/ajuda_arquitetura.py",
+      "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebook_id.py",
+      "caminho": "_scripts/notebook_id.py",
+      "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
+      "runtime": "python (stdlib) + CLI notebooklm na sondagem"
+    },
+    {
+      "nome": "sincronizar_notebooks.py",
+      "caminho": "_scripts/sincronizar_notebooks.py",
+      "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebooklm_consulta.py",
+      "caminho": "_scripts/notebooklm_consulta.py",
+      "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
+      "runtime": "python (stdlib) + CLI notebooklm"
+    },
+    {
+      "nome": "lre_esocial.py",
+      "caminho": "_scripts/lre_esocial.py",
+      "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_ferias.py",
+      "caminho": "_scripts/lre_ferias.py",
+      "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_folha.py",
+      "caminho": "_scripts/lre_folha.py",
+      "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "cbo.json",
+      "caminho": "_scripts/cbo.json",
+      "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
+      "runtime": "dado (JSON)"
+    },
+    {
+      "nome": "consulta_cnpj.py",
+      "caminho": "_scripts/consulta_cnpj.py",
+      "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+      "runtime": "Python stdlib"
     }
-   ]
-  },
-  {
-   "nome": "Empacotamento, rastreamento e relatórios",
-   "cor": "ok",
-   "skills": [
+  ],
+  "dados": [
     {
-     "nome": "/aft-revisa-auto",
-     "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
-     "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+      "arquivo": "config/notebooks.json",
+      "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
+      "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
     },
     {
-     "nome": "/aft-gera-ai",
-     "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
-     "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+      "arquivo": "config/uorgs.csv",
+      "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
+      "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
     },
     {
-     "nome": "/aft-autos-lavrados",
-     "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
-     "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+      "arquivo": "config/CLAUDE-aft.md",
+      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
+      "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
     },
     {
-     "nome": "/aft-autos-pdf-reunidos",
-     "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
-     "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+      "arquivo": "config/blocos_auto.md",
+      "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
+      "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
     },
     {
-     "nome": "/aft-relatorio",
-     "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
-     "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+      "arquivo": "config/settings-aft.json",
+      "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
+      "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
     },
     {
-     "nome": "/aft-relatorio-acidentes",
-     "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
-     "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
-    },
-    {
-     "nome": "/aft-cat-trabalhador",
-     "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
-     "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
-    },
-    {
-     "nome": "/aft-modelo-docx",
-     "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
-     "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
-    },
-    {
-     "nome": "/aft-sessoes-os",
-     "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
-     "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+      "arquivo": "config/models-validos.json",
+      "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
+      "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
     }
-   ]
-  }
- ],
- "scripts": [
-  {
-   "nome": "rehydrate.py",
-   "caminho": "_scripts/rehydrate.py",
-   "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "bloco3_inject.py",
-   "caminho": "_scripts/bloco3_inject.py",
-   "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "validar_txt.py",
-   "caminho": "_scripts/validar_txt.py",
-   "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_pii.py",
-   "caminho": "_scripts/checar_pii.py",
-   "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_diff.py",
-   "caminho": "_scripts/checar_diff.py",
-   "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivo_aberto.py",
-   "caminho": "_scripts/checar_arquivo_aberto.py",
-   "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "backup_arquivo.py",
-   "caminho": "_scripts/backup_arquivo.py",
-   "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_rt_autos.py",
-   "caminho": "_scripts/checar_rt_autos.py",
-   "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
-   "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
-  },
-  {
-   "nome": "gerar_painel.py",
-   "caminho": "_scripts/gerar_painel.py",
-   "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
-   "runtime": "Python stdlib (+pdfplumber opcional)"
-  },
-  {
-   "nome": "servir_painel.py",
-   "caminho": "_scripts/servir_painel.py",
-   "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_sync.py",
-   "caminho": "_scripts/det_sync.py",
-   "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_baixar.py",
-   "caminho": "_scripts/det_baixar.py",
-   "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ (convenção do AFT, 21/08/2026 — data do primeiro download, sem o prefixo notificacao- no nome): os 2 PDFs + item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote; legados migram sozinhos (pacote notificacao-<COD> na raiz ou em NOTIFICACOES/ é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro, conta em movidos). Idempotente por existência do arquivo; nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_criar.py",
-   "caminho": "_scripts/det_criar.py",
-   "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_rotina_painel.py",
-   "caminho": "_scripts/instalar_rotina_painel.py",
-   "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_servidor_painel.py",
-   "caminho": "_scripts/instalar_servidor_painel.py",
-   "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "aft_doctor.py",
-   "caminho": "_scripts/aft_doctor.py",
-   "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "fotos_para_pdf.py",
-   "caminho": "_scripts/fotos_para_pdf.py",
-   "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
-   "runtime": "Python · pillow"
-  },
-  {
-   "nome": "comprimir_pdf.py",
-   "caminho": "_scripts/comprimir_pdf.py",
-   "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
-   "runtime": "Python · pikepdf/pypdf"
-  },
-  {
-   "nome": "docx_pack.py / docx_unpack.py",
-   "caminho": "_scripts/docx_*.py",
-   "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "nome": "scan_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
-   "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
-   "runtime": "Python · pypdf"
-  },
-  {
-   "nome": "gera_relacao_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
-   "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
-   "runtime": "Python (python-docx)"
-  },
-  {
-   "nome": "inspecionar_assinatura.py",
-   "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
-   "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
-   "runtime": "Python"
-  },
-  {
-   "nome": "validar.py",
-   "caminho": "aft-jornada-valida-afd-aej/validar.py",
-   "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "gerar_relatorio_docx.py",
-   "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
-   "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "runtime": "Python stdlib",
-   "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
-   "nome": "pasta_aft.py",
-   "caminho": "_scripts/pasta_aft.py"
-  },
-  {
-   "nome": "instalar_agentes.py",
-   "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
-  },
-  {
-   "nome": "erro_ticket.py",
-   "caminho": "_scripts/erro_ticket.py",
-   "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sync_perfil.py",
-   "caminho": "_scripts/sync_perfil.py",
-   "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sessoes_os.py",
-   "caminho": "_scripts/sessoes_os.py",
-   "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_vigia_sessoes.py",
-   "caminho": "_scripts/instalar_vigia_sessoes.py",
-   "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "checar_acentos.py",
-   "caminho": "_scripts/checar_acentos.py",
-   "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivos_internos.py",
-   "caminho": "_scripts/checar_arquivos_internos.py",
-   "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "indenta_quebras.py",
-   "caminho": "_scripts/indenta_quebras.py",
-   "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "ajuda_arquitetura.py",
-   "caminho": "_scripts/ajuda_arquitetura.py",
-   "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebook_id.py",
-   "caminho": "_scripts/notebook_id.py",
-   "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
-   "runtime": "python (stdlib) + CLI notebooklm na sondagem"
-  },
-  {
-   "nome": "sincronizar_notebooks.py",
-   "caminho": "_scripts/sincronizar_notebooks.py",
-   "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebooklm_consulta.py",
-   "caminho": "_scripts/notebooklm_consulta.py",
-   "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
-   "runtime": "python (stdlib) + CLI notebooklm"
-  },
-  {
-   "nome": "lre_esocial.py",
-   "caminho": "_scripts/lre_esocial.py",
-   "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_ferias.py",
-   "caminho": "_scripts/lre_ferias.py",
-   "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_folha.py",
-   "caminho": "_scripts/lre_folha.py",
-   "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "cbo.json",
-   "caminho": "_scripts/cbo.json",
-   "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
-   "runtime": "dado (JSON)"
-  },
-  {
-   "nome": "consulta_cnpj.py",
-   "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
-   "runtime": "Python stdlib"
-  }
- ],
- "dados": [
-  {
-   "arquivo": "config/notebooks.json",
-   "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
-   "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
-  },
-  {
-   "arquivo": "config/uorgs.csv",
-   "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
-   "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
-  },
-  {
-   "arquivo": "config/CLAUDE-aft.md",
-   "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
-   "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
-  },
-  {
-   "arquivo": "config/blocos_auto.md",
-   "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
-   "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
-  },
-  {
-   "arquivo": "config/settings-aft.json",
-   "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
-   "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
-  },
-  {
-   "arquivo": "config/models-validos.json",
-   "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
-   "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
-  }
- ],
- "ementas": [
-  {
-   "camada": "1. NotebookLM (recomendado)",
-   "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
-  },
-  {
-   "camada": "2. Google Drive compartilhado",
-   "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
-  },
-  {
-   "camada": "3. O AFT informa o código",
-   "txt": "Formato XXXXXX-X, conferido no ementário oficial."
-  }
- ],
- "anonimizacao": [
-  "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
-  "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
-  "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
-  "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
-  "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
-  "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
-  "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
- ],
- "decisoes": [
-  {
-   "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
-   "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
-  },
-  {
-   "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
-   "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
-  },
-  {
-   "topico": "Relação de autos é .docx, sem PDF",
-   "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
-  },
-  {
-   "topico": "Nomes das skills",
-   "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
-  },
-  {
-   "topico": "Instalação",
-   "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
-  },
-  {
-   "topico": "Git obrigatório",
-   "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
-  },
-  {
-   "topico": "Sem SISOS/Supabase",
-   "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
-  },
-  {
-   "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
-   "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
-  },
-  {
-   "topico": "Empacotamento único",
-   "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
-  },
-  {
-   "topico": "Latin-1 sem iconv",
-   "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
-  },
-  {
-   "topico": "Lotação pela cidade",
-   "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
-  },
-  {
-   "topico": "Ementas em 3 camadas",
-   "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
-  },
-  {
-   "topico": "Bloco 3 centralizado",
-   "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
-  },
-  {
-   "topico": "Atualização separada do diagnóstico",
-   "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
-  },
-  {
-   "topico": "Política de model por skill",
-   "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
-  },
-  {
-   "topico": "allowed-tools como garantia",
-   "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
-  },
-  {
-   "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
-   "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
-  },
-  {
-   "topico": "Detecção determinística no /aft-painel",
-   "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
-  },
-  {
-   "topico": "Bases distintas",
-   "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
-  },
-  {
-   "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
-   "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
-  },
-  {
-   "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
-   "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
-  },
-  {
-   "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
-   "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
-  },
-  {
-   "topico": "Painel virou dashboard de cards (SISOS local, offline)",
-   "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
-  },
-  {
-   "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
-   "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
-  },
-  {
-   "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
-   "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
-  },
-  {
-   "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
-   "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
-  },
-  {
-   "topico": "Painel ativo (modo interativo local)",
-   "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
-  },
-  {
-   "topico": "Extensão Chrome sincroniza o DET com o painel local",
-   "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
-  },
-  {
-   "topico": "Servidor do painel sempre ligado (padrão na instalação)",
-   "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
-  },
-  {
-   "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
-   "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
-  },
-  {
-   "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
-   "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
-  },
-  {
-   "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
-   "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
-  },
-  {
-   "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
-   "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
-  },
-  {
-   "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
-   "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
-  },
-  {
-   "topico": "Google Calendar: conector do Claude, não OAuth próprio",
-   "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
-  },
-  {
-   "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
-   "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
-  },
-  {
-   "topico": "Pasta única interdicao-embargo/ por OS",
-   "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
-  },
-  {
-   "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
-   "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
-  },
-  {
-   "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
-   "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
-  },
-  {
-   "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
-   "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
-  },
-  {
-   "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
-   "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
-  },
-  {
-   "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
-   "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
-  },
-  {
-   "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
-   "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
-  },
-  {
-   "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
-   "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
-  },
-  {
-   "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
-   "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
-  },
-  {
-   "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
-   "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
-  },
-  {
-   "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
-   "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
-  }
- ],
- "diferencas": [
-  {
-   "topico": "Plataforma",
-   "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
-  },
-  {
-   "topico": "Estado central",
-   "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
-  },
-  {
-   "topico": "Empacotamento",
-   "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
-  },
-  {
-   "topico": "Identidade do AFT",
-   "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
-  }
- ],
- "foraDoToolkit": [
-  "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
-  "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
-  "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
-  "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
-  "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
- ],
- "avisos": [
-  "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
-  "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
-  "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
-  "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
-  "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
-  "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
-  "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-  "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
-  "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
- ]
+  ],
+  "ementas": [
+    {
+      "camada": "1. NotebookLM (recomendado)",
+      "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
+    },
+    {
+      "camada": "2. Google Drive compartilhado",
+      "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
+    },
+    {
+      "camada": "3. O AFT informa o código",
+      "txt": "Formato XXXXXX-X, conferido no ementário oficial."
+    }
+  ],
+  "anonimizacao": [
+    "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
+    "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
+    "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
+    "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
+    "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
+    "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
+    "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
+  ],
+  "decisoes": [
+    {
+      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+    },
+    {
+      "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
+      "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
+    },
+    {
+      "topico": "Relação de autos é .docx, sem PDF",
+      "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
+    },
+    {
+      "topico": "Nomes das skills",
+      "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
+    },
+    {
+      "topico": "Instalação",
+      "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
+    },
+    {
+      "topico": "Git obrigatório",
+      "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
+    },
+    {
+      "topico": "Sem SISOS/Supabase",
+      "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
+    },
+    {
+      "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
+      "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
+    },
+    {
+      "topico": "Empacotamento único",
+      "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
+    },
+    {
+      "topico": "Latin-1 sem iconv",
+      "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
+    },
+    {
+      "topico": "Lotação pela cidade",
+      "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
+    },
+    {
+      "topico": "Ementas em 3 camadas",
+      "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
+    },
+    {
+      "topico": "Bloco 3 centralizado",
+      "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
+    },
+    {
+      "topico": "Atualização separada do diagnóstico",
+      "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
+    },
+    {
+      "topico": "Política de model por skill",
+      "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
+    },
+    {
+      "topico": "allowed-tools como garantia",
+      "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
+    },
+    {
+      "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
+      "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
+    },
+    {
+      "topico": "Detecção determinística no /aft-painel",
+      "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
+    },
+    {
+      "topico": "Bases distintas",
+      "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
+    },
+    {
+      "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
+      "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
+    },
+    {
+      "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
+      "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
+    },
+    {
+      "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
+      "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
+    },
+    {
+      "topico": "Painel virou dashboard de cards (SISOS local, offline)",
+      "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
+    },
+    {
+      "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
+      "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
+    },
+    {
+      "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
+      "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
+    },
+    {
+      "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
+      "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
+    },
+    {
+      "topico": "Painel ativo (modo interativo local)",
+      "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
+    },
+    {
+      "topico": "Extensão Chrome sincroniza o DET com o painel local",
+      "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
+    },
+    {
+      "topico": "Servidor do painel sempre ligado (padrão na instalação)",
+      "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
+    },
+    {
+      "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
+      "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
+    },
+    {
+      "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
+      "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
+    },
+    {
+      "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
+      "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
+    },
+    {
+      "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
+      "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
+    },
+    {
+      "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
+      "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
+    },
+    {
+      "topico": "Google Calendar: conector do Claude, não OAuth próprio",
+      "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
+    },
+    {
+      "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
+      "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
+    },
+    {
+      "topico": "Pasta única interdicao-embargo/ por OS",
+      "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
+    },
+    {
+      "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
+      "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
+    },
+    {
+      "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
+      "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
+    },
+    {
+      "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
+      "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
+    },
+    {
+      "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
+      "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
+    },
+    {
+      "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
+      "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
+    },
+    {
+      "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
+      "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
+    },
+    {
+      "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
+      "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
+    },
+    {
+      "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
+      "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
+    },
+    {
+      "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
+      "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
+    },
+    {
+      "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
+      "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
+    }
+  ],
+  "diferencas": [
+    {
+      "topico": "Plataforma",
+      "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
+    },
+    {
+      "topico": "Estado central",
+      "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
+    },
+    {
+      "topico": "Empacotamento",
+      "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
+    },
+    {
+      "topico": "Identidade do AFT",
+      "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
+    }
+  ],
+  "foraDoToolkit": [
+    "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
+    "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
+    "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
+    "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
+    "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
+  ],
+  "avisos": [
+    "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
+    "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
+    "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
+    "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
+    "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
+    "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
+    "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
+    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
+  ]
 };
 
 const $=s=>document.querySelector(s), el=(t,c,h)=>{const e=document.createElement(t);if(c)e.className=c;if(h!=null)e.innerHTML=h;return e;};

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -1,932 +1,937 @@
 {
- "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
- "repo": "github.com/ryckardo42/aft-toolkit",
- "data": "2026-08-24",
- "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
- "stats": {
-  "skills": 52,
-  "scripts": 42,
-  "dados": 6,
-  "commit": "ver `git log -1` — atualizado em 23/08/2026"
- },
- "atores": [
-  {
-   "nome": "AFT colega (novo usuário)",
-   "papel": "Auditor no Windows",
-   "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
+  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
+  "repo": "github.com/ryckardo42/aft-toolkit",
+  "data": "2026-08-24",
+  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+  "stats": {
+    "skills": 53,
+    "scripts": 42,
+    "dados": 6,
+    "commit": "ver `git log -1` — atualizado em 24/08/2026"
   },
-  {
-   "nome": "Claude Code",
-   "papel": "Assistente técnico",
-   "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
-  },
-  {
-   "nome": "Sistema Auditor",
-   "papel": "App oficial do MTE",
-   "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
-  },
-  {
-   "nome": "NotebookLM",
-   "papel": "Fonte de ementas",
-   "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
-  },
-  {
-   "nome": "Ricardo (mantenedor)",
-   "papel": "AFT — SRTE/GO",
-   "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
-  }
- ],
- "fluxo": [
-  {
-   "who": "/aft-preparacao-acao-fiscal",
-   "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
-  },
-  {
-   "who": "/aft-nova-auditoria",
-   "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
-  },
-  {
-   "who": "/aft-painel",
-   "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
-  },
-  {
-   "who": "Visita ao estabelecimento",
-   "act": "Inspeção física presencial."
-  },
-  {
-   "who": "/aft-inspecao-fisica",
-   "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
-  },
-  {
-   "who": "/aft-auditoria-geral",
-   "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
-  },
-  {
-   "who": "/aft-revisa-auto",
-   "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
-  },
-  {
-   "who": "/aft-gera-ai",
-   "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
-  },
-  {
-   "who": "Sistema Auditor",
-   "act": "Botão imp. txt → revisão do AFT → transmissão."
-  },
-  {
-   "who": "/aft-autos-lavrados",
-   "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
-  },
-  {
-   "who": "/aft-relatorio",
-   "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
-  }
- ],
- "instalacao": [
-  {
-   "who": "Instalar o app Claude",
-   "act": "claude.com/claude-code — único passo realmente inicial."
-  },
-  {
-   "who": "Instalar o Git + reiniciar pela bandeja",
-   "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
-  },
-  {
-   "who": "Colar o prompt de instalação no </> Code",
-   "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
-  },
-  {
-   "who": "/aft-setup",
-   "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
-  },
-  {
-   "who": "Codex: dois atalhos (opcional)",
-   "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
-  }
- ],
- "camadas": [
-  {
-   "nome": "Configuração e visão geral",
-   "cor": "accent2",
-   "skills": [
+  "atores": [
     {
-     "nome": "/aft-ajuda",
-     "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
-     "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+      "nome": "AFT colega (novo usuário)",
+      "papel": "Auditor no Windows",
+      "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
     },
     {
-     "nome": "/aft-setup",
-     "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
-     "tech": "winget · pipx · uorgs.csv · model: sonnet"
+      "nome": "Claude Code",
+      "papel": "Assistente técnico",
+      "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
     },
     {
-     "nome": "/aft-doctor",
-     "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
-     "tech": "aft_doctor.py · model: sonnet"
+      "nome": "Sistema Auditor",
+      "papel": "App oficial do MTE",
+      "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
     },
     {
-     "nome": "/aft-erro",
-     "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
-     "tech": "erro_ticket.py · model: sonnet"
+      "nome": "NotebookLM",
+      "papel": "Fonte de ementas",
+      "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
     },
     {
-     "nome": "/aft-atualizar",
-     "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
-     "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-notebooklm-login",
-     "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
-     "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-auditoria",
-     "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
-     "tech": "cria memory.md · model: sonnet"
-    },
-    {
-     "nome": "/aft-organiza-os",
-     "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
-     "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
-    },
-    {
-     "nome": "/aft-painel",
-     "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
-     "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
-    },
-    {
-     "nome": "/aft-agenda-det",
-     "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
-    },
-    {
-     "nome": "/aft-det-baixar",
-     "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da OS. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
-     "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-det-baixar-notificacoes",
-     "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da /aft-det-baixar, então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
-     "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-skill",
-     "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
-     "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+      "nome": "Ricardo (mantenedor)",
+      "papel": "AFT — SRTE/GO",
+      "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
     }
-   ]
-  },
-  {
-   "nome": "Preparação da ação fiscal (antes da visita)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "fluxo": [
     {
-     "nome": "/aft-preparacao-acao-fiscal",
-     "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
-     "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+      "who": "/aft-preparacao-acao-fiscal",
+      "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
     },
     {
-     "nome": "/aft-cnpjs-endereco",
-     "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
-     "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+      "who": "/aft-nova-auditoria",
+      "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
     },
     {
-     "nome": "/aft-NAD",
-     "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
-     "tech": "espelha /aft-tn-nco · model: sonnet"
+      "who": "/aft-painel",
+      "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
     },
     {
-     "nome": "/aft-lre-esocial",
-     "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
-     "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+      "who": "Visita ao estabelecimento",
+      "act": "Inspeção física presencial."
+    },
+    {
+      "who": "/aft-inspecao-fisica",
+      "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
+    },
+    {
+      "who": "/aft-auditoria-geral",
+      "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
+    },
+    {
+      "who": "/aft-revisa-auto",
+      "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
+    },
+    {
+      "who": "/aft-gera-ai",
+      "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
+    },
+    {
+      "who": "Sistema Auditor",
+      "act": "Botão imp. txt → revisão do AFT → transmissão."
+    },
+    {
+      "who": "/aft-autos-lavrados",
+      "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
+    },
+    {
+      "who": "/aft-relatorio",
+      "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
     }
-   ]
-  },
-  {
-   "nome": "Inspeção e lavratura",
-   "cor": "accent",
-   "skills": [
+  ],
+  "instalacao": [
     {
-     "nome": "/aft-inspecao-fisica",
-     "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
-     "tech": "relato → memory.md · model: sonnet"
+      "who": "Instalar o app Claude",
+      "act": "claude.com/claude-code — único passo realmente inicial."
     },
     {
-     "nome": "/aft-consulta",
-     "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
-     "tech": "notebooklm ask · herda o modelo da sessão"
+      "who": "Instalar o Git + reiniciar pela bandeja",
+      "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
     },
     {
-     "nome": "/aft-auditoria-geral",
-     "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
-     "tech": "orquestra consultoras · herda o modelo da sessão"
+      "who": "Colar o prompt de instalação no </> Code",
+      "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
     },
     {
-     "nome": "/aft-informalidade",
-     "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
-     "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+      "who": "/aft-setup",
+      "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
     },
     {
-     "nome": "/aft-PGR-analise",
-     "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-aet-auditoria",
-     "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-auditoria-AR-NR12",
-     "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
-     "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
-    },
-    {
-     "nome": "/aft-det-630",
-     "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
-     "tech": "escreve em ## Notificações DET · model: sonnet"
-    },
-    {
-     "nome": "/aft-tn-nco",
-     "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
-     "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
-    },
-    {
-     "nome": "/aft-email",
-     "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
-     "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
-    },
-    {
-     "nome": "/aft-embargo-interdicao",
-     "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
-     "tech": "template.docx SRTE/GO · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-manutencao",
-     "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
-     "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-levantamento",
-     "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
-     "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
-    },
-    {
-     "nome": "/aft-analise-acidente",
-     "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
-     "tech": "gerar_relatorio_docx.py · model: opus 1M"
+      "who": "Codex: dois atalhos (opcional)",
+      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
     }
-   ]
-  },
-  {
-   "nome": "Consultoras especializadas por NR",
-   "cor": "warn",
-   "skills": [
+  ],
+  "camadas": [
     {
-     "nome": "/aft-NR01",
-     "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
-     "tech": ""
+      "nome": "Configuração e visão geral",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-ajuda",
+          "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
+          "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+        },
+        {
+          "nome": "/aft-setup",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+          "tech": "winget · pipx · uorgs.csv · model: sonnet"
+        },
+        {
+          "nome": "/aft-doctor",
+          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
+          "tech": "aft_doctor.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-erro",
+          "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
+          "tech": "erro_ticket.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-atualizar",
+          "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
+          "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-notebooklm-login",
+          "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
+          "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-auditoria",
+          "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
+          "tech": "cria memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-organiza-os",
+          "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (PDFs de notificação + resposta do empregador) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está.",
+          "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
+        },
+        {
+          "nome": "/aft-painel",
+          "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
+          "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
+        },
+        {
+          "nome": "/aft-agenda-det",
+          "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
+        },
+        {
+          "nome": "/aft-det-baixar",
+          "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da OS. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
+          "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-det-baixar-notificacoes",
+          "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ da /aft-det-baixar, então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
+          "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-skill",
+          "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
+          "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR12",
-     "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Preparação da ação fiscal (antes da visita)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-preparacao-acao-fiscal",
+          "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
+          "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+        },
+        {
+          "nome": "/aft-cnpjs-endereco",
+          "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
+          "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-NAD",
+          "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
+          "tech": "espelha /aft-tn-nco · model: sonnet"
+        },
+        {
+          "nome": "/aft-lre-esocial",
+          "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
+          "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR18",
-     "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Inspeção e lavratura",
+      "cor": "accent",
+      "skills": [
+        {
+          "nome": "/aft-inspecao-fisica",
+          "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
+          "tech": "relato → memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-consulta",
+          "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
+          "tech": "notebooklm ask · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-auditoria-geral",
+          "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
+          "tech": "orquestra consultoras · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-informalidade",
+          "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
+          "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+        },
+        {
+          "nome": "/aft-PGR-analise",
+          "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-PGRTR-analise",
+          "role": "Auditoria sistemática do PGRTR (NR-31, rural) na base fixa de 30 ementas, com confronto campo × documento, extração delegada e citação de páginas.",
+          "tech": "handoff p/ gera-ai · model: opus"
+        },
+        {
+          "nome": "/aft-aet-auditoria",
+          "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-auditoria-AR-NR12",
+          "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
+          "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
+        },
+        {
+          "nome": "/aft-det-630",
+          "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
+          "tech": "escreve em ## Notificações DET · model: sonnet"
+        },
+        {
+          "nome": "/aft-tn-nco",
+          "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
+          "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
+        },
+        {
+          "nome": "/aft-email",
+          "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
+          "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
+        },
+        {
+          "nome": "/aft-embargo-interdicao",
+          "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
+          "tech": "template.docx SRTE/GO · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-manutencao",
+          "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
+          "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-levantamento",
+          "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
+          "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
+        },
+        {
+          "nome": "/aft-analise-acidente",
+          "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
+          "tech": "gerar_relatorio_docx.py · model: opus 1M"
+        }
+      ]
     },
     {
-     "nome": "/aft-cnae-grau-risco-nr04",
-     "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
-     "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+      "nome": "Consultoras especializadas por NR",
+      "cor": "warn",
+      "skills": [
+        {
+          "nome": "/aft-NR01",
+          "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
+          "tech": ""
+        },
+        {
+          "nome": "/aft-NR12",
+          "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-NR18",
+          "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cnae-grau-risco-nr04",
+          "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
+          "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-dimensionamento-sesmt-nr04",
+          "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
+          "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cipa-nr05-dimensionamento",
+          "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
+          "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-nr24-dimensionamento",
+          "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
+          "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-dimensionamento-sesmt-nr04",
-     "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
-     "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+      "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-jornada-analise",
+          "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
+          "tech": "roteador · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-valida-afd-aej",
+          "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
+          "tech": "validar.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-atestado",
+          "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
+          "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-jornada-auto-afd-aej",
+          "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
+          "tech": "handoff p/ gera-ai · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-cipa-nr05-dimensionamento",
-     "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
-     "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-nr24-dimensionamento",
-     "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
-     "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+      "nome": "Empacotamento, rastreamento e relatórios",
+      "cor": "ok",
+      "skills": [
+        {
+          "nome": "/aft-revisa-auto",
+          "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
+          "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+        },
+        {
+          "nome": "/aft-gera-ai",
+          "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
+          "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-lavrados",
+          "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
+          "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-pdf-reunidos",
+          "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
+          "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio",
+          "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
+          "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio-acidentes",
+          "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
+          "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-cat-trabalhador",
+          "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
+          "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
+        },
+        {
+          "nome": "/aft-modelo-docx",
+          "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
+          "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
+        },
+        {
+          "nome": "/aft-sessoes-os",
+          "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
+          "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+        }
+      ]
     }
-   ]
-  },
-  {
-   "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "scripts": [
     {
-     "nome": "/aft-jornada-analise",
-     "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
-     "tech": "roteador · model: sonnet"
+      "nome": "rehydrate.py",
+      "caminho": "_scripts/rehydrate.py",
+      "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-valida-afd-aej",
-     "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
-     "tech": "validar.py · model: sonnet"
+      "nome": "bloco3_inject.py",
+      "caminho": "_scripts/bloco3_inject.py",
+      "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-atestado",
-     "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
-     "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+      "nome": "validar_txt.py",
+      "caminho": "_scripts/validar_txt.py",
+      "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-auto-afd-aej",
-     "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
-     "tech": "handoff p/ gera-ai · model: sonnet"
+      "nome": "checar_pii.py",
+      "caminho": "_scripts/checar_pii.py",
+      "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_diff.py",
+      "caminho": "_scripts/checar_diff.py",
+      "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivo_aberto.py",
+      "caminho": "_scripts/checar_arquivo_aberto.py",
+      "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "backup_arquivo.py",
+      "caminho": "_scripts/backup_arquivo.py",
+      "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_rt_autos.py",
+      "caminho": "_scripts/checar_rt_autos.py",
+      "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
+      "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
+    },
+    {
+      "nome": "gerar_painel.py",
+      "caminho": "_scripts/gerar_painel.py",
+      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+      "runtime": "Python stdlib (+pdfplumber opcional)"
+    },
+    {
+      "nome": "servir_painel.py",
+      "caminho": "_scripts/servir_painel.py",
+      "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_sync.py",
+      "caminho": "_scripts/det_sync.py",
+      "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_baixar.py",
+      "caminho": "_scripts/det_baixar.py",
+      "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ (convenção do AFT, 21/08/2026 — data do primeiro download, sem o prefixo notificacao- no nome): os 2 PDFs + item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote; legados migram sozinhos (pacote notificacao-<COD> na raiz ou em NOTIFICACOES/ é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro, conta em movidos). Idempotente por existência do arquivo; nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_criar.py",
+      "caminho": "_scripts/det_criar.py",
+      "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_rotina_painel.py",
+      "caminho": "_scripts/instalar_rotina_painel.py",
+      "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_servidor_painel.py",
+      "caminho": "_scripts/instalar_servidor_painel.py",
+      "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "aft_doctor.py",
+      "caminho": "_scripts/aft_doctor.py",
+      "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "fotos_para_pdf.py",
+      "caminho": "_scripts/fotos_para_pdf.py",
+      "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
+      "runtime": "Python · pillow"
+    },
+    {
+      "nome": "comprimir_pdf.py",
+      "caminho": "_scripts/comprimir_pdf.py",
+      "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
+      "runtime": "Python · pikepdf/pypdf"
+    },
+    {
+      "nome": "docx_pack.py / docx_unpack.py",
+      "caminho": "_scripts/docx_*.py",
+      "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "nome": "scan_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
+      "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
+      "runtime": "Python · pypdf"
+    },
+    {
+      "nome": "gera_relacao_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
+      "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
+      "runtime": "Python (python-docx)"
+    },
+    {
+      "nome": "inspecionar_assinatura.py",
+      "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
+      "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
+      "runtime": "Python"
+    },
+    {
+      "nome": "validar.py",
+      "caminho": "aft-jornada-valida-afd-aej/validar.py",
+      "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "gerar_relatorio_docx.py",
+      "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
+      "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "runtime": "Python stdlib",
+      "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
+      "nome": "pasta_aft.py",
+      "caminho": "_scripts/pasta_aft.py"
+    },
+    {
+      "nome": "instalar_agentes.py",
+      "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
+    },
+    {
+      "nome": "erro_ticket.py",
+      "caminho": "_scripts/erro_ticket.py",
+      "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sync_perfil.py",
+      "caminho": "_scripts/sync_perfil.py",
+      "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sessoes_os.py",
+      "caminho": "_scripts/sessoes_os.py",
+      "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_vigia_sessoes.py",
+      "caminho": "_scripts/instalar_vigia_sessoes.py",
+      "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "checar_acentos.py",
+      "caminho": "_scripts/checar_acentos.py",
+      "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivos_internos.py",
+      "caminho": "_scripts/checar_arquivos_internos.py",
+      "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "indenta_quebras.py",
+      "caminho": "_scripts/indenta_quebras.py",
+      "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "ajuda_arquitetura.py",
+      "caminho": "_scripts/ajuda_arquitetura.py",
+      "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebook_id.py",
+      "caminho": "_scripts/notebook_id.py",
+      "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
+      "runtime": "python (stdlib) + CLI notebooklm na sondagem"
+    },
+    {
+      "nome": "sincronizar_notebooks.py",
+      "caminho": "_scripts/sincronizar_notebooks.py",
+      "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebooklm_consulta.py",
+      "caminho": "_scripts/notebooklm_consulta.py",
+      "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
+      "runtime": "python (stdlib) + CLI notebooklm"
+    },
+    {
+      "nome": "lre_esocial.py",
+      "caminho": "_scripts/lre_esocial.py",
+      "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_ferias.py",
+      "caminho": "_scripts/lre_ferias.py",
+      "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_folha.py",
+      "caminho": "_scripts/lre_folha.py",
+      "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "cbo.json",
+      "caminho": "_scripts/cbo.json",
+      "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
+      "runtime": "dado (JSON)"
+    },
+    {
+      "nome": "consulta_cnpj.py",
+      "caminho": "_scripts/consulta_cnpj.py",
+      "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+      "runtime": "Python stdlib"
     }
-   ]
-  },
-  {
-   "nome": "Empacotamento, rastreamento e relatórios",
-   "cor": "ok",
-   "skills": [
+  ],
+  "dados": [
     {
-     "nome": "/aft-revisa-auto",
-     "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
-     "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+      "arquivo": "config/notebooks.json",
+      "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
+      "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
     },
     {
-     "nome": "/aft-gera-ai",
-     "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
-     "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+      "arquivo": "config/uorgs.csv",
+      "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
+      "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
     },
     {
-     "nome": "/aft-autos-lavrados",
-     "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
-     "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+      "arquivo": "config/CLAUDE-aft.md",
+      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
+      "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
     },
     {
-     "nome": "/aft-autos-pdf-reunidos",
-     "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
-     "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+      "arquivo": "config/blocos_auto.md",
+      "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
+      "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
     },
     {
-     "nome": "/aft-relatorio",
-     "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
-     "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+      "arquivo": "config/settings-aft.json",
+      "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
+      "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
     },
     {
-     "nome": "/aft-relatorio-acidentes",
-     "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
-     "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
-    },
-    {
-     "nome": "/aft-cat-trabalhador",
-     "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
-     "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
-    },
-    {
-     "nome": "/aft-modelo-docx",
-     "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
-     "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
-    },
-    {
-     "nome": "/aft-sessoes-os",
-     "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
-     "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+      "arquivo": "config/models-validos.json",
+      "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
+      "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
     }
-   ]
-  }
- ],
- "scripts": [
-  {
-   "nome": "rehydrate.py",
-   "caminho": "_scripts/rehydrate.py",
-   "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "bloco3_inject.py",
-   "caminho": "_scripts/bloco3_inject.py",
-   "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "validar_txt.py",
-   "caminho": "_scripts/validar_txt.py",
-   "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_pii.py",
-   "caminho": "_scripts/checar_pii.py",
-   "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_diff.py",
-   "caminho": "_scripts/checar_diff.py",
-   "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivo_aberto.py",
-   "caminho": "_scripts/checar_arquivo_aberto.py",
-   "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "backup_arquivo.py",
-   "caminho": "_scripts/backup_arquivo.py",
-   "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_rt_autos.py",
-   "caminho": "_scripts/checar_rt_autos.py",
-   "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
-   "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
-  },
-  {
-   "nome": "gerar_painel.py",
-   "caminho": "_scripts/gerar_painel.py",
-   "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
-   "runtime": "Python stdlib (+pdfplumber opcional)"
-  },
-  {
-   "nome": "servir_painel.py",
-   "caminho": "_scripts/servir_painel.py",
-   "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_sync.py",
-   "caminho": "_scripts/det_sync.py",
-   "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_baixar.py",
-   "caminho": "_scripts/det_baixar.py",
-   "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<COD> <dd-mm-aaaa>/ (convenção do AFT, 21/08/2026 — data do primeiro download, sem o prefixo notificacao- no nome): os 2 PDFs + item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote; legados migram sozinhos (pacote notificacao-<COD> na raiz ou em NOTIFICACOES/ é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro, conta em movidos). Idempotente por existência do arquivo; nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_criar.py",
-   "caminho": "_scripts/det_criar.py",
-   "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_rotina_painel.py",
-   "caminho": "_scripts/instalar_rotina_painel.py",
-   "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_servidor_painel.py",
-   "caminho": "_scripts/instalar_servidor_painel.py",
-   "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "aft_doctor.py",
-   "caminho": "_scripts/aft_doctor.py",
-   "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "fotos_para_pdf.py",
-   "caminho": "_scripts/fotos_para_pdf.py",
-   "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
-   "runtime": "Python · pillow"
-  },
-  {
-   "nome": "comprimir_pdf.py",
-   "caminho": "_scripts/comprimir_pdf.py",
-   "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
-   "runtime": "Python · pikepdf/pypdf"
-  },
-  {
-   "nome": "docx_pack.py / docx_unpack.py",
-   "caminho": "_scripts/docx_*.py",
-   "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "nome": "scan_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
-   "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
-   "runtime": "Python · pypdf"
-  },
-  {
-   "nome": "gera_relacao_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
-   "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
-   "runtime": "Python (python-docx)"
-  },
-  {
-   "nome": "inspecionar_assinatura.py",
-   "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
-   "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
-   "runtime": "Python"
-  },
-  {
-   "nome": "validar.py",
-   "caminho": "aft-jornada-valida-afd-aej/validar.py",
-   "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "gerar_relatorio_docx.py",
-   "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
-   "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "runtime": "Python stdlib",
-   "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
-   "nome": "pasta_aft.py",
-   "caminho": "_scripts/pasta_aft.py"
-  },
-  {
-   "nome": "instalar_agentes.py",
-   "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
-  },
-  {
-   "nome": "erro_ticket.py",
-   "caminho": "_scripts/erro_ticket.py",
-   "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sync_perfil.py",
-   "caminho": "_scripts/sync_perfil.py",
-   "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sessoes_os.py",
-   "caminho": "_scripts/sessoes_os.py",
-   "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_vigia_sessoes.py",
-   "caminho": "_scripts/instalar_vigia_sessoes.py",
-   "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "checar_acentos.py",
-   "caminho": "_scripts/checar_acentos.py",
-   "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivos_internos.py",
-   "caminho": "_scripts/checar_arquivos_internos.py",
-   "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "indenta_quebras.py",
-   "caminho": "_scripts/indenta_quebras.py",
-   "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "ajuda_arquitetura.py",
-   "caminho": "_scripts/ajuda_arquitetura.py",
-   "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebook_id.py",
-   "caminho": "_scripts/notebook_id.py",
-   "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
-   "runtime": "python (stdlib) + CLI notebooklm na sondagem"
-  },
-  {
-   "nome": "sincronizar_notebooks.py",
-   "caminho": "_scripts/sincronizar_notebooks.py",
-   "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebooklm_consulta.py",
-   "caminho": "_scripts/notebooklm_consulta.py",
-   "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
-   "runtime": "python (stdlib) + CLI notebooklm"
-  },
-  {
-   "nome": "lre_esocial.py",
-   "caminho": "_scripts/lre_esocial.py",
-   "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_ferias.py",
-   "caminho": "_scripts/lre_ferias.py",
-   "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_folha.py",
-   "caminho": "_scripts/lre_folha.py",
-   "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "cbo.json",
-   "caminho": "_scripts/cbo.json",
-   "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
-   "runtime": "dado (JSON)"
-  },
-  {
-   "nome": "consulta_cnpj.py",
-   "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
-   "runtime": "Python stdlib"
-  }
- ],
- "dados": [
-  {
-   "arquivo": "config/notebooks.json",
-   "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
-   "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
-  },
-  {
-   "arquivo": "config/uorgs.csv",
-   "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
-   "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
-  },
-  {
-   "arquivo": "config/CLAUDE-aft.md",
-   "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
-   "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
-  },
-  {
-   "arquivo": "config/blocos_auto.md",
-   "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
-   "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
-  },
-  {
-   "arquivo": "config/settings-aft.json",
-   "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
-   "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
-  },
-  {
-   "arquivo": "config/models-validos.json",
-   "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
-   "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
-  }
- ],
- "ementas": [
-  {
-   "camada": "1. NotebookLM (recomendado)",
-   "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
-  },
-  {
-   "camada": "2. Google Drive compartilhado",
-   "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
-  },
-  {
-   "camada": "3. O AFT informa o código",
-   "txt": "Formato XXXXXX-X, conferido no ementário oficial."
-  }
- ],
- "anonimizacao": [
-  "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
-  "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
-  "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
-  "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
-  "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
-  "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
-  "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
- ],
- "decisoes": [
-  {
-   "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
-   "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
-  },
-  {
-   "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
-   "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
-  },
-  {
-   "topico": "Relação de autos é .docx, sem PDF",
-   "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
-  },
-  {
-   "topico": "Nomes das skills",
-   "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
-  },
-  {
-   "topico": "Instalação",
-   "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
-  },
-  {
-   "topico": "Git obrigatório",
-   "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
-  },
-  {
-   "topico": "Sem SISOS/Supabase",
-   "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
-  },
-  {
-   "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
-   "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
-  },
-  {
-   "topico": "Empacotamento único",
-   "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
-  },
-  {
-   "topico": "Latin-1 sem iconv",
-   "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
-  },
-  {
-   "topico": "Lotação pela cidade",
-   "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
-  },
-  {
-   "topico": "Ementas em 3 camadas",
-   "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
-  },
-  {
-   "topico": "Bloco 3 centralizado",
-   "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
-  },
-  {
-   "topico": "Atualização separada do diagnóstico",
-   "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
-  },
-  {
-   "topico": "Política de model por skill",
-   "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
-  },
-  {
-   "topico": "allowed-tools como garantia",
-   "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
-  },
-  {
-   "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
-   "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
-  },
-  {
-   "topico": "Detecção determinística no /aft-painel",
-   "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
-  },
-  {
-   "topico": "Bases distintas",
-   "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
-  },
-  {
-   "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
-   "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
-  },
-  {
-   "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
-   "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
-  },
-  {
-   "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
-   "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
-  },
-  {
-   "topico": "Painel virou dashboard de cards (SISOS local, offline)",
-   "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
-  },
-  {
-   "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
-   "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
-  },
-  {
-   "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
-   "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
-  },
-  {
-   "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
-   "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
-  },
-  {
-   "topico": "Painel ativo (modo interativo local)",
-   "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
-  },
-  {
-   "topico": "Extensão Chrome sincroniza o DET com o painel local",
-   "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
-  },
-  {
-   "topico": "Servidor do painel sempre ligado (padrão na instalação)",
-   "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
-  },
-  {
-   "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
-   "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
-  },
-  {
-   "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
-   "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
-  },
-  {
-   "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
-   "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
-  },
-  {
-   "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
-   "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
-  },
-  {
-   "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
-   "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
-  },
-  {
-   "topico": "Google Calendar: conector do Claude, não OAuth próprio",
-   "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
-  },
-  {
-   "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
-   "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
-  },
-  {
-   "topico": "Pasta única interdicao-embargo/ por OS",
-   "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
-  },
-  {
-   "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
-   "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
-  },
-  {
-   "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
-   "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
-  },
-  {
-   "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
-   "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
-  },
-  {
-   "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
-   "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
-  },
-  {
-   "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
-   "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
-  },
-  {
-   "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
-   "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
-  },
-  {
-   "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
-   "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
-  },
-  {
-   "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
-   "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
-  },
-  {
-   "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
-   "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
-  },
-  {
-   "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
-   "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
-  }
- ],
- "diferencas": [
-  {
-   "topico": "Plataforma",
-   "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
-  },
-  {
-   "topico": "Estado central",
-   "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
-  },
-  {
-   "topico": "Empacotamento",
-   "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
-  },
-  {
-   "topico": "Identidade do AFT",
-   "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
-  }
- ],
- "foraDoToolkit": [
-  "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
-  "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
-  "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
-  "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
-  "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
- ],
- "avisos": [
-  "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
-  "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
-  "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
-  "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
-  "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
-  "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
-  "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-  "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
-  "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
- ]
+  ],
+  "ementas": [
+    {
+      "camada": "1. NotebookLM (recomendado)",
+      "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
+    },
+    {
+      "camada": "2. Google Drive compartilhado",
+      "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
+    },
+    {
+      "camada": "3. O AFT informa o código",
+      "txt": "Formato XXXXXX-X, conferido no ementário oficial."
+    }
+  ],
+  "anonimizacao": [
+    "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
+    "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
+    "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
+    "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
+    "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
+    "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
+    "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
+  ],
+  "decisoes": [
+    {
+      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+    },
+    {
+      "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
+      "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
+    },
+    {
+      "topico": "Relação de autos é .docx, sem PDF",
+      "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
+    },
+    {
+      "topico": "Nomes das skills",
+      "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
+    },
+    {
+      "topico": "Instalação",
+      "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
+    },
+    {
+      "topico": "Git obrigatório",
+      "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
+    },
+    {
+      "topico": "Sem SISOS/Supabase",
+      "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
+    },
+    {
+      "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
+      "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
+    },
+    {
+      "topico": "Empacotamento único",
+      "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
+    },
+    {
+      "topico": "Latin-1 sem iconv",
+      "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
+    },
+    {
+      "topico": "Lotação pela cidade",
+      "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
+    },
+    {
+      "topico": "Ementas em 3 camadas",
+      "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
+    },
+    {
+      "topico": "Bloco 3 centralizado",
+      "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
+    },
+    {
+      "topico": "Atualização separada do diagnóstico",
+      "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
+    },
+    {
+      "topico": "Política de model por skill",
+      "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
+    },
+    {
+      "topico": "allowed-tools como garantia",
+      "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
+    },
+    {
+      "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
+      "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
+    },
+    {
+      "topico": "Detecção determinística no /aft-painel",
+      "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
+    },
+    {
+      "topico": "Bases distintas",
+      "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
+    },
+    {
+      "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
+      "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
+    },
+    {
+      "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
+      "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
+    },
+    {
+      "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
+      "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
+    },
+    {
+      "topico": "Painel virou dashboard de cards (SISOS local, offline)",
+      "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
+    },
+    {
+      "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
+      "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
+    },
+    {
+      "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
+      "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
+    },
+    {
+      "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
+      "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
+    },
+    {
+      "topico": "Painel ativo (modo interativo local)",
+      "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
+    },
+    {
+      "topico": "Extensão Chrome sincroniza o DET com o painel local",
+      "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
+    },
+    {
+      "topico": "Servidor do painel sempre ligado (padrão na instalação)",
+      "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
+    },
+    {
+      "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
+      "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
+    },
+    {
+      "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
+      "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
+    },
+    {
+      "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
+      "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
+    },
+    {
+      "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
+      "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
+    },
+    {
+      "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
+      "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
+    },
+    {
+      "topico": "Google Calendar: conector do Claude, não OAuth próprio",
+      "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
+    },
+    {
+      "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
+      "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
+    },
+    {
+      "topico": "Pasta única interdicao-embargo/ por OS",
+      "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
+    },
+    {
+      "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
+      "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
+    },
+    {
+      "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
+      "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
+    },
+    {
+      "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
+      "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
+    },
+    {
+      "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
+      "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
+    },
+    {
+      "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
+      "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
+    },
+    {
+      "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
+      "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
+    },
+    {
+      "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
+      "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
+    },
+    {
+      "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
+      "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
+    },
+    {
+      "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
+      "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
+    },
+    {
+      "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
+      "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
+    }
+  ],
+  "diferencas": [
+    {
+      "topico": "Plataforma",
+      "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
+    },
+    {
+      "topico": "Estado central",
+      "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
+    },
+    {
+      "topico": "Empacotamento",
+      "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
+    },
+    {
+      "topico": "Identidade do AFT",
+      "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
+    }
+  ],
+  "foraDoToolkit": [
+    "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
+    "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
+    "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
+    "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
+    "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
+  ],
+  "avisos": [
+    "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
+    "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
+    "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
+    "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
+    "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
+    "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
+    "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
+    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
+  ]
 }

--- a/novidades/2026-08-24-05-pgrtr-analise.md
+++ b/novidades/2026-08-24-05-pgrtr-analise.md
@@ -1,0 +1,16 @@
+## 24/08/2026
+<!-- commit: pgrtr-analise-skill -->
+
+**Nova skill: análise de PGRTR (trabalho rural).** A `/aft-PGRTR-analise` audita o
+Programa de Gerenciamento de Riscos do Trabalho Rural exigido pela NR-31 — o "PGR das
+fazendas". Ela varre uma base de 33 ementas de NR-31 (das instruções aos trabalhadores
+aos exames médicos, passando por trabalho com animais, clima extremo e trânsito interno),
+cada uma com código, capitulação e grau de infração conferidos no ementário oficial,
+confronta o documento com o que você viu na inspeção física, cita a página de cada
+evidência e, ao final, oferece a redação dos autos (prontos para o `/aft-gera-ai`) e uma
+carta de recomendação ao produtor rural. Documento grande é lido em segundo plano, fora
+da conversa, para não estourar o seu limite de uso — igual à análise de PGR urbano. A
+base de ementas nasceu de uma contribuição de um colega AFT usuário do toolkit. Não
+confunda: PGR urbano (NR-01) continua na `/aft-PGR-analise`; a nova cuida só do rural.
+
+---


### PR DESCRIPTION
Nova skill de auditoria de PGRTR (o PGR dos estabelecimentos rurais, NR-31), adaptada de uma contribuição de um colega AFT usuário do toolkit.

- Base fixa de 33 ementas de NR-31, com código, capitulação e gradação validados no ementário oficial (3 consultas ao notebook nr-31 em 24/08/2026).
- Arquitetura igual à /aft-PGR-analise: contexto de inspeção física obrigatório (modo confronto/documental), extração delegada ao agente aft-extrator-documento (roteiro de 7 blocos, saída pgrtr-extrato.md), análise sobre o extrato com citação de página, consulta complementar por key (nunca ID fixo de notebook), autos no formato /aft-gera-ai com o parágrafo canônico de dano coletivo.
- Agente aft-extrator-documento: PGRTR adicionado como quarto chamador (description e tabela).
- Testada de ponta a ponta num PGRTR real de 24 páginas (fazenda de soja): extração, varredura das 33 ementas, confronto de campo, consulta complementar e redação de 2 autos.
- Changelog em novidades/, nota técnica no cofre e arquitetura atualizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)