### PR TITLE
pdf_texto_paginado: fecha o extrato com FIM DO DOCUMENTO (leitura truncada deixa de passar por completa)

### DIFF
--- a/_scripts/pdf_texto_paginado.py
+++ b/_scripts/pdf_texto_paginado.py
@@ -375,8 +375,23 @@ def main():
         partes.append("===== PAGINA %d =====\n%s" % (i, corpo))
 
     if not so_resumo:
+        # RODAPE DE FECHAMENTO. Sem ele, uma leitura TRUNCADA do extrato e
+        # indistinguivel de uma leitura completa -- e nada no texto denuncia a
+        # diferenca. O caso que motivou: um requerimento de fiscalizacao foi
+        # lido ate o meio da segunda pagina, teve a lista de pedidos dada por
+        # encerrada em cinco itens, e tinha oito. O erro so apareceu quando
+        # alguem releu o documento inteiro por outra razao.
+        #
+        # Quem le o extrato passa a ter como verificar que chegou ao fim: se
+        # este rodape nao apareceu, faltou documento.
+        corpo_final = "\n\n".join(partes)
+        corpo_final += (
+            "\n\n===== FIM DO DOCUMENTO | %s | %d pagina(s) | %d caracteres =====\n"
+            "Se esta linha nao aparece no que voce leu, a leitura foi TRUNCADA:\n"
+            "leia o restante antes de concluir qualquer coisa sobre o documento.\n"
+            % (os.path.basename(pdf_path), n, len(corpo_final)))
         with io.open(saida, "w", encoding="utf-8") as f:
-            f.write("\n\n".join(partes))
+            f.write(corpo_final)
 
     print("PDF: %s" % os.path.basename(pdf_path))
     print("Paginas: %d" % n)


### PR DESCRIPTION
## O problema

O extrato termina na última página, **sem nada que diga que era a última**. Uma leitura truncada fica, por isso, indistinguível de uma leitura completa: quem lê só parte do arquivo — por corte de saída, por limite de contexto, por um `head` mal calibrado — não tem como perceber que faltou documento.

## O caso concreto

Um requerimento de fiscalização foi lido até o meio da segunda página. A lista de pedidos foi dada por encerrada em **cinco itens**. Tinha **oito**.

Os três que faltavam só apareceram quando alguém releu o documento inteiro, dias depois, por outra razão. Nada no texto denunciava a falta — e o número errado já tinha sido gravado na ficha da OS.

## A correção

Seis linhas ao fim do arquivo gravado:

```
===== FIM DO DOCUMENTO | <arquivo> | <n> pagina(s) | <n> caracteres =====
Se esta linha nao aparece no que voce leu, a leitura foi TRUNCADA:
leia o restante antes de concluir qualquer coisa sobre o documento.
```

O ganho não é o aviso: é que a **verificação passa a ser possível**. Quem lê confere se chegou ao fim, em vez de supor que chegou.

O total de páginas e de caracteres vai no rodapé de propósito — permite conferir o extrato contra o resumo que o próprio script já imprime na tela.

## Testes

| O que | Resultado |
|---|---|
| Documento real de 6 páginas, 3 delas escaneadas sem camada de texto | rodapé gravado, contagem correta |
| `--so-resumo` | continua **não** gravando arquivo, como antes |

Nenhum dado de fiscalização no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)