### PR TITLE
consulta_cnpj: reconfigura stdout para UTF-8 (acentos corrompidos na tela no Windows)

### DIFF
--- a/_scripts/consulta_cnpj.py
+++ b/_scripts/consulta_cnpj.py
@@ -27,6 +27,18 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+# O console do Windows abre em cp1252, e a base da RFB devolve razao social,
+# natureza juridica e descricao de CNAE com acento. Sem esta reconfiguracao a
+# tela mostra "Fabricacao" como "Fabrica??ao" e "Empresaria" como "Empres?ria":
+# o dado chega certo (a resposta e decodificada como UTF-8 mais abaixo) e se
+# corrompe so na impressao -- de modo que quem copia da tela para um documento
+# leva a corrupcao junto. errors="replace" garante que um caractere fora do
+# alcance jamais derrube a consulta.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:                                   # Python < 3.7 ou stdout redirecionado
+    pass
+
 CACHE_DIR = Path.home() / "Documents" / "AFT" / "cache" / "cnpj"
 TIMEOUT = 30
 


### PR DESCRIPTION
## O problema

No Windows, o `consulta_cnpj.py` imprime os dados cadastrais com os acentos corrompidos:

```
  Natureza juridica..: Sociedade Empres?ria Limitada
  CNAE principal.....: 2543800  Fabrica??ao de ferramentas
     2229301  Fabrica??ao de artefatos de material pl?stico
```

## A causa

O dado nunca esteve errado. A resposta da API já é decodificada como UTF-8 (`r.read().decode("utf-8")`) e o cache é gravado em UTF-8. O que falta é reconfigurar a **saída**: o console do Windows abre em cp1252, e `sys.stdout` herda esse encoding.

Ou seja, a corrupção acontece só na impressão — e é justamente aí que ela importa, porque a tela é de onde o auditor copia razão social, natureza jurídica e descrição de CNAE para dentro de um documento da inspeção, que exige acentuação completa.

## A correção

Uma linha, no mesmo padrão que outros scripts do toolkit já usam, com `errors="replace"` para que um caractere fora do alcance jamais derrube a consulta:

```python
try:
    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
except Exception:
    pass
```

Depois:

```
  Natureza juridica..: Sociedade Empresária Limitada
  CNAE principal.....: 2543800  Fabricação de ferramentas
```

## Testes

Executado contra uma consulta real de CNPJ, nos três modos em que o script é usado:

| Cenário | Resultado |
|---|---|
| Saída na tela | acentos corretos |
| Saída redirecionada para arquivo | acentos corretos no arquivo |
| `--json` redirecionado e parseado | JSON válido, 50 chaves, acentos corretos |

O `--json` não muda de forma alguma: já era `json.dumps` sobre os mesmos dados, e continua parseável pelos scripts que o consomem.

Não altera comportamento em macOS ou Linux, onde `sys.stdout` já costuma ser UTF-8 — nesses casos a chamada é inócua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)