### PR TITLE
_scripts: --help responde com a ajuda, e não gera ticket de erro

### DIFF
--- a/_scripts/checar_arquivos_internos.py
+++ b/_scripts/checar_arquivos_internos.py
@@ -88,6 +88,13 @@ def trechos_do_arquivo(caminho):
 
 
 def main():
+    # -h/--help responde com o proprio docstring. Antes, "--help" era tratado
+    # como caminho de arquivo: o script levantava FileNotFoundError e o
+    # mecanismo de ticket registrava isso como DEFEITO DO TOOLKIT -- um relato
+    # de bug gerado por alguem perguntando como usar a ferramenta.
+    if any(a in ("-h", "--help") for a in sys.argv[1:]):
+        print(__doc__ or "uso: python checar_arquivos_internos.py <arquivo>")
+        return 0
     if len(sys.argv) < 2:
         print("uso: python checar_arquivos_internos.py <arquivo>", file=sys.stderr)
         return 2

--- a/_scripts/indenta_quebras.py
+++ b/_scripts/indenta_quebras.py
@@ -49,6 +49,13 @@ def indentar_campo(campo: str) -> str:
 
 
 def main():
+    # -h/--help responde com o proprio docstring. Antes, "--help" era tratado
+    # como caminho de arquivo: o script levantava FileNotFoundError e o
+    # mecanismo de ticket registrava isso como DEFEITO DO TOOLKIT -- um relato
+    # de bug gerado por alguem perguntando como usar a ferramenta.
+    if any(a in ("-h", "--help") for a in sys.argv[1:]):
+        print(__doc__ or "uso: python indenta_quebras.py <arquivo>")
+        return 0
     if len(sys.argv) < 2:
         print("uso: python indenta_quebras.py <arquivo.txt>", file=sys.stderr)
         return 2


### PR DESCRIPTION
## O problema

`python checar_arquivos_internos.py --help` trata `--help` como **caminho de arquivo**. O script levanta `FileNotFoundError` e — por causa do `erro_ticket` — **grava um ticket de correção**, como se o toolkit tivesse um defeito.

O efeito é ruim em dois sentidos:

- quem quer aprender a usar a ferramenta recebe um *traceback* em vez da documentação, que já está escrita e completa no docstring;
- a pasta de tickets acumula **relatos de bug que não são bug**, prontos para serem encaminhados de boa-fé ao mantenedor.

## Como apareceu

Uma varredura rodou `--help` em cada script do `_scripts/` para descobrir quais respondiam com ajuda. Em quatro minutos, **sete tickets falsos** foram gravados — três scripts, cada um algumas vezes:

```
# Ticket de correção — AFT Toolkit
**FileNotFoundError em checar_acentos.py**
| Quando | 25/08/2026 às 05:03 |
```

O relato descreve o sintoma como erro de arquivo. A causa é o script não reconhecer o pedido de ajuda.

## A correção

Cinco linhas na entrada de `main()`, em cada arquivo: havendo `-h` ou `--help` entre os argumentos, imprime o `__doc__` e sai com 0. Nada mais muda.

O terceiro script com o mesmo defeito — `checar_acentos.py` — foi corrigido **no PR #85**, que já mexe naquele arquivo, para não criar conflito entre os dois PRs.

## Testes

| O que | Resultado |
|---|---|
| `--help` nos dois | imprime o docstring, exit 0, **nenhum ticket gerado** |
| arquivo real (`autos.md` de fiscalização encerrada) | comportamento idêntico ao anterior |
| sem argumento | segue com a mensagem de uso, como antes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)