### PR TITLE
feat(tn-nco): itens da notificacao em ordem crescente de NR

### DIFF
--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -187,6 +187,31 @@ Em conformidade com a legislação em vigor, especialmente o previsto na alínea
 
 ### Itens (um por irregularidade)
 
+**ORDEM DOS ITENS: crescente por Norma Regulamentadora, da NR-01 à NR-38.** Agrupe os itens
+pela NR citada na base legal e ordene os grupos por número. Dentro de cada NR, mantenha a
+ordem lógica em que os itens foram redigidos (identificação de perigos antes do inventário,
+inventário antes do plano de ação).
+
+> Por que importa: uma notificação com os itens embaralhados por norma obriga o empregador a
+> reconstruir o assunto a cada linha. Agrupada, ela se lê de uma vez, e ele enxerga o que
+> resolve com cada consultoria — o PGR num bloco, o PCMSO noutro, as máquinas noutro. Numa
+> fiscalização real o AFT recebeu a notificação fora dessa ordem e a devolveu com a
+> observação de que estava "muito confusa, toda embaralhada".
+
+Três cuidados ao ordenar:
+
+- **A chave é a PRIMEIRA NR citada na base legal** do item — é a principal, sob a qual ele
+  foi redigido. As demais entram como complemento e não mudam a posição.
+- **Item sem NR na base legal** (só CLT, só Portaria) vai para o fim, e você avisa o AFT:
+  nunca se atribui uma NR ao item só para ele caber na ordem.
+- **REFERÊNCIA CRUZADA.** Item que mencione "no item N" tem o alvo deslocado pela
+  reordenação. Confira e corrija cada uma DEPOIS de ordenar — numa fiscalização real um item
+  apontava para "o item 1" quando o alvo havia se tornado o item 10.
+
+Ordene **antes** de gerar o `.docx` e **antes** de criar o rascunho no DET: o `det_criar.py`
+apenas cria notificação, não atualiza, e reordenar depois obriga a criar outra e o AFT a
+apagar a anterior no site.
+
 Formato de cada item:
 
 ```


### PR DESCRIPTION
A skill nao dizia nada sobre a ordem dos itens, e eles saem na ordem em que a analise os produziu -- que e a ordem dos achados, nao a das normas. Numa fiscalizacao real a notificacao saiu com NR-12, NR-01, NR-07, NR-17, NR-09, NR-10 e NR-12 de novo, e o AFT a devolveu: "esta muito confusa, toda embaralhada".

O motivo dele e pratico e vale para qualquer empregador: notificacao agrupada por norma se le de uma vez, e o notificado enxerga o que resolve com cada consultoria -- o PGR num bloco, o PCMSO noutro, as maquinas noutro. Embaralhada, obriga a reconstruir o assunto a cada linha.

O que muda: a FASE 3 passa a mandar agrupar por NR e ordenar os grupos, com tres cuidados que so aparecem quando se faz de verdade:

- a chave e a PRIMEIRA NR da base legal (a principal, sob a qual o item foi redigido); as demais nao mudam a posicao;
- item sem NR na base legal vai para o fim, com aviso ao AFT -- nunca se atribui uma NR ao item so para ele caber na ordem;
- REFERENCIA CRUZADA: item que diga "no item N" tem o alvo deslocado pela reordenacao. Num caso real um item apontava para "o item 1" quando o alvo havia virado o item 10.

E a ordenacao vai ANTES de gerar o .docx e de criar o rascunho: o det_criar.py cria notificacao, nao atualiza.