### PR TITLE
Scripts internos: acentuacao, rastreamento, cotejo, tokenizar, ordem NR na TN-NCO

### DIFF
--- a/_scripts/checar_acentos.py
+++ b/_scripts/checar_acentos.py
@@ -75,7 +75,14 @@ MARCADORES = [
     "tolerancia", "vigilancia", "importancia", "distancia_ignore",
     "circunstancia", "circunstancias", "instancia", "relevancia",
     # substantivos/adjetivos com acento gráfico
-    "analise", "analises", "maquina", "maquinas", "pagina", "paginas",
+    #
+    # "analise" saiu da lista: é forma verbal legítima ("a análise que ele
+    # analise depois"), e reprovava texto correto. Mesmo motivo de "calculo"
+    # (eu calculo), "numero" (eu numero) e "vinculo" (eu vinculo), que também
+    # não entram. É o critério que o cabeçalho já declara — só entra a forma
+    # cuja versão sem acento NÃO é, ela mesma, palavra portuguesa válida.
+    "analise_ignore", "analises_ignore",
+    "maquina", "maquinas", "pagina", "paginas",
     "area", "areas", "nivel", "niveis", "criterio", "criterios", "periodo",
     "periodos", "seguranca", "amonia", "quimico", "quimicos", "quimica",
     "fisico", "fisicos", "fisica", "mecanico", "mecanicos", "mecanica",
@@ -87,6 +94,18 @@ MARCADORES = [
     "eletrico", "eletrica", "eletricos", "explosao", "corrosao", "reducao",
     "distancia", "vitima", "vitimas", "obitos", "obito", "saude", "tambem",
     "porem", "alem", "atraves", "apos", "ja_ignore",
+    # Vocabulario de SST e de inspecao colhido em fiscalizacao real
+    # (25/08/2026). Ficaram de fora as formas ja cobertas pela rede por
+    # terminacao acima, para nao repetir, e as que tem homografo verbal:
+    # "ultima" (ele ultima), "medica" e "medico" (eu medico).
+    "admissao", "automatica", "automatico", "biologica", "carcaca",
+    "carcacas", "codigo", "eletricas", "hidraulica", "hidraulico",
+    "higienica", "higienico", "indicio", "indicios", "maxima", "maximo",
+    "minima", "minimo", "moveis", "movel", "necessaria", "necessario",
+    "orgao", "orgaos", "periodica", "periodico", "pneumatica", "pneumatico",
+    "residuo", "residuos", "ruido", "ruidos", "sanitaria", "sanitario",
+    "sanitarios", "servico", "servicos", "ultimo", "uteis", "util", "veiculo",
+    "veiculos",
 ]
 # remove sentinelas ambíguas
 MARCADORES = [m for m in MARCADORES if not m.endswith("_ignore")]

--- a/_scripts/checar_acentos.py
+++ b/_scripts/checar_acentos.py
@@ -20,6 +20,18 @@ Só entram na lista formas cuja versão sem acento não é, ela mesma, uma palav
 portuguesa válida (evita falso-positivo). Por isso NÃO estão aqui casos ambíguos
 como "para/pára", "e/é", "esta/está", "so/só", "as/às".
 
+Duas redes complementam a lista, pelo mesmo critério de inequivocidade:
+
+  TERMINAÇÃO — nenhuma palavra portuguesa correta termina em "-cao", "-coes",
+  "-oes", "-avel" ou "-ivel" sem acento. Isso alcança vocabulário que nenhuma
+  lista teria ("exequivel", "manutencoes") sem precisar prevê-lo um a um.
+
+  RAZÃO SOCIAL — ela é registrada na Receita Federal SEM acento e vai ao auto
+  como consta do cadastro, de modo que a conferência de acentuação a ignora.
+  Sem isso o script reprovava um auto CORRETO sempre que a autuada se chamasse
+  "... PRODUCAO ...", "... MANUTENCAO ..." ou "... SEGURANCA ...", palavras que
+  já estavam na lista e são comuns em nome de empresa.
+
 Uso:
     python checar_acentos.py "<arquivo.md>"
 Saída: lista de achados com nº da linha; exit 0 se limpo, 1 se encontrou defeito.
@@ -57,6 +69,11 @@ MARCADORES = [
     "deteccao", "condicao", "condicoes", "observacao", "observacoes",
     "ocorrencia", "ocorrencias", "consequencia", "frequencia", "referencia",
     "emergencia", "existencia", "advertencia", "eficiencia",
+    "aderencia", "abrangencia", "incidencia", "reincidencia", "competencia",
+    "insalubridade_ignore", "periculosidade_ignore", "transferencia",
+    "permanencia", "urgencia", "ausencia", "presencia_ignore", "clemencia",
+    "tolerancia", "vigilancia", "importancia", "distancia_ignore",
+    "circunstancia", "circunstancias", "instancia", "relevancia",
     # substantivos/adjetivos com acento gráfico
     "analise", "analises", "maquina", "maquinas", "pagina", "paginas",
     "area", "areas", "nivel", "niveis", "criterio", "criterios", "periodo",
@@ -78,6 +95,60 @@ MARCADORES = sorted(set(MARCADORES), key=len, reverse=True)
 PADRAO = re.compile(r"(?<![0-9A-Za-zÀ-ÿ])(" + "|".join(MARCADORES) + r")(?![0-9A-Za-zÀ-ÿ])",
                     re.IGNORECASE)
 
+# Rede por TERMINAÇÃO, complementar à lista acima. Em português não existe
+# palavra correta terminada assim SEM acento: toda palavra com estas
+# terminações leva acento. Isso alcança vocabulário que nenhuma lista teria —
+# "aderencia", "exequivel", "manutencoes" — sem precisar prevê-lo um a um.
+#
+# Ficaram DE FORA, de propósito, as terminações que produziriam falso-positivo
+# em texto bem escrito: "-orio/-oria" (auditoria, categoria, maioria são
+# corretas sem acento), "-ario/-aria" (padaria, maquinaria) e "-ico" (rico).
+# Guarda que reprova texto correto é desligada por quem a usa, e aí deixa de
+# proteger de tudo — mesmo critério da lista acima, que já exclui os ambíguos.
+#
+# Duas outras ficaram de fora depois de reprovarem texto CORRETO no teste desta
+# mudança, contra os autos reais de fiscalizações já encerradas:
+#   "-aes"   pegaria SOBRENOME grafado corretamente sem acento (há vários, e um
+#            deles apareceu no corpo de um auto real durante este teste);
+#   "-encia" e "-ancia" têm homógrafo VERBAL — em "o que evidencia que...",
+#            "evidencia" é verbo e está certo sem acento, como "influencia",
+#            "diferencia" e "presencia". Os substantivos úteis dessa família
+#            entraram na lista MARCADORES acima, um a um, que é onde o critério
+#            de inequivocidade pode ser aplicado palavra por palavra.
+SUFIXOS = re.compile(
+    r"(?<![0-9A-Za-zÀ-ÿ])(\w{2,}(?:cao|coes|oes|avel|aveis|ivel|iveis))"
+    r"(?![0-9A-Za-zÀ-ÿ])", re.IGNORECASE)
+
+# Identificador em CamelCase não é prosa: é nome de pasta, de arquivo ou de
+# variável, e ali a grafia sem acento é a correta. Sem esta exclusão a rede por
+# terminação reprova o caminho "C:\SistemasAFT\...\AutosDeInfracao\PRO" citado
+# no corpo de um relatório — outro caso apanhado no teste desta mudança.
+CAMELCASE = re.compile(r"^.[a-zà-ÿ]*[A-ZÀ-Ü]")
+
+# RAZÃO SOCIAL. Ela é registrada na Receita Federal SEM acento e tem de ser
+# escrita no auto exatamente como consta do cadastro — grafá-la "MÓVEIS" seria
+# divergir do registro, e o art. 8º da Portaria MTP nº 667/2021 não admite
+# corrigir o sujeito passivo depois. Nos documentos ela aparece como sequência
+# de palavras em CAIXA ALTA.
+#
+# Sem esta máscara o script REPROVA HOJE um auto correto sempre que a autuada
+# se chama "... PRODUCAO ...", "... PROTECAO ...", "... MANUTENCAO ...",
+# "... REFRIGERACAO ..." ou "... SEGURANCA ..." — todas na lista acima, e todas
+# comuns em razão social brasileira. Foi assim que o defeito apareceu: numa
+# fiscalização real, a razão social da autuada terminava em "DECORACOES".
+CAIXA_ALTA = re.compile(
+    r"(?<![0-9A-Za-zÀ-ÿ])[A-ZÀ-ÜÇ][A-ZÀ-ÜÇ0-9&./\-]*"
+    r"(?:\s+[A-ZÀ-ÜÇ0-9&./\-]{2,}){1,}(?![0-9A-Za-zÀ-ÿ])")
+
+
+def mascarar_nomes_proprios(linha):
+    """Troca por espaços as sequências em CAIXA ALTA, preservando as colunas.
+
+    Preservar o comprimento importa: o número da coluna continua valendo para o
+    trecho de contexto que o relatório imprime.
+    """
+    return CAIXA_ALTA.sub(lambda m: " " * len(m.group(0)), linha)
+
 
 def main():
     if len(sys.argv) < 2:
@@ -91,13 +162,24 @@ def main():
 
     achados = []
     for i, linha in enumerate(texto.splitlines(), 1):
+        # A razão social vai no auto sem acento, como consta do cadastro da RFB:
+        # ela sai da conferência, e só ela. O resto da linha continua valendo.
+        conferivel = mascarar_nomes_proprios(linha)
         # ignora a linha de OBSERVAÇÕES já injetada com marcadores #13#10 (boilerplate)
-        for m in PADRAO.finditer(linha):
-            token = m.group(1)
-            ini = max(0, m.start() - 30)
-            fim = min(len(linha), m.end() + 30)
-            trecho = linha[ini:fim].replace("\t", " ")
-            achados.append((i, token, trecho))
+        vistos = set()
+        for padrao in (PADRAO, SUFIXOS):
+            for m in padrao.finditer(conferivel):
+                token = m.group(1)
+                if m.start() in vistos:      # a lista e a terminação podem casar
+                    continue                 # a mesma palavra; conta uma vez só
+                if padrao is SUFIXOS and CAMELCASE.match(token):
+                    continue                 # identificador, não prosa
+                vistos.add(m.start())
+                ini = max(0, m.start() - 30)
+                fim = min(len(linha), m.end() + 30)
+                trecho = linha[ini:fim].replace("\t", " ")
+                achados.append((i, token, trecho))
+    achados.sort(key=lambda a: a[0])
 
     if not achados:
         print("OK: nenhum indicio de texto sem acentuacao pt-br.")

--- a/_scripts/checar_acentos.py
+++ b/_scripts/checar_acentos.py
@@ -170,6 +170,13 @@ def mascarar_nomes_proprios(linha):
 
 
 def main():
+    # -h/--help responde com o proprio docstring. Antes, "--help" era tratado
+    # como caminho de arquivo: o script levantava FileNotFoundError e o
+    # mecanismo de ticket registrava isso como DEFEITO DO TOOLKIT -- um relato
+    # de bug gerado por alguem perguntando como usar a ferramenta.
+    if any(a in ("-h", "--help") for a in sys.argv[1:]):
+        print(__doc__ or "uso: python checar_acentos.py <arquivo>")
+        return 0
     if len(sys.argv) < 2:
         print("uso: python checar_acentos.py <arquivo>", file=sys.stderr)
         return 2

--- a/_scripts/checar_arquivos_internos.py
+++ b/_scripts/checar_arquivos_internos.py
@@ -88,6 +88,13 @@ def trechos_do_arquivo(caminho):
 
 
 def main():
+    # -h/--help responde com o proprio docstring. Antes, "--help" era tratado
+    # como caminho de arquivo: o script levantava FileNotFoundError e o
+    # mecanismo de ticket registrava isso como DEFEITO DO TOOLKIT -- um relato
+    # de bug gerado por alguem perguntando como usar a ferramenta.
+    if any(a in ("-h", "--help") for a in sys.argv[1:]):
+        print(__doc__ or "uso: python checar_arquivos_internos.py <arquivo>")
+        return 0
     if len(sys.argv) < 2:
         print("uso: python checar_arquivos_internos.py <arquivo>", file=sys.stderr)
         return 2

--- a/_scripts/conferir_cotejo.py
+++ b/_scripts/conferir_cotejo.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+conferir_cotejo.py — acha o documento que entrou na OS e nunca foi confrontado.
+
+Duas lacunas com a mesma raiz, e nenhuma tinha ferramenta:
+
+  - DOCUMENTO SEM SKILL DONA. Cada skill de análise cuida do seu documento: o
+    PGR tem a /aft-PGR-analise, a AET tem a /aft-aet-auditoria, o laudo de
+    máquinas tem a /aft-auditoria-AR-NR12. O que sobra — planilha de empregados,
+    ficha de EPI, certificado de treinamento, projeto elétrico, CCT, protocolo —
+    não tem etapa que obrigue a lê-lo, e some da análise sem nada acusar.
+
+  - AS FOTOS DA INSPEÇÃO. Nenhuma skill lê foto. Elas são documento
+    complementar da mesma resposta, e ficam à margem exatamente porque nada as
+    cobra.
+
+Numa fiscalização real as duas se materializaram juntas: documentos entregues na
+resposta a uma notificação foram inventariados e nunca abertos, e a análise foi
+concluída sem que as fotos da inspeção entrassem nela.
+
+O QUE ESTE SCRIPT PROVA, E O QUE NÃO PROVA. Ele compara o que EXISTE na pasta
+com o que é MENCIONADO nos documentos de análise da própria OS. **Menção não é
+análise**: um documento citado de passagem aparece como mencionado, e nenhuma
+leitura de arquivo distinguiria isso. O inverso, porém, é conclusivo — documento
+que não aparece em lugar nenhum certamente não foi confrontado, e é isso que
+interessa achar ANTES de dar a análise por encerrada.
+
+Ele não apaga, não move e não escreve nada. Só lista, e a decisão é do
+Auditor-Fiscal.
+
+Uso:
+    python conferir_cotejo.py "<pasta da OS>"
+    python conferir_cotejo.py "<pasta da OS>" --resumo
+
+Exit 0 = todo documento de entrada aparece nas análises; 1 = há documento sem
+menção (ou foto não tratada); 2 = erro de uso.
+"""
+
+try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
+    import sys as _sys
+    from pathlib import Path as _Path
+    _aqui = _Path(__file__).resolve()
+    for _p in (_aqui.parent, *(_a / "_scripts" for _a in _aqui.parents)):
+        if (_p / "erro_ticket.py").is_file():
+            _sys.path.insert(0, str(_p))
+            from erro_ticket import ativar as _ativar_ticket
+            _ativar_ticket(__file__)
+            break
+except Exception:
+    pass
+
+import argparse
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+# O que conta como documento a confrontar.
+EXT_DOCUMENTO = {".pdf", ".docx", ".doc", ".xlsx", ".xls", ".csv", ".txt", ".md"}
+EXT_FOTO = {".jpg", ".jpeg", ".png", ".heic", ".bmp", ".tif", ".tiff", ".webp"}
+
+# Pastas que guardam o que a FISCALIZACAO produziu, nao o que ela recebeu.
+# Documento de saida nao e objeto de cotejo -- ele e o resultado dele.
+# ATENCAO ao escrever esta lista: os nomes passam por normalizar(), que troca
+# TODO caractere nao alfanumerico por espaco. "interdicao-embargo" com hifen
+# nunca casaria -- e nao casava, de modo que o Relatorio Tecnico de embargo,
+# documento PRODUZIDO pela fiscalizacao, aparecia como nao confrontado.
+PASTAS_SAIDA = {"autos", "relatorios de fiscalizacao", "interdicao embargo",
+                "backups", "pycache", "autos reunidos"}
+
+# Arquivos que o proprio fluxo produz e que, por isso, nao se confrontam.
+# AGENTS/CLAUDE/README sao instrucoes do toolkit, nao documento de fiscalizacao:
+# apareceram como "nao confrontados" na primeira execucao real deste script.
+NOMES_SAIDA = re.compile(
+    r"^(autos|tn-nco|nco|nad|relatorio|relacao|analise preliminar|memory|"
+    r"autos-lavrados|inspecao-fisica|caderno-constatacoes|preparacao|"
+    r"lre-esocial|relatorio-validacao)", re.I)
+
+# Instrucoes do toolkit, nao documento de fiscalizacao. Casam por nome EXATO --
+# um PDF chamado "Claudete.pdf" continuaria sendo documento a confrontar.
+NOMES_INSTRUCAO = re.compile(r"^(agents|claude|readme|notes)$", re.I)
+
+# Pastas cujo conteudo e DERIVADO da analise (extrato, OCR): confrontar o
+# derivado seria confrontar o proprio trabalho, nao o documento da empresa.
+PASTAS_DERIVADAS = {"extratos", "ocr", "esocial", "cache"}
+
+# Onde a analise mora. As skills de analise escrevem nestes lugares, e e neles
+# que um documento confrontado deixa rastro.
+FONTES_ANALISE = [
+    "memory.md",
+    "*-extrato.md", "pgr-extrato.md", "aet-extrato.md", "laudo-extrato.md",
+    "inspecao-fisica.md",
+    "NOTIFICACOES/*.docx", "NOTIFICACOES/*.md",
+    "NOTIFICACOES/EXTRATOS/*.md", "NOTIFICACOES/EXTRATOS/*.docx",
+    "RELATÓRIOS DE FISCALIZAÇÃO/*.docx", "RELATORIOS DE FISCALIZACAO/*.docx",
+    "AUTOS/**/autos*.md",
+]
+
+# Palavras que denunciam que as fotos foram efetivamente tratadas na analise.
+RE_FOTO_TRATADA = re.compile(
+    r"\bfoto|fotogr|registro fotogr|imagem|imagens|constatad[oa] na imagem", re.I)
+
+# Palavras curtas ou genericas demais para identificar um documento pelo nome.
+VAZIAS = {"documento", "documentos", "arquivo", "digitalizado", "scan", "novo",
+          "final", "copia", "anexo", "anexos", "parte", "pagina", "paginas",
+          "resposta", "empresa", "ltda", "corrigido", "assinado", "versao"}
+
+
+def normalizar(t: str) -> str:
+    t = "".join(c for c in unicodedata.normalize("NFD", t.lower())
+                if unicodedata.category(c) != "Mn")
+    return re.sub(r"[^a-z0-9]+", " ", t)
+
+
+def e_saida(caminho: Path, raiz: Path) -> bool:
+    rel = caminho.relative_to(raiz)
+    partes = {normalizar(p).strip() for p in rel.parts[:-1]}
+    if partes & PASTAS_SAIDA:
+        return True
+    # Derivada: basta a pasta COMECAR pelo nome (EXTRATOS, OCR-item13...).
+    if any(any(p.startswith(d) for d in PASTAS_DERIVADAS) for p in partes):
+        return True
+    if any(p.startswith(".") for p in rel.parts):
+        return True
+    return bool(NOMES_SAIDA.match(caminho.stem)
+                or NOMES_INSTRUCAO.match(caminho.stem))
+
+
+def texto_das_analises(raiz: Path) -> tuple[str, list[str]]:
+    """Junta o texto de toda analise ja produzida na OS. Devolve (texto, fontes)."""
+    pedacos, fontes = [], []
+    vistos = set()
+    for padrao in FONTES_ANALISE:
+        for f in raiz.glob(padrao):
+            if not f.is_file() or f in vistos:
+                continue
+            vistos.add(f)
+            try:
+                if f.suffix.lower() == ".docx":
+                    import docx
+                    d = docx.Document(str(f))
+                    t = "\n".join(p.text for p in d.paragraphs)
+                    for tb in d.tables:
+                        for lin in tb.rows:
+                            t += "\n" + "\n".join(c.text for c in lin.cells)
+                else:
+                    t = f.read_text(encoding="utf-8", errors="replace")
+            except Exception as e:
+                fontes.append("%s (ILEGIVEL: %s)" % (f.name, type(e).__name__))
+                continue
+            pedacos.append(t)
+            fontes.append(f.name)
+    return normalizar("\n".join(pedacos)), fontes
+
+
+def mencionado(doc: Path, analise: str) -> bool:
+    """O documento aparece na analise? Casa pelo nome inteiro ou pelos termos.
+
+    Nao inventa vinculo: exige que TODOS os termos significativos do nome
+    apareçam. "PGR 2026 assinado.pdf" casa com um texto que fale de PGR e 2026;
+    nao casa com um texto que so cite "2026".
+    """
+    nome = normalizar(doc.stem)
+    if nome.strip() and nome.strip() in analise:
+        return True
+    termos = [t for t in nome.split() if len(t) >= 4 and t not in VAZIAS]
+    if not termos:
+        return False
+    return all(t in analise for t in termos)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Acha documento e foto que entraram na OS e nunca apareceram "
+                    "em analise.")
+    ap.add_argument("pasta_os", help="pasta da OS")
+    ap.add_argument("--resumo", action="store_true", help="so o veredito")
+    ap.add_argument("--forcar", action="store_true",
+                    help="lista mesmo com a analise incipiente")
+    args = ap.parse_args()
+    raiz = Path(args.pasta_os).expanduser()
+    resumo = args.resumo
+    forcar = args.forcar
+    if not raiz.is_dir():
+        print("ERRO: nao e uma pasta: %s" % raiz, file=sys.stderr)
+        return 2
+
+    docs, fotos = [], []
+    for f in raiz.rglob("*"):
+        if not f.is_file():
+            continue
+        ext = f.suffix.lower()
+        if ext in EXT_FOTO:
+            if not any(p.startswith(".") for p in f.relative_to(raiz).parts):
+                fotos.append(f)
+        elif ext in EXT_DOCUMENTO and not e_saida(f, raiz):
+            docs.append(f)
+
+    analise, fontes = texto_das_analises(raiz)
+    if not analise.strip():
+        print("Nenhum documento de análise encontrado nesta OS.")
+        print("Nada a conferir ainda: rode ao ENCERRAR a análise, não antes.")
+        return 0
+
+    # ANALISE INCIPIENTE. Numa OS em que a analise mal comecou, quase todo
+    # documento estara "sem mencao" -- e listar cento e trinta nomes nao ajuda
+    # ninguem, so ensina a ignorar a saida. O script diz o que de fato observou
+    # e para. O numero e proposital: quatro fontes de analise ja indicam uma OS
+    # em que se escreveu alguma coisa; abaixo disso, o cotejo e prematuro.
+    if len(fontes) < 4 and len(docs) > 3 * max(1, len(fontes)):
+        print("ANÁLISE AINDA INCIPIENTE nesta OS: %d documento(s) de entrada para "
+              "apenas %d de análise." % (len(docs), len(fontes)))
+        print("Quase tudo apareceria como não confrontado, o que não seria achado —")
+        print("seria o retrato de uma análise que ainda não foi feita.")
+        print("Rode de novo ao encerrar a análise. (--forcar lista assim mesmo)")
+        if not forcar:
+            return 0
+
+    # Um documento cujo EXTRATO ou OCR existe na OS foi lido, ainda que a
+    # analise nao o cite pelo nome do arquivo -- e ela raramente cita: fala do
+    # ASSUNTO ("o procedimento de seguranca da serra"), nao de "PS001_PS002".
+    # Sem esta distincao a ferramenta acusava como nao confrontado justamente o
+    # documento que tinha 16 mil caracteres de OCR gravados ao lado.
+    extraidos = {normalizar(f.stem).strip()
+                 for f in raiz.rglob("*")
+                 if f.is_file() and f.suffix.lower() in (".txt", ".md")
+                 and any(any(normalizar(p).startswith(d) for d in PASTAS_DERIVADAS)
+                         for p in f.relative_to(raiz).parts[:-1])}
+
+    sem_mencao, so_extraidos = [], []
+    for d in sorted(docs):
+        if mencionado(d, analise):
+            continue
+        (so_extraidos if normalizar(d.stem).strip() in extraidos
+         else sem_mencao).append(d)
+    fotos_tratadas = bool(RE_FOTO_TRATADA.search(analise))
+
+    if not resumo:
+        print("=" * 72)
+        print("  COTEJO -- o que entrou na OS apareceu na análise?")
+        print("=" * 72)
+        print("  pasta ....... %s" % raiz.name[:56])
+        print("  analisado a partir de %d documento(s) de análise" % len(fontes))
+        print("  documentos de entrada: %d   |   fotos: %d" % (len(docs), len(fotos)))
+
+    problemas = 0
+
+    print("\n1. DOCUMENTOS SEM MENÇÃO EM NENHUMA ANÁLISE")
+    if sem_mencao:
+        problemas += len(sem_mencao)
+        print("   Estes existem na pasta e não aparecem em análise nenhuma. Antes de")
+        print("   encerrar a análise: ou o documento é confrontado, ou o motivo de não")
+        print("   o ser é declarado ao AFT, com a ementa que fica sem resposta.")
+        for d in sem_mencao:
+            print("     - %s" % d.relative_to(raiz))
+    else:
+        print("   Nenhum: todo documento de entrada aparece em alguma análise.")
+        print("   (menção não é análise -- isto exclui o esquecimento, não o descuido)")
+
+    if so_extraidos:
+        print("\n1b. EXTRAÍDOS, mas não citados pelo nome do arquivo")
+        print("    Existe extrato ou OCR destes na OS, logo foram lidos. A análise")
+        print("    costuma falar do ASSUNTO e não do nome do arquivo, então isto")
+        print("    normalmente está certo -- confira só se o achado deles apareceu.")
+        for d in so_extraidos:
+            print("     - %s" % d.relative_to(raiz))
+
+    print("\n2. FOTOS DA INSPEÇÃO — documento complementar da mesma resposta")
+    if not fotos:
+        print("   Nenhuma foto nesta OS.")
+    elif fotos_tratadas:
+        print("   %d foto(s) na pasta, e a análise fala de fotografia/imagem." % len(fotos))
+        print("   Confira se ela trata do que as fotos MOSTRAM, e não só que existem.")
+    else:
+        problemas += 1
+        print("   %d foto(s) na pasta e NENHUMA análise menciona foto ou imagem." % len(fotos))
+        print("   Nenhuma skill lê foto: se a análise não fala delas, elas ficaram fora.")
+        print("   Já aconteceu de a conclusão sair sem elas e o AFT ter de perguntar")
+        print("   \"você não viu as fotos?\" -- depois de a análise estar pronta.")
+        for f in sorted(fotos)[:10]:
+            print("     - %s" % f.relative_to(raiz))
+        if len(fotos) > 10:
+            print("     ... (+%d)" % (len(fotos) - 10))
+
+    print("\n" + "-" * 72)
+    if problemas:
+        print("%d ponto(s) a resolver antes de encerrar a análise." % problemas)
+        return 1
+    print("Nada pendente de cotejo nesta OS.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_scripts/conferir_rastreamento.py
+++ b/_scripts/conferir_rastreamento.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+conferir_rastreamento.py — acha CONTRADIÇÃO entre os registros de auto do memory.md.
+
+O mesmo auto de infração aparece em até quatro lugares: as três seções do
+`memory.md` da OS (`## Ementas da OS`, `## Autos de Infração` e
+`## Autos lavrados`) e, depois de transmitido, o `autos-lavrados.md` que a
+`/aft-autos-lavrados` extrai do Sistema Auditor. Manter os quatro coerentes é
+trabalho manual, e numa fiscalização real dois deles se contradisseram: a caixa
+marcada `[x]` com o texto ao lado dizendo "pendente de importação".
+
+A convenção que evita isso já existe — status e checkbox mudam JUNTOS, no mesmo
+Edit — e não impediu nada, porque convenção escrita não confere arquivo. Este
+script confere.
+
+A seção `## Ementas da OS` é a mais perigosa das três, porque alimenta a
+avaliação de ementas do Relatório de Inspeção: um "auto lavrado" falso ali entra
+em documento oficial. Nela o `[x]` significa "ementa TRATADA nesta fiscalização",
+nunca "auto transmitido" — e é essa confusão que o script procura.
+
+O que ele acha:
+
+  1. em `## Autos lavrados`, caixa `[x]` cujo texto diz que o auto ainda não foi
+     transmitido ("pendente de importação", "TXT gerado", "em redação");
+  2. em `## Autos lavrados`, caixa `[x]` sem número de AI no texto — o `[x]` só
+     vale depois de a `/aft-autos-lavrados` confirmar o auto no Sistema Auditor,
+     e aí o número real aparece;
+  3. em `## Autos lavrados`, caixa `[ ]` cujo texto já traz número de AI;
+  4. em `## Ementas da OS`, linha que AFIRMA auto lavrado sem respaldo em
+     `## Autos lavrados`.
+
+LIMITE DECLARADO, para o relatório não mentir: isto acha CONTRADIÇÃO entre
+registros. Não prova que algum deles está certo — os dois podem estar errados
+juntos, e nenhuma leitura de arquivo descobriria isso. Só o Sistema Auditor
+responde o que foi de fato transmitido.
+
+O script NUNCA escreve no memory.md. Corrigir é ato do Auditor-Fiscal.
+
+Uso:
+    python conferir_rastreamento.py "<pasta da OS>"
+    python conferir_rastreamento.py "<pasta da OS>" --resumo
+
+Exit 0 = sem contradição; 1 = há contradição; 2 = erro de uso.
+"""
+
+try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
+    import sys as _sys
+    from pathlib import Path as _Path
+    _aqui = _Path(__file__).resolve()
+    for _p in (_aqui.parent, *(_a / "_scripts" for _a in _aqui.parents)):
+        if (_p / "erro_ticket.py").is_file():
+            _sys.path.insert(0, str(_p))
+            from erro_ticket import ativar as _ativar_ticket
+            _ativar_ticket(__file__)
+            break
+except Exception:
+    pass
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Numero de auto de infracao como o Sistema Auditor o escreve: 23.402.518-2.
+RE_AI = re.compile(r"\b\d{2}\.\d{3}\.\d{3}-\d\b")
+RE_EMENTA = re.compile(r"\b(\d{6}-\d)\b")
+
+# Expressoes que dizem, em texto livre, que o auto AINDA NAO foi transmitido.
+# A lista e conservadora de proposito: e melhor deixar passar uma forma nova do
+# que acusar contradicao onde nao ha.
+NAO_TRANSMITIDO = re.compile(
+    r"pendente de importa|pendente de transmiss|txt gerado|em reda[çc][ãa]o|"
+    r"auto elaborado|n[ãa]o transmitid|aguardando importa", re.I)
+
+
+def secao(texto, nome):
+    """As linhas de item de uma seção '## Nome'. Lista vazia se ela não existe."""
+    m = re.search(r"^## %s[ \t]*\n(.*?)(?=^## |\Z)" % re.escape(nome),
+                  texto, re.S | re.M)
+    if not m:
+        return []
+    return [l.strip() for l in m.group(1).splitlines() if l.strip().startswith("-")]
+
+
+def marcado(linha):
+    """True se [x], False se [ ], None se a linha não tem caixa."""
+    m = re.match(r"-\s*\[([ xX])\]", linha)
+    return None if not m else m.group(1).lower() == "x"
+
+
+def conferir(pasta):
+    """Devolve a lista de contradições encontradas (vazia = tudo coerente)."""
+    memoria = Path(pasta) / "memory.md"
+    if not memoria.is_file():
+        return ["nao achei memory.md em %s" % pasta]
+    texto = memoria.read_text(encoding="utf-8", errors="replace")
+    problemas = []
+
+    lavrados = secao(texto, "Autos lavrados")
+    ementas = secao(texto, "Ementas da OS")
+
+    # --- 1) Em "Autos lavrados": a caixa e o texto tem de dizer a mesma coisa.
+    transmitidas = set()
+    for linha in lavrados:
+        m = marcado(linha)
+        if m is None:
+            continue
+        tem_ai = bool(RE_AI.search(linha))
+        diz_pendente = bool(NAO_TRANSMITIDO.search(linha))
+        codigos = set(RE_EMENTA.findall(linha))
+        if m:
+            # So conta como transmitida a linha COERENTE: marcada, com numero de
+            # AI e sem dizer que esta pendente. Contar a linha contraditoria
+            # daria respaldo a si mesma, e o caso 4 nunca dispararia.
+            if tem_ai and not diz_pendente:
+                transmitidas |= codigos
+            if diz_pendente:
+                problemas.append(
+                    "Autos lavrados: caixa MARCADA [x] mas o texto diz que nao foi "
+                    "transmitido -> %s" % linha[:110])
+            elif not tem_ai:
+                problemas.append(
+                    "Autos lavrados: caixa MARCADA [x] sem numero de AI no texto. O [x] "
+                    "so vale depois de a /aft-autos-lavrados confirmar o auto no Sistema "
+                    "Auditor, e ai o numero real aparece -> %s" % linha[:110])
+        else:
+            if tem_ai and not diz_pendente:
+                problemas.append(
+                    "Autos lavrados: caixa VAZIA [ ] mas o texto ja traz numero de AI -> %s"
+                    % linha[:110])
+
+    # --- 2) Em "Ementas da OS": [x] que afirma auto lavrado precisa de respaldo.
+    #        Aqui o [x] significa "ementa tratada", nunca "auto transmitido" --
+    #        entao so se investiga a linha que AFIRMA, em texto, o auto lavrado.
+    for linha in ementas:
+        if marcado(linha) is not True:
+            continue
+        if not re.search(r"auto lavrado|lavrado o auto|auto transmitido", linha, re.I):
+            continue
+        orfas = set(RE_EMENTA.findall(linha)) - transmitidas
+        if orfas:
+            problemas.append(
+                "Ementas da OS: a linha afirma AUTO LAVRADO, mas a ementa %s nao aparece "
+                "como transmitida em 'Autos lavrados'. Esta secao alimenta a avaliacao do "
+                "Relatorio de Inspecao: um 'auto lavrado' falso aqui entra em documento "
+                "oficial -> %s" % (", ".join(sorted(orfas)), linha[:100]))
+
+    # --- 3) Coerencia com o snapshot oficial, quando ele existe.
+    oficial = Path(pasta) / "autos-lavrados.md"
+    if oficial.is_file() and transmitidas:
+        no_oficial = set(RE_EMENTA.findall(
+            oficial.read_text(encoding="utf-8", errors="replace")))
+        # So acusa o sentido perigoso: o memory.md afirma transmitido e o
+        # snapshot do Sistema Auditor nao conhece. O contrario (o snapshot com
+        # mais ementas) e normal -- pode ser auto de outra leva ainda nao anotado.
+        faltando = transmitidas - no_oficial
+        if faltando:
+            problemas.append(
+                "memory.md marca como transmitida(s) a(s) ementa(s) %s, mas o "
+                "autos-lavrados.md (snapshot do Sistema Auditor) nao as traz. Ou o "
+                "snapshot esta velho, ou o [x] foi marcado antes da transmissao."
+                % ", ".join(sorted(faltando)))
+
+    return problemas
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Acha contradicao entre os registros de auto do memory.md.")
+    ap.add_argument("pasta_os", help="pasta da OS (a que contem o memory.md)")
+    ap.add_argument("--resumo", action="store_true",
+                    help="so o veredito, sem cabecalho")
+    args = ap.parse_args()
+
+    pasta = Path(args.pasta_os).expanduser()
+    if not pasta.is_dir():
+        print("ERRO: nao e uma pasta: %s" % pasta, file=sys.stderr)
+        return 2
+
+    problemas = conferir(pasta)
+    if not args.resumo:
+        print("=" * 72)
+        print("  RASTREAMENTO DOS AUTOS -- %s" % pasta.name[:52])
+        print("=" * 72)
+    if problemas:
+        for p in problemas:
+            print("  CONTRADICAO: %s" % p)
+        print("-" * 72)
+        print("%d contradicao(oes). Status e checkbox mudam JUNTOS, no mesmo Edit."
+              % len(problemas))
+        return 1
+    print("Sem contradicao entre os registros de auto do memory.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_scripts/conferir_rastreamento.py
+++ b/_scripts/conferir_rastreamento.py
@@ -89,11 +89,23 @@ def marcado(linha):
     return None if not m else m.group(1).lower() == "x"
 
 
+class NaoEUmaOS(Exception):
+    """A pasta existe, mas nao e uma OS: nao ha memory.md para conferir.
+
+    Isto NAO e contradicao. A primeira versao devolvia a falta do memory.md
+    junto com os achados, e o script saia com o codigo de "encontrei
+    contradicao" -- de modo que quem apontasse para a pasta errada concluiria
+    que a fiscalizacao tem defeito. Erro de uso e erro de uso.
+    """
+
+
 def conferir(pasta):
     """Devolve a lista de contradições encontradas (vazia = tudo coerente)."""
     memoria = Path(pasta) / "memory.md"
     if not memoria.is_file():
-        return ["nao achei memory.md em %s" % pasta]
+        raise NaoEUmaOS(
+            "nao achei memory.md em %s -- esta pasta nao e uma OS. Aponte para a "
+            "pasta da empresa, a que contem o memory.md." % pasta)
     texto = memoria.read_text(encoding="utf-8", errors="replace")
     problemas = []
 
@@ -178,7 +190,11 @@ def main():
         print("ERRO: nao e uma pasta: %s" % pasta, file=sys.stderr)
         return 2
 
-    problemas = conferir(pasta)
+    try:
+        problemas = conferir(pasta)
+    except NaoEUmaOS as e:
+        print("ERRO: %s" % e, file=sys.stderr)
+        return 2
     if not args.resumo:
         print("=" * 72)
         print("  RASTREAMENTO DOS AUTOS -- %s" % pasta.name[:52])

--- a/_scripts/conferir_rastreamento.py
+++ b/_scripts/conferir_rastreamento.py
@@ -62,6 +62,15 @@ import re
 import sys
 from pathlib import Path
 
+# O console do Windows abre em cp1252 e o nome da pasta da OS (razao social) tem
+# acento: sem esta reconfiguracao, "FUNDICAO" sai "FUNDI??O" no cabecalho do
+# relatorio. errors=replace garante que um caractere fora do alcance nunca
+# derrube a conferencia.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
 # Numero de auto de infracao como o Sistema Auditor o escreve: 23.402.518-2.
 RE_AI = re.compile(r"\b\d{2}\.\d{3}\.\d{3}-\d\b")
 RE_EMENTA = re.compile(r"\b(\d{6}-\d)\b")

--- a/_scripts/consulta_cnpj.py
+++ b/_scripts/consulta_cnpj.py
@@ -27,6 +27,18 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+# O console do Windows abre em cp1252, e a base da RFB devolve razao social,
+# natureza juridica e descricao de CNAE com acento. Sem esta reconfiguracao a
+# tela mostra "Fabricacao" como "Fabrica??ao" e "Empresaria" como "Empres?ria":
+# o dado chega certo (a resposta e decodificada como UTF-8 mais abaixo) e se
+# corrompe so na impressao -- de modo que quem copia da tela para um documento
+# leva a corrupcao junto. errors="replace" garante que um caractere fora do
+# alcance jamais derrube a consulta.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:                                   # Python < 3.7 ou stdout redirecionado
+    pass
+
 CACHE_DIR = Path.home() / "Documents" / "AFT" / "cache" / "cnpj"
 TIMEOUT = 30
 

--- a/_scripts/indenta_quebras.py
+++ b/_scripts/indenta_quebras.py
@@ -49,6 +49,13 @@ def indentar_campo(campo: str) -> str:
 
 
 def main():
+    # -h/--help responde com o proprio docstring. Antes, "--help" era tratado
+    # como caminho de arquivo: o script levantava FileNotFoundError e o
+    # mecanismo de ticket registrava isso como DEFEITO DO TOOLKIT -- um relato
+    # de bug gerado por alguem perguntando como usar a ferramenta.
+    if any(a in ("-h", "--help") for a in sys.argv[1:]):
+        print(__doc__ or "uso: python indenta_quebras.py <arquivo>")
+        return 0
     if len(sys.argv) < 2:
         print("uso: python indenta_quebras.py <arquivo.txt>", file=sys.stderr)
         return 2

--- a/_scripts/pdf_texto_paginado.py
+++ b/_scripts/pdf_texto_paginado.py
@@ -375,8 +375,23 @@ def main():
         partes.append("===== PAGINA %d =====\n%s" % (i, corpo))
 
     if not so_resumo:
+        # RODAPE DE FECHAMENTO. Sem ele, uma leitura TRUNCADA do extrato e
+        # indistinguivel de uma leitura completa -- e nada no texto denuncia a
+        # diferenca. O caso que motivou: um requerimento de fiscalizacao foi
+        # lido ate o meio da segunda pagina, teve a lista de pedidos dada por
+        # encerrada em cinco itens, e tinha oito. O erro so apareceu quando
+        # alguem releu o documento inteiro por outra razao.
+        #
+        # Quem le o extrato passa a ter como verificar que chegou ao fim: se
+        # este rodape nao apareceu, faltou documento.
+        corpo_final = "\n\n".join(partes)
+        corpo_final += (
+            "\n\n===== FIM DO DOCUMENTO | %s | %d pagina(s) | %d caracteres =====\n"
+            "Se esta linha nao aparece no que voce leu, a leitura foi TRUNCADA:\n"
+            "leia o restante antes de concluir qualquer coisa sobre o documento.\n"
+            % (os.path.basename(pdf_path), n, len(corpo_final)))
         with io.open(saida, "w", encoding="utf-8") as f:
-            f.write("\n\n".join(partes))
+            f.write(corpo_final)
 
     print("PDF: %s" % os.path.basename(pdf_path))
     print("Paginas: %d" % n)

--- a/_scripts/tokenizar.py
+++ b/_scripts/tokenizar.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Monta e confere o mapa de-para (.depara_[CNPJ].json) de uma OS, por script.
+
+Fecha o lado que faltava da pseudonimizacao. O toolkit ja tinha o sentido de
+VOLTA -- rehydrate.py, que troca [[TRAB_NN]] pelo nome real no TXT final, por
+string-replace deterministico, "NUNCA e o modelo que faz a substituicao... um
+CPF/nome errado e inaceitavel". O sentido de IDA (criar o mapa e trocar o nome
+pelo token) nao tinha script nenhum: sobrava para o assistente digitar o nome a
+mao no JSON. Este script tira o modelo desse caminho.
+
+O que NAO faz, de proposito:
+  - nao le PDF nem adivinha nomes: quem informa o nome e o AFT (ou uma lista que
+    ele aponte), porque errar um nome aqui contamina o auto;
+  - nao coleta CPF de trabalhador (o /aft-gera-ai nao usa: campo fica vazio);
+  - nao renumera token existente, nunca -- token ja usado num auto e imutavel.
+
+Uso:
+  tokenizar.py <pasta-OS> --add "NOME COMPLETO" [--funcao X] [--admissao dd/mm/aaaa]
+                          [--fonte "de onde veio o nome"]
+  tokenizar.py <pasta-OS> --add-lista <arquivo.txt>   (um nome por linha; aceita
+                          "NOME;funcao;dd/mm/aaaa")
+  tokenizar.py <pasta-OS> --autuada "RAZAO SOCIAL LTDA"
+  tokenizar.py <pasta-OS> --substituir <arquivo>      (troca nomes reais por tokens)
+  tokenizar.py <pasta-OS> --conferir <arquivo>        (token orfao? nome real vazado?)
+  tokenizar.py <pasta-OS> --listar [--mostrar]        (mascarado por padrao)
+
+Exit 0 = ok; 1 = achado que exige acao; 2 = erro de uso.
+"""
+
+try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
+    import sys as _sys
+    from pathlib import Path as _Path
+    _aqui = _Path(__file__).resolve()
+    for _p in (_aqui.parent, *(_a / "_scripts" for _a in _aqui.parents)):
+        if (_p / "erro_ticket.py").is_file():
+            _sys.path.insert(0, str(_p))
+            from erro_ticket import ativar as _ativar_ticket
+            _ativar_ticket(__file__)
+            break
+except Exception:
+    pass
+
+import argparse
+import io
+import json
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+RE_TOKEN_TRAB = re.compile(r"\[\[TRAB_(\d{2})\]\]")
+RE_QUALQUER_TOKEN = re.compile(r"\[\[[A-Z0-9_]+\]\]")
+RE_CPF = re.compile(r"\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b")
+
+
+def normaliza(nome):
+    """Para comparar nomes sem depender de acento, caixa ou espaco duplo."""
+    s = unicodedata.normalize("NFKD", nome)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", s).strip().upper()
+
+
+def mascara(nome):
+    partes = nome.split()
+    if not partes:
+        return "?"
+    return partes[0] + " " + " ".join(p[0] + "." for p in partes[1:])
+
+
+def acha_cnpj(pasta):
+    """CNPJ pelo front-matter do memory.md; se nao houver, pelo nome da pasta."""
+    mem = pasta / "memory.md"
+    if mem.is_file():
+        m = re.search(r'^cnpj:\s*"?(\d{11,14})"?', mem.read_text(encoding="utf-8"), re.M)
+        if m:
+            return m.group(1)
+    m = re.search(r"(\d{14}|\d{11})\s*$", pasta.name)
+    if m:
+        return m.group(1)
+    return None
+
+
+def carrega(caminho):
+    if caminho.is_file():
+        return json.loads(caminho.read_text(encoding="utf-8"))
+    return {"autuada": {}, "trabalhadores": []}
+
+
+def grava(caminho, mapa):
+    caminho.write_text(json.dumps(mapa, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def proximo_token(mapa):
+    usados = set()
+    for t in mapa.get("trabalhadores", []):
+        m = RE_TOKEN_TRAB.match(t.get("token_nome", ""))
+        if m:
+            usados.add(int(m.group(1)))
+    n = 1
+    while n in usados:
+        n += 1
+    if n > 99:
+        print("ERRO: mais de 99 trabalhadores; o formato do token e de 2 digitos.",
+              file=sys.stderr)
+        sys.exit(2)
+    return "[[TRAB_%02d]]" % n
+
+
+def add(mapa, nome, funcao, admissao, fonte):
+    """Devolve (token, ja_existia). Nome ja mapeado reaproveita o token."""
+    if RE_CPF.search(nome):
+        print("ERRO: o nome contem algo com cara de CPF. CPF de trabalhador nao "
+              "entra no de-para (o /aft-gera-ai deixa o campo vazio).", file=sys.stderr)
+        sys.exit(2)
+    alvo = normaliza(nome)
+    if not alvo:
+        print("ERRO: nome vazio.", file=sys.stderr)
+        sys.exit(2)
+    for t in mapa.setdefault("trabalhadores", []):
+        if normaliza(t.get("nome", "")) == alvo:
+            return t["token_nome"], True
+    token = proximo_token(mapa)
+    entrada = {"token_nome": token, "nome": nome.strip()}
+    if funcao:
+        entrada["funcao"] = funcao
+    if admissao:
+        entrada["admissao"] = admissao
+    if fonte:
+        entrada["fonte"] = fonte
+    mapa["trabalhadores"].append(entrada)
+    return token, False
+
+
+def substituir(mapa, caminho):
+    """Troca nome real por token, do mais longo para o mais curto (para 'Joao
+    Silva Souza' nao virar '[[TRAB_01]] Souza' quando 'Joao Silva' tambem estiver
+    mapeado). Casa tambem a forma sem acento e em qualquer caixa."""
+    texto = caminho.read_text(encoding="utf-8")
+    pares = []
+    raz = (mapa.get("autuada") or {}).get("razao_social")
+    if raz:
+        pares.append((raz, mapa["autuada"]["token"]))
+    for t in mapa.get("trabalhadores", []):
+        pares.append((t["nome"], t["token_nome"]))
+    pares.sort(key=lambda par: len(par[0]), reverse=True)
+
+    trocas = 0
+    for real, token in pares:
+        # casamento tolerante a acento/caixa/espaco duplo, sem heuristica de apelido
+        padrao = r"\s+".join(re.escape(p) for p in real.split())
+        padrao = "".join(
+            "[%s%s]" % (c.lower(), c.upper()) if c.isalpha() and c.isascii() else c
+            for c in padrao)
+        novo, n = re.subn(padrao, token.replace("\\", "\\\\"), texto)
+        if n == 0:
+            # tenta pela forma sem acento (documento as vezes traz sem)
+            sem = normaliza(real)
+            padrao2 = r"\s+".join(re.escape(p) for p in sem.split())
+            novo, n = re.subn(padrao2, token, texto, flags=re.I)
+        texto, trocas = novo, trocas + n
+    caminho.write_text(texto, encoding="utf-8")
+    return trocas
+
+
+def conferir(mapa, caminho):
+    """Token sem par no mapa, e nome real que vazou para o arquivo tokenizado."""
+    texto = caminho.read_text(encoding="utf-8")
+    conhecidos = {t["token_nome"] for t in mapa.get("trabalhadores", [])}
+    raz_tok = (mapa.get("autuada") or {}).get("token")
+    if raz_tok:
+        conhecidos.add(raz_tok)
+    orfaos = sorted(set(RE_QUALQUER_TOKEN.findall(texto)) - conhecidos)
+
+    vazados = []
+    for t in mapa.get("trabalhadores", []):
+        if normaliza(t["nome"]) in normaliza(texto):
+            vazados.append(mascara(t["nome"]))
+    return orfaos, vazados, RE_CPF.findall(texto)
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("pasta_os")
+    # Numa OS de GRUPO ECONOMICO a mesma pasta abriga mais de um CNPJ (cada empresa
+    # com seu RI e seus autos). O de-para e por CNPJ, entao e preciso poder apontar
+    # qual: sem isso, o mapa da segunda empresa teria de ser escrito a mao -- que e
+    # exatamente o que este script existe para evitar.
+    ap.add_argument("--cnpj", metavar="CNPJ14",
+                    help="CNPJ do de-para, quando a OS tem mais de uma empresa "
+                         "(grupo economico). Padrao: o CNPJ da propria OS.")
+    ap.add_argument("--add", metavar="NOME")
+    ap.add_argument("--add-lista", metavar="ARQUIVO")
+    ap.add_argument("--autuada", metavar="RAZAO_SOCIAL")
+    ap.add_argument("--funcao", default=None)
+    ap.add_argument("--admissao", default=None)
+    ap.add_argument("--fonte", default=None)
+    ap.add_argument("--substituir", metavar="ARQUIVO")
+    ap.add_argument("--conferir", metavar="ARQUIVO")
+    ap.add_argument("--listar", action="store_true")
+    ap.add_argument("--mostrar", action="store_true",
+                    help="revela os nomes no --listar (dado sensivel)")
+    args = ap.parse_args()
+
+    pasta = Path(args.pasta_os)
+    if not pasta.is_dir():
+        print("ERRO: pasta nao encontrada: %s" % pasta, file=sys.stderr)
+        return 2
+    cnpj = re.sub(r"\D", "", args.cnpj) if args.cnpj else acha_cnpj(pasta)
+    if args.cnpj and len(cnpj) not in (11, 14):
+        print("ERRO: --cnpj deve ter 11 ou 14 digitos.", file=sys.stderr)
+        return 2
+    if not cnpj:
+        print("ERRO: nao consegui descobrir o CNPJ (front-matter `cnpj:` do memory.md "
+              "ou final do nome da pasta).", file=sys.stderr)
+        return 2
+    caminho = pasta / (".depara_%s.json" % cnpj)
+    mapa = carrega(caminho)
+    mudou = False
+
+    if args.autuada:
+        mapa["autuada"] = {"token": "[[AUTUADA]]", "razao_social": args.autuada.strip()}
+        mudou = True
+        print("autuada -> [[AUTUADA]]")
+
+    if args.add:
+        tok, existia = add(mapa, args.add, args.funcao, args.admissao, args.fonte)
+        mudou = True
+        print("%s -> %s%s" % (mascara(args.add), tok, "  (ja existia)" if existia else ""))
+
+    if args.add_lista:
+        for linha in io.open(args.add_lista, encoding="utf-8"):
+            linha = linha.strip()
+            if not linha or linha.startswith("#"):
+                continue
+            campos = [c.strip() for c in linha.split(";")]
+            nome = campos[0]
+            funcao = campos[1] if len(campos) > 1 and campos[1] else args.funcao
+            adm = campos[2] if len(campos) > 2 and campos[2] else args.admissao
+            tok, existia = add(mapa, nome, funcao, adm, args.fonte)
+            mudou = True
+            print("%s -> %s%s" % (mascara(nome), tok, "  (ja existia)" if existia else ""))
+
+    if mudou:
+        grava(caminho, mapa)
+        print("gravado: %s" % caminho.name)
+
+    if args.listar:
+        print("\nde-para (%d trabalhador(es)):" % len(mapa.get("trabalhadores", [])))
+        raz = (mapa.get("autuada") or {}).get("razao_social")
+        if raz:
+            print("  [[AUTUADA]]  %s" % (raz if args.mostrar else mascara(raz)))
+        for t in mapa.get("trabalhadores", []):
+            nome = t["nome"] if args.mostrar else mascara(t["nome"])
+            extra = " | %s" % t["funcao"] if t.get("funcao") else ""
+            print("  %s  %s%s" % (t["token_nome"], nome, extra))
+        if not args.mostrar:
+            print("  (nomes mascarados; --mostrar revela, mas o de-para e dado sensivel)")
+
+    if args.substituir:
+        alvo = Path(args.substituir)
+        if not alvo.is_file():
+            print("ERRO: arquivo nao encontrado: %s" % alvo, file=sys.stderr)
+            return 2
+        n = substituir(mapa, alvo)
+        print("substituicoes em %s: %d" % (alvo.name, n))
+
+    if args.conferir:
+        alvo = Path(args.conferir)
+        if not alvo.is_file():
+            print("ERRO: arquivo nao encontrado: %s" % alvo, file=sys.stderr)
+            return 2
+        orfaos, vazados, cpfs = conferir(mapa, alvo)
+        print("\nconferencia de %s" % alvo.name)
+        print("  tokens sem par no de-para: %s" % (", ".join(orfaos) if orfaos else "nenhum"))
+        print("  nomes reais no arquivo   : %s" % (", ".join(vazados) if vazados else "nenhum"))
+        print("  CPF no arquivo           : %d" % len(cpfs))
+        if orfaos or vazados or cpfs:
+            print("  RESULTADO: REPROVADO - resolva antes de empacotar.")
+            return 1
+        print("  RESULTADO: APROVADO.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -187,6 +187,31 @@ Em conformidade com a legislação em vigor, especialmente o previsto na alínea
 
 ### Itens (um por irregularidade)
 
+**ORDEM DOS ITENS: crescente por Norma Regulamentadora, da NR-01 à NR-38.** Agrupe os itens
+pela NR citada na base legal e ordene os grupos por número. Dentro de cada NR, mantenha a
+ordem lógica em que os itens foram redigidos (identificação de perigos antes do inventário,
+inventário antes do plano de ação).
+
+> Por que importa: uma notificação com os itens embaralhados por norma obriga o empregador a
+> reconstruir o assunto a cada linha. Agrupada, ela se lê de uma vez, e ele enxerga o que
+> resolve com cada consultoria — o PGR num bloco, o PCMSO noutro, as máquinas noutro. Numa
+> fiscalização real o AFT recebeu a notificação fora dessa ordem e a devolveu com a
+> observação de que estava "muito confusa, toda embaralhada".
+
+Três cuidados ao ordenar:
+
+- **A chave é a PRIMEIRA NR citada na base legal** do item — é a principal, sob a qual ele
+  foi redigido. As demais entram como complemento e não mudam a posição.
+- **Item sem NR na base legal** (só CLT, só Portaria) vai para o fim, e você avisa o AFT:
+  nunca se atribui uma NR ao item só para ele caber na ordem.
+- **REFERÊNCIA CRUZADA.** Item que mencione "no item N" tem o alvo deslocado pela
+  reordenação. Confira e corrija cada uma DEPOIS de ordenar — numa fiscalização real um item
+  apontava para "o item 1" quando o alvo havia se tornado o item 10.
+
+Ordene **antes** de gerar o `.docx` e **antes** de criar o rascunho no DET: o `det_criar.py`
+apenas cria notificação, não atualiza, e reordenar depois obriga a criar outra e o AFT a
+apagar a anterior no site.
+
 Formato de cada item:
 
 ```

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -132,941 +132,959 @@
 
 <script>
 const ARCH = {
- "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
- "repo": "github.com/ryckardo42/aft-toolkit",
- "data": "2026-08-24",
- "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
- "stats": {
-  "skills": 52,
-  "scripts": 42,
-  "dados": 6,
-  "commit": "ver `git log -1` — atualizado em 23/08/2026"
- },
- "atores": [
-  {
-   "nome": "AFT colega (novo usuário)",
-   "papel": "Auditor no Windows",
-   "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
+  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
+  "repo": "github.com/ryckardo42/aft-toolkit",
+  "data": "2026-08-25",
+  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+  "stats": {
+    "skills": 52,
+    "scripts": 45,
+    "dados": 6,
+    "commit": "ver `git log -1` — atualizado em 23/08/2026"
   },
-  {
-   "nome": "Claude Code",
-   "papel": "Assistente técnico",
-   "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
-  },
-  {
-   "nome": "Sistema Auditor",
-   "papel": "App oficial do MTE",
-   "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
-  },
-  {
-   "nome": "NotebookLM",
-   "papel": "Fonte de ementas",
-   "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
-  },
-  {
-   "nome": "Ricardo (mantenedor)",
-   "papel": "AFT — SRTE/GO",
-   "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
-  }
- ],
- "fluxo": [
-  {
-   "who": "/aft-preparacao-acao-fiscal",
-   "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
-  },
-  {
-   "who": "/aft-nova-auditoria",
-   "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
-  },
-  {
-   "who": "/aft-painel",
-   "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
-  },
-  {
-   "who": "Visita ao estabelecimento",
-   "act": "Inspeção física presencial."
-  },
-  {
-   "who": "/aft-inspecao-fisica",
-   "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
-  },
-  {
-   "who": "/aft-auditoria-geral",
-   "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
-  },
-  {
-   "who": "/aft-revisa-auto",
-   "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
-  },
-  {
-   "who": "/aft-gera-ai",
-   "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
-  },
-  {
-   "who": "Sistema Auditor",
-   "act": "Botão imp. txt → revisão do AFT → transmissão."
-  },
-  {
-   "who": "/aft-autos-lavrados",
-   "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
-  },
-  {
-   "who": "/aft-relatorio",
-   "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
-  }
- ],
- "instalacao": [
-  {
-   "who": "Instalar o app Claude",
-   "act": "claude.com/claude-code — único passo realmente inicial."
-  },
-  {
-   "who": "Instalar o Git + reiniciar pela bandeja",
-   "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
-  },
-  {
-   "who": "Colar o prompt de instalação no </> Code",
-   "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
-  },
-  {
-   "who": "/aft-setup",
-   "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
-  },
-  {
-   "who": "Codex: dois atalhos (opcional)",
-   "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
-  }
- ],
- "camadas": [
-  {
-   "nome": "Configuração e visão geral",
-   "cor": "accent2",
-   "skills": [
+  "atores": [
     {
-     "nome": "/aft-ajuda",
-     "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
-     "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+      "nome": "AFT colega (novo usuário)",
+      "papel": "Auditor no Windows",
+      "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
     },
     {
-     "nome": "/aft-setup",
-     "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
-     "tech": "winget · pipx · uorgs.csv · model: sonnet"
+      "nome": "Claude Code",
+      "papel": "Assistente técnico",
+      "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
     },
     {
-     "nome": "/aft-doctor",
-     "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
-     "tech": "aft_doctor.py · model: sonnet"
+      "nome": "Sistema Auditor",
+      "papel": "App oficial do MTE",
+      "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
     },
     {
-     "nome": "/aft-erro",
-     "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
-     "tech": "erro_ticket.py · model: sonnet"
+      "nome": "NotebookLM",
+      "papel": "Fonte de ementas",
+      "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
     },
     {
-     "nome": "/aft-atualizar",
-     "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
-     "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-notebooklm-login",
-     "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
-     "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-auditoria",
-     "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
-     "tech": "cria memory.md · model: sonnet"
-    },
-    {
-     "nome": "/aft-organiza-os",
-     "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (pacotes <NN> - <COD> <data de lavratura>/, com a resposta do empregador por dia de download via det_baixar.py --reorganizar; a data de lavratura é lida do PDF) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está. FASE 6 (opcional, sempre perguntada; atende também o pedido direto 'sincroniza minhas pastas com o DET'): varredura via det_baixar.py --varredura — sync das fichas + download do pacote completo de toda notificação sem pacote local e com prazo já vencido, em todas as OS de uma vez; prazo ainda corrente (ou sem prazo na linha) = só o PDF da notificação, sem documentos e sem registrar visualização; notificação com alerta amarelo pendente NUNCA entra no lote (o alerta não se apaga sem o AFT ver): volta listada para baixa individual, uma /aft-det-baixar por código autorizado.",
-     "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
-    },
-    {
-     "nome": "/aft-painel",
-     "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
-     "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
-    },
-    {
-     "nome": "/aft-agenda-det",
-     "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
-    },
-    {
-     "nome": "/aft-det-baixar",
-     "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da OS (NN = ordem de lavratura; renumerado sozinho), com o conteúdo de cada download na subpasta 'baixada em <data>/' — o AFT sabe o que a empresa apresentou em cada dia. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
-     "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-det-baixar-notificacoes",
-     "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da /aft-det-baixar (numera e corrige a data mesmo sem re-baixar), então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
-     "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-skill",
-     "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
-     "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+      "nome": "Ricardo (mantenedor)",
+      "papel": "AFT — SRTE/GO",
+      "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
     }
-   ]
-  },
-  {
-   "nome": "Preparação da ação fiscal (antes da visita)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "fluxo": [
     {
-     "nome": "/aft-preparacao-acao-fiscal",
-     "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
-     "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+      "who": "/aft-preparacao-acao-fiscal",
+      "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
     },
     {
-     "nome": "/aft-cnpjs-endereco",
-     "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
-     "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+      "who": "/aft-nova-auditoria",
+      "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
     },
     {
-     "nome": "/aft-NAD",
-     "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
-     "tech": "espelha /aft-tn-nco · model: sonnet"
+      "who": "/aft-painel",
+      "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
     },
     {
-     "nome": "/aft-lre-esocial",
-     "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
-     "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+      "who": "Visita ao estabelecimento",
+      "act": "Inspeção física presencial."
+    },
+    {
+      "who": "/aft-inspecao-fisica",
+      "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
+    },
+    {
+      "who": "/aft-auditoria-geral",
+      "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
+    },
+    {
+      "who": "/aft-revisa-auto",
+      "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
+    },
+    {
+      "who": "/aft-gera-ai",
+      "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
+    },
+    {
+      "who": "Sistema Auditor",
+      "act": "Botão imp. txt → revisão do AFT → transmissão."
+    },
+    {
+      "who": "/aft-autos-lavrados",
+      "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
+    },
+    {
+      "who": "/aft-relatorio",
+      "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
     }
-   ]
-  },
-  {
-   "nome": "Inspeção e lavratura",
-   "cor": "accent",
-   "skills": [
+  ],
+  "instalacao": [
     {
-     "nome": "/aft-inspecao-fisica",
-     "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
-     "tech": "relato → memory.md · model: sonnet"
+      "who": "Instalar o app Claude",
+      "act": "claude.com/claude-code — único passo realmente inicial."
     },
     {
-     "nome": "/aft-consulta",
-     "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
-     "tech": "notebooklm ask · herda o modelo da sessão"
+      "who": "Instalar o Git + reiniciar pela bandeja",
+      "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
     },
     {
-     "nome": "/aft-auditoria-geral",
-     "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
-     "tech": "orquestra consultoras · herda o modelo da sessão"
+      "who": "Colar o prompt de instalação no </> Code",
+      "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
     },
     {
-     "nome": "/aft-informalidade",
-     "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
-     "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+      "who": "/aft-setup",
+      "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
     },
     {
-     "nome": "/aft-PGR-analise",
-     "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-PGRTR-analise",
-     "role": "Auditoria sistemática do PGRTR (NR-31, rural) na base fixa de 33 ementas com gradação validada no ementário, com confronto campo × documento, extração delegada e citação de páginas. Consulta complementar ao ementário (key nr-31) para o que a base não cobre.",
-     "tech": "handoff p/ gera-ai · model: opus"
-    },
-    {
-     "nome": "/aft-aet-auditoria",
-     "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-auditoria-AR-NR12",
-     "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
-     "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
-    },
-    {
-     "nome": "/aft-det-630",
-     "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
-     "tech": "escreve em ## Notificações DET · model: sonnet"
-    },
-    {
-     "nome": "/aft-tn-nco",
-     "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
-     "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
-    },
-    {
-     "nome": "/aft-email",
-     "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
-     "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
-    },
-    {
-     "nome": "/aft-embargo-interdicao",
-     "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
-     "tech": "template.docx SRTE/GO · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-manutencao",
-     "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
-     "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-levantamento",
-     "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
-     "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
-    },
-    {
-     "nome": "/aft-analise-acidente",
-     "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
-     "tech": "gerar_relatorio_docx.py · model: opus 1M"
+      "who": "Codex: dois atalhos (opcional)",
+      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
     }
-   ]
-  },
-  {
-   "nome": "Consultoras especializadas por NR",
-   "cor": "warn",
-   "skills": [
+  ],
+  "camadas": [
     {
-     "nome": "/aft-NR01",
-     "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
-     "tech": ""
+      "nome": "Configuração e visão geral",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-ajuda",
+          "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
+          "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+        },
+        {
+          "nome": "/aft-setup",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+          "tech": "winget · pipx · uorgs.csv · model: sonnet"
+        },
+        {
+          "nome": "/aft-doctor",
+          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
+          "tech": "aft_doctor.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-erro",
+          "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
+          "tech": "erro_ticket.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-atualizar",
+          "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
+          "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-notebooklm-login",
+          "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
+          "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-auditoria",
+          "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
+          "tech": "cria memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-organiza-os",
+          "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (pacotes <NN> - <COD> <data de lavratura>/, com a resposta do empregador por dia de download via det_baixar.py --reorganizar; a data de lavratura é lida do PDF) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está. FASE 6 (opcional, sempre perguntada; atende também o pedido direto 'sincroniza minhas pastas com o DET'): varredura via det_baixar.py --varredura — sync das fichas + download do pacote completo de toda notificação sem pacote local e com prazo já vencido, em todas as OS de uma vez; prazo ainda corrente (ou sem prazo na linha) = só o PDF da notificação, sem documentos e sem registrar visualização; notificação com alerta amarelo pendente NUNCA entra no lote (o alerta não se apaga sem o AFT ver): volta listada para baixa individual, uma /aft-det-baixar por código autorizado.",
+          "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
+        },
+        {
+          "nome": "/aft-painel",
+          "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
+          "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
+        },
+        {
+          "nome": "/aft-agenda-det",
+          "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
+        },
+        {
+          "nome": "/aft-det-baixar",
+          "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da OS (NN = ordem de lavratura; renumerado sozinho), com o conteúdo de cada download na subpasta 'baixada em <data>/' — o AFT sabe o que a empresa apresentou em cada dia. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
+          "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-det-baixar-notificacoes",
+          "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da /aft-det-baixar (numera e corrige a data mesmo sem re-baixar), então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
+          "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-skill",
+          "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
+          "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR12",
-     "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Preparação da ação fiscal (antes da visita)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-preparacao-acao-fiscal",
+          "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
+          "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+        },
+        {
+          "nome": "/aft-cnpjs-endereco",
+          "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
+          "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-NAD",
+          "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
+          "tech": "espelha /aft-tn-nco · model: sonnet"
+        },
+        {
+          "nome": "/aft-lre-esocial",
+          "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
+          "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR18",
-     "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Inspeção e lavratura",
+      "cor": "accent",
+      "skills": [
+        {
+          "nome": "/aft-inspecao-fisica",
+          "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
+          "tech": "relato → memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-consulta",
+          "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
+          "tech": "notebooklm ask · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-auditoria-geral",
+          "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
+          "tech": "orquestra consultoras · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-informalidade",
+          "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
+          "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+        },
+        {
+          "nome": "/aft-PGR-analise",
+          "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-PGRTR-analise",
+          "role": "Auditoria sistemática do PGRTR (NR-31, rural) na base fixa de 33 ementas com gradação validada no ementário, com confronto campo × documento, extração delegada e citação de páginas. Consulta complementar ao ementário (key nr-31) para o que a base não cobre.",
+          "tech": "handoff p/ gera-ai · model: opus"
+        },
+        {
+          "nome": "/aft-aet-auditoria",
+          "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-auditoria-AR-NR12",
+          "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
+          "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
+        },
+        {
+          "nome": "/aft-det-630",
+          "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
+          "tech": "escreve em ## Notificações DET · model: sonnet"
+        },
+        {
+          "nome": "/aft-tn-nco",
+          "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
+          "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
+        },
+        {
+          "nome": "/aft-email",
+          "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
+          "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
+        },
+        {
+          "nome": "/aft-embargo-interdicao",
+          "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
+          "tech": "template.docx SRTE/GO · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-manutencao",
+          "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
+          "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-levantamento",
+          "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
+          "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
+        },
+        {
+          "nome": "/aft-analise-acidente",
+          "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
+          "tech": "gerar_relatorio_docx.py · model: opus 1M"
+        }
+      ]
     },
     {
-     "nome": "/aft-cnae-grau-risco-nr04",
-     "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
-     "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+      "nome": "Consultoras especializadas por NR",
+      "cor": "warn",
+      "skills": [
+        {
+          "nome": "/aft-NR01",
+          "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
+          "tech": ""
+        },
+        {
+          "nome": "/aft-NR12",
+          "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-NR18",
+          "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cnae-grau-risco-nr04",
+          "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
+          "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-dimensionamento-sesmt-nr04",
+          "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
+          "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cipa-nr05-dimensionamento",
+          "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
+          "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-nr24-dimensionamento",
+          "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
+          "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-dimensionamento-sesmt-nr04",
-     "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
-     "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+      "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-jornada-analise",
+          "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
+          "tech": "roteador · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-valida-afd-aej",
+          "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
+          "tech": "validar.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-atestado",
+          "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
+          "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-jornada-auto-afd-aej",
+          "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
+          "tech": "handoff p/ gera-ai · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-cipa-nr05-dimensionamento",
-     "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
-     "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-nr24-dimensionamento",
-     "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
-     "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+      "nome": "Empacotamento, rastreamento e relatórios",
+      "cor": "ok",
+      "skills": [
+        {
+          "nome": "/aft-revisa-auto",
+          "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
+          "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+        },
+        {
+          "nome": "/aft-gera-ai",
+          "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
+          "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-lavrados",
+          "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
+          "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-pdf-reunidos",
+          "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
+          "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio",
+          "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
+          "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio-acidentes",
+          "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
+          "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-cat-trabalhador",
+          "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
+          "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
+        },
+        {
+          "nome": "/aft-modelo-docx",
+          "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
+          "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
+        },
+        {
+          "nome": "/aft-sessoes-os",
+          "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
+          "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+        }
+      ]
     }
-   ]
-  },
-  {
-   "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "scripts": [
     {
-     "nome": "/aft-jornada-analise",
-     "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
-     "tech": "roteador · model: sonnet"
+      "nome": "rehydrate.py",
+      "caminho": "_scripts/rehydrate.py",
+      "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-valida-afd-aej",
-     "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
-     "tech": "validar.py · model: sonnet"
+      "nome": "bloco3_inject.py",
+      "caminho": "_scripts/bloco3_inject.py",
+      "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-atestado",
-     "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
-     "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+      "nome": "validar_txt.py",
+      "caminho": "_scripts/validar_txt.py",
+      "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-auto-afd-aej",
-     "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
-     "tech": "handoff p/ gera-ai · model: sonnet"
+      "nome": "checar_pii.py",
+      "caminho": "_scripts/checar_pii.py",
+      "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_diff.py",
+      "caminho": "_scripts/checar_diff.py",
+      "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivo_aberto.py",
+      "caminho": "_scripts/checar_arquivo_aberto.py",
+      "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "backup_arquivo.py",
+      "caminho": "_scripts/backup_arquivo.py",
+      "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_rt_autos.py",
+      "caminho": "_scripts/checar_rt_autos.py",
+      "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
+      "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
+    },
+    {
+      "nome": "gerar_painel.py",
+      "caminho": "_scripts/gerar_painel.py",
+      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+      "runtime": "Python stdlib (+pdfplumber opcional)"
+    },
+    {
+      "nome": "servir_painel.py",
+      "caminho": "_scripts/servir_painel.py",
+      "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e desde 24/08/2026 o /api/det-sync também aceita corpo SEM token (usa o da RAM; 409 se não houver) — é como a varredura da /aft-organiza-os dispara o sync das fichas, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_sync.py",
+      "caminho": "_scripts/det_sync.py",
+      "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto. Desde 24/08/2026 também resume o status de cada item na sub-linha com o marcador 📋 (resumo_itens): UMA requisição GET /itens-notificacao?uidNotificacao= — cada item já traz o campo status, o mesmo número da coluna Status da tela do DET (verificado na API), traduzido pelo enum STATUS_ITEM reaproveitado do det_baixar; não é preciso varrer /eventos-item. Sai '📋 itens: 5 aguardando avaliação de prazo' (ou a contagem por estado); o gerar_painel lê o marcador (RE_DET_ITENS) e mostra no dossiê, e conta os 'aguardando avaliação' num selo do card da grade ('📋 5 itens aguardam sua decisão'). O GATE é a notificação estar EM ABERTO na ficha (codigos_abertos, checkbox '- [ ]'), NÃO o triângulo itemAtualizado: corrigido em 25/08/2026 (caso BUENO 28) porque o triângulo é alerta de NOVIDADE — some quando o AFT o dispensa no painel ou abre a notificação no DET — e levava junto o ESTADO dos itens, que continua verdadeiro depois de visto. Custo medido: 12 requisições extras por sync nas 11 OS ativas. Best-effort.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_baixar.py",
+      "caminho": "_scripts/det_baixar.py",
+      "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<NN> - <COD> <dd-mm-aaaa>/ (convenção do AFT, 24/08/2026 — NN é a ordem de LAVRATURA, renumerada sozinha via renumerar_pacotes() quando uma antiga chega depois, e a data é a de LAVRATURA, o dataEnvio da pesquisa): o PDF da notificação e canal-comunicacao/ na raiz do pacote, e o resto na subpasta do dia 'baixada em <data>/' — relatório de atendimento (fotografia daquele dia), historico-itens.md e item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote, cada dia na sua subpasta; legados migram sozinhos (pacote notificacao-<COD> ou <COD> <data> é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro; migrar_pacote_para_dias() desce o conteúdo da raiz do pacote para o dia da data de modificação de cada arquivo; tudo conta em movidos; modo --reorganizar faz o mesmo sem rede, para a /aft-organiza-os). Modo --varredura (FASE 6 da /aft-organiza-os): POST /api/det-sync sem corpo (token da RAM) para atualizar as fichas e, por OS, download completo dos códigos sem pacote local, sem alerta pendente E com prazo vencido — pendente ('atualização pendente' na sub-linha) nunca entra no lote (regra do AFT de 24/08/2026: o triângulo só se apaga em baixa individual) e volta no campo pendentes; prazo corrente ou desconhecido (datas da linha checkbox, parseadas em codigos_da_ficha) recebe no máximo o PDF via modo só-notificação e volta no campo no_prazo; cancelada pula, em dia fica quieta; token vencido devolve token_expirado com o parcial, e rodar de novo é seguro; conexão recusada (painel caído) ganha nova tentativa após 15 s — o vigia o reergue sozinho. Idempotente por existência do arquivo em qualquer subpasta de dia (_ja_baixado); nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_criar.py",
+      "caminho": "_scripts/det_criar.py",
+      "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_rotina_painel.py",
+      "caminho": "_scripts/instalar_rotina_painel.py",
+      "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_servidor_painel.py",
+      "caminho": "_scripts/instalar_servidor_painel.py",
+      "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "aft_doctor.py",
+      "caminho": "_scripts/aft_doctor.py",
+      "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "fotos_para_pdf.py",
+      "caminho": "_scripts/fotos_para_pdf.py",
+      "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
+      "runtime": "Python · pillow"
+    },
+    {
+      "nome": "comprimir_pdf.py",
+      "caminho": "_scripts/comprimir_pdf.py",
+      "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
+      "runtime": "Python · pikepdf/pypdf"
+    },
+    {
+      "nome": "docx_pack.py / docx_unpack.py",
+      "caminho": "_scripts/docx_*.py",
+      "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "nome": "scan_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
+      "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
+      "runtime": "Python · pypdf"
+    },
+    {
+      "nome": "gera_relacao_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
+      "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
+      "runtime": "Python (python-docx)"
+    },
+    {
+      "nome": "inspecionar_assinatura.py",
+      "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
+      "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
+      "runtime": "Python"
+    },
+    {
+      "nome": "validar.py",
+      "caminho": "aft-jornada-valida-afd-aej/validar.py",
+      "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "gerar_relatorio_docx.py",
+      "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
+      "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "runtime": "Python stdlib",
+      "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
+      "nome": "pasta_aft.py",
+      "caminho": "_scripts/pasta_aft.py"
+    },
+    {
+      "nome": "instalar_agentes.py",
+      "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
+    },
+    {
+      "nome": "erro_ticket.py",
+      "caminho": "_scripts/erro_ticket.py",
+      "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sync_perfil.py",
+      "caminho": "_scripts/sync_perfil.py",
+      "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sessoes_os.py",
+      "caminho": "_scripts/sessoes_os.py",
+      "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_vigia_sessoes.py",
+      "caminho": "_scripts/instalar_vigia_sessoes.py",
+      "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "checar_acentos.py",
+      "caminho": "_scripts/checar_acentos.py",
+      "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivos_internos.py",
+      "caminho": "_scripts/checar_arquivos_internos.py",
+      "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "indenta_quebras.py",
+      "caminho": "_scripts/indenta_quebras.py",
+      "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "ajuda_arquitetura.py",
+      "caminho": "_scripts/ajuda_arquitetura.py",
+      "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebook_id.py",
+      "caminho": "_scripts/notebook_id.py",
+      "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
+      "runtime": "python (stdlib) + CLI notebooklm na sondagem"
+    },
+    {
+      "nome": "sincronizar_notebooks.py",
+      "caminho": "_scripts/sincronizar_notebooks.py",
+      "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebooklm_consulta.py",
+      "caminho": "_scripts/notebooklm_consulta.py",
+      "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
+      "runtime": "python (stdlib) + CLI notebooklm"
+    },
+    {
+      "nome": "lre_esocial.py",
+      "caminho": "_scripts/lre_esocial.py",
+      "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_ferias.py",
+      "caminho": "_scripts/lre_ferias.py",
+      "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_folha.py",
+      "caminho": "_scripts/lre_folha.py",
+      "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "cbo.json",
+      "caminho": "_scripts/cbo.json",
+      "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
+      "runtime": "dado (JSON)"
+    },
+    {
+      "nome": "consulta_cnpj.py",
+      "caminho": "_scripts/consulta_cnpj.py",
+      "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "tokenizar.py",
+      "caminho": "_scripts/tokenizar.py",
+      "papel": "Sentido de IDA da pseudonimização: monta o de-para .depara_<CNPJ>.json, troca nome real por [[TRAB_NN]]/[[AUTUADA]] no arquivo e confere se sobrou nome real, token órfão ou CPF. Recusa CPF de trabalhador no mapa e nunca renumera token já usado. Complementa o rehydrate.py, que faz a volta.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "conferir_rastreamento.py",
+      "caminho": "_scripts/conferir_rastreamento.py",
+      "papel": "Acha CONTRADIÇÃO entre os registros de auto do memory.md (checkbox [x] com texto dizendo pendente, [x] sem número de AI, [ ] com número, afirmação de auto lavrado em `## Ementas da OS` sem respaldo). Só aponta divergência: não prova qual registro está certo, e nunca escreve no memory.md.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "conferir_cotejo.py",
+      "caminho": "_scripts/conferir_cotejo.py",
+      "papel": "Cotejo de encerramento: lista documento e foto que entraram na OS e nunca foram mencionados em nenhuma análise. Antes de encerrar, ou o documento é confrontado, ou o motivo de não o ser é declarado ao AFT.",
+      "runtime": "Python stdlib"
     }
-   ]
-  },
-  {
-   "nome": "Empacotamento, rastreamento e relatórios",
-   "cor": "ok",
-   "skills": [
+  ],
+  "dados": [
     {
-     "nome": "/aft-revisa-auto",
-     "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
-     "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+      "arquivo": "config/notebooks.json",
+      "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
+      "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
     },
     {
-     "nome": "/aft-gera-ai",
-     "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
-     "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+      "arquivo": "config/uorgs.csv",
+      "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
+      "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
     },
     {
-     "nome": "/aft-autos-lavrados",
-     "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
-     "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+      "arquivo": "config/CLAUDE-aft.md",
+      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
+      "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
     },
     {
-     "nome": "/aft-autos-pdf-reunidos",
-     "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
-     "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+      "arquivo": "config/blocos_auto.md",
+      "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
+      "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
     },
     {
-     "nome": "/aft-relatorio",
-     "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
-     "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+      "arquivo": "config/settings-aft.json",
+      "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
+      "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
     },
     {
-     "nome": "/aft-relatorio-acidentes",
-     "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
-     "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
-    },
-    {
-     "nome": "/aft-cat-trabalhador",
-     "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
-     "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
-    },
-    {
-     "nome": "/aft-modelo-docx",
-     "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
-     "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
-    },
-    {
-     "nome": "/aft-sessoes-os",
-     "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
-     "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+      "arquivo": "config/models-validos.json",
+      "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
+      "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
     }
-   ]
-  }
- ],
- "scripts": [
-  {
-   "nome": "rehydrate.py",
-   "caminho": "_scripts/rehydrate.py",
-   "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "bloco3_inject.py",
-   "caminho": "_scripts/bloco3_inject.py",
-   "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "validar_txt.py",
-   "caminho": "_scripts/validar_txt.py",
-   "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_pii.py",
-   "caminho": "_scripts/checar_pii.py",
-   "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_diff.py",
-   "caminho": "_scripts/checar_diff.py",
-   "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivo_aberto.py",
-   "caminho": "_scripts/checar_arquivo_aberto.py",
-   "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "backup_arquivo.py",
-   "caminho": "_scripts/backup_arquivo.py",
-   "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_rt_autos.py",
-   "caminho": "_scripts/checar_rt_autos.py",
-   "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
-   "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
-  },
-  {
-   "nome": "gerar_painel.py",
-   "caminho": "_scripts/gerar_painel.py",
-   "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
-   "runtime": "Python stdlib (+pdfplumber opcional)"
-  },
-  {
-   "nome": "servir_painel.py",
-   "caminho": "_scripts/servir_painel.py",
-   "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e desde 24/08/2026 o /api/det-sync também aceita corpo SEM token (usa o da RAM; 409 se não houver) — é como a varredura da /aft-organiza-os dispara o sync das fichas, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_sync.py",
-   "caminho": "_scripts/det_sync.py",
-   "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto. Desde 24/08/2026 também resume o status de cada item na sub-linha com o marcador 📋 (resumo_itens): UMA requisição GET /itens-notificacao?uidNotificacao= — cada item já traz o campo status, o mesmo número da coluna Status da tela do DET (verificado na API), traduzido pelo enum STATUS_ITEM reaproveitado do det_baixar; não é preciso varrer /eventos-item. Sai '📋 itens: 5 aguardando avaliação de prazo' (ou a contagem por estado); o gerar_painel lê o marcador (RE_DET_ITENS) e mostra no dossiê, e conta os 'aguardando avaliação' num selo do card da grade ('📋 5 itens aguardam sua decisão'). O GATE é a notificação estar EM ABERTO na ficha (codigos_abertos, checkbox '- [ ]'), NÃO o triângulo itemAtualizado: corrigido em 25/08/2026 (caso BUENO 28) porque o triângulo é alerta de NOVIDADE — some quando o AFT o dispensa no painel ou abre a notificação no DET — e levava junto o ESTADO dos itens, que continua verdadeiro depois de visto. Custo medido: 12 requisições extras por sync nas 11 OS ativas. Best-effort.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_baixar.py",
-   "caminho": "_scripts/det_baixar.py",
-   "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<NN> - <COD> <dd-mm-aaaa>/ (convenção do AFT, 24/08/2026 — NN é a ordem de LAVRATURA, renumerada sozinha via renumerar_pacotes() quando uma antiga chega depois, e a data é a de LAVRATURA, o dataEnvio da pesquisa): o PDF da notificação e canal-comunicacao/ na raiz do pacote, e o resto na subpasta do dia 'baixada em <data>/' — relatório de atendimento (fotografia daquele dia), historico-itens.md e item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote, cada dia na sua subpasta; legados migram sozinhos (pacote notificacao-<COD> ou <COD> <data> é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro; migrar_pacote_para_dias() desce o conteúdo da raiz do pacote para o dia da data de modificação de cada arquivo; tudo conta em movidos; modo --reorganizar faz o mesmo sem rede, para a /aft-organiza-os). Modo --varredura (FASE 6 da /aft-organiza-os): POST /api/det-sync sem corpo (token da RAM) para atualizar as fichas e, por OS, download completo dos códigos sem pacote local, sem alerta pendente E com prazo vencido — pendente ('atualização pendente' na sub-linha) nunca entra no lote (regra do AFT de 24/08/2026: o triângulo só se apaga em baixa individual) e volta no campo pendentes; prazo corrente ou desconhecido (datas da linha checkbox, parseadas em codigos_da_ficha) recebe no máximo o PDF via modo só-notificação e volta no campo no_prazo; cancelada pula, em dia fica quieta; token vencido devolve token_expirado com o parcial, e rodar de novo é seguro; conexão recusada (painel caído) ganha nova tentativa após 15 s — o vigia o reergue sozinho. Idempotente por existência do arquivo em qualquer subpasta de dia (_ja_baixado); nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_criar.py",
-   "caminho": "_scripts/det_criar.py",
-   "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_rotina_painel.py",
-   "caminho": "_scripts/instalar_rotina_painel.py",
-   "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_servidor_painel.py",
-   "caminho": "_scripts/instalar_servidor_painel.py",
-   "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "aft_doctor.py",
-   "caminho": "_scripts/aft_doctor.py",
-   "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "fotos_para_pdf.py",
-   "caminho": "_scripts/fotos_para_pdf.py",
-   "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
-   "runtime": "Python · pillow"
-  },
-  {
-   "nome": "comprimir_pdf.py",
-   "caminho": "_scripts/comprimir_pdf.py",
-   "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
-   "runtime": "Python · pikepdf/pypdf"
-  },
-  {
-   "nome": "docx_pack.py / docx_unpack.py",
-   "caminho": "_scripts/docx_*.py",
-   "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "nome": "scan_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
-   "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
-   "runtime": "Python · pypdf"
-  },
-  {
-   "nome": "gera_relacao_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
-   "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
-   "runtime": "Python (python-docx)"
-  },
-  {
-   "nome": "inspecionar_assinatura.py",
-   "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
-   "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
-   "runtime": "Python"
-  },
-  {
-   "nome": "validar.py",
-   "caminho": "aft-jornada-valida-afd-aej/validar.py",
-   "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "gerar_relatorio_docx.py",
-   "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
-   "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "runtime": "Python stdlib",
-   "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
-   "nome": "pasta_aft.py",
-   "caminho": "_scripts/pasta_aft.py"
-  },
-  {
-   "nome": "instalar_agentes.py",
-   "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
-  },
-  {
-   "nome": "erro_ticket.py",
-   "caminho": "_scripts/erro_ticket.py",
-   "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sync_perfil.py",
-   "caminho": "_scripts/sync_perfil.py",
-   "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sessoes_os.py",
-   "caminho": "_scripts/sessoes_os.py",
-   "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_vigia_sessoes.py",
-   "caminho": "_scripts/instalar_vigia_sessoes.py",
-   "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "checar_acentos.py",
-   "caminho": "_scripts/checar_acentos.py",
-   "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivos_internos.py",
-   "caminho": "_scripts/checar_arquivos_internos.py",
-   "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "indenta_quebras.py",
-   "caminho": "_scripts/indenta_quebras.py",
-   "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "ajuda_arquitetura.py",
-   "caminho": "_scripts/ajuda_arquitetura.py",
-   "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebook_id.py",
-   "caminho": "_scripts/notebook_id.py",
-   "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
-   "runtime": "python (stdlib) + CLI notebooklm na sondagem"
-  },
-  {
-   "nome": "sincronizar_notebooks.py",
-   "caminho": "_scripts/sincronizar_notebooks.py",
-   "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebooklm_consulta.py",
-   "caminho": "_scripts/notebooklm_consulta.py",
-   "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
-   "runtime": "python (stdlib) + CLI notebooklm"
-  },
-  {
-   "nome": "lre_esocial.py",
-   "caminho": "_scripts/lre_esocial.py",
-   "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_ferias.py",
-   "caminho": "_scripts/lre_ferias.py",
-   "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_folha.py",
-   "caminho": "_scripts/lre_folha.py",
-   "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "cbo.json",
-   "caminho": "_scripts/cbo.json",
-   "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
-   "runtime": "dado (JSON)"
-  },
-  {
-   "nome": "consulta_cnpj.py",
-   "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
-   "runtime": "Python stdlib"
-  }
- ],
- "dados": [
-  {
-   "arquivo": "config/notebooks.json",
-   "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
-   "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
-  },
-  {
-   "arquivo": "config/uorgs.csv",
-   "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
-   "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
-  },
-  {
-   "arquivo": "config/CLAUDE-aft.md",
-   "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
-   "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
-  },
-  {
-   "arquivo": "config/blocos_auto.md",
-   "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
-   "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
-  },
-  {
-   "arquivo": "config/settings-aft.json",
-   "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
-   "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
-  },
-  {
-   "arquivo": "config/models-validos.json",
-   "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
-   "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
-  }
- ],
- "ementas": [
-  {
-   "camada": "1. NotebookLM (recomendado)",
-   "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
-  },
-  {
-   "camada": "2. Google Drive compartilhado",
-   "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
-  },
-  {
-   "camada": "3. O AFT informa o código",
-   "txt": "Formato XXXXXX-X, conferido no ementário oficial."
-  }
- ],
- "anonimizacao": [
-  "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
-  "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
-  "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
-  "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
-  "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
-  "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
-  "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
- ],
- "decisoes": [
-  {
-   "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
-   "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
-  },
-  {
-   "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
-   "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
-  },
-  {
-   "topico": "Relação de autos é .docx, sem PDF",
-   "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
-  },
-  {
-   "topico": "Nomes das skills",
-   "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
-  },
-  {
-   "topico": "Instalação",
-   "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
-  },
-  {
-   "topico": "Git obrigatório",
-   "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
-  },
-  {
-   "topico": "Sem SISOS/Supabase",
-   "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
-  },
-  {
-   "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
-   "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
-  },
-  {
-   "topico": "Empacotamento único",
-   "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-PGRTR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
-  },
-  {
-   "topico": "Latin-1 sem iconv",
-   "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
-  },
-  {
-   "topico": "Lotação pela cidade",
-   "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
-  },
-  {
-   "topico": "Ementas em 3 camadas",
-   "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
-  },
-  {
-   "topico": "Bloco 3 centralizado",
-   "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
-  },
-  {
-   "topico": "Atualização separada do diagnóstico",
-   "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
-  },
-  {
-   "topico": "Política de model por skill",
-   "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
-  },
-  {
-   "topico": "allowed-tools como garantia",
-   "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
-  },
-  {
-   "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
-   "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
-  },
-  {
-   "topico": "Detecção determinística no /aft-painel",
-   "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
-  },
-  {
-   "topico": "Bases distintas",
-   "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
-  },
-  {
-   "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
-   "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
-  },
-  {
-   "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
-   "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
-  },
-  {
-   "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
-   "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
-  },
-  {
-   "topico": "Painel virou dashboard de cards (SISOS local, offline)",
-   "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
-  },
-  {
-   "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
-   "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
-  },
-  {
-   "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
-   "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
-  },
-  {
-   "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
-   "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
-  },
-  {
-   "topico": "Painel ativo (modo interativo local)",
-   "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
-  },
-  {
-   "topico": "Extensão Chrome sincroniza o DET com o painel local",
-   "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
-  },
-  {
-   "topico": "Servidor do painel sempre ligado (padrão na instalação)",
-   "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
-  },
-  {
-   "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
-   "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
-  },
-  {
-   "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
-   "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
-  },
-  {
-   "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
-   "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
-  },
-  {
-   "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
-   "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
-  },
-  {
-   "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
-   "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
-  },
-  {
-   "topico": "Google Calendar: conector do Claude, não OAuth próprio",
-   "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
-  },
-  {
-   "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
-   "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
-  },
-  {
-   "topico": "Pasta única interdicao-embargo/ por OS",
-   "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
-  },
-  {
-   "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
-   "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
-  },
-  {
-   "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
-   "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
-  },
-  {
-   "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
-   "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
-  },
-  {
-   "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
-   "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
-  },
-  {
-   "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
-   "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
-  },
-  {
-   "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
-   "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
-  },
-  {
-   "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
-   "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
-  },
-  {
-   "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
-   "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
-  },
-  {
-   "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
-   "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
-  },
-  {
-   "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
-   "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
-  }
- ],
- "diferencas": [
-  {
-   "topico": "Plataforma",
-   "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
-  },
-  {
-   "topico": "Estado central",
-   "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
-  },
-  {
-   "topico": "Empacotamento",
-   "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
-  },
-  {
-   "topico": "Identidade do AFT",
-   "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
-  }
- ],
- "foraDoToolkit": [
-  "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
-  "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
-  "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
-  "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
-  "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
- ],
- "avisos": [
-  "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
-  "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
-  "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
-  "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
-  "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
-  "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
-  "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-  "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
-  "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
- ]
+  ],
+  "ementas": [
+    {
+      "camada": "1. NotebookLM (recomendado)",
+      "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
+    },
+    {
+      "camada": "2. Google Drive compartilhado",
+      "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
+    },
+    {
+      "camada": "3. O AFT informa o código",
+      "txt": "Formato XXXXXX-X, conferido no ementário oficial."
+    }
+  ],
+  "anonimizacao": [
+    "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
+    "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
+    "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
+    "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
+    "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
+    "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
+    "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
+  ],
+  "decisoes": [
+    {
+      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+    },
+    {
+      "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
+      "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
+    },
+    {
+      "topico": "Relação de autos é .docx, sem PDF",
+      "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
+    },
+    {
+      "topico": "Nomes das skills",
+      "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
+    },
+    {
+      "topico": "Instalação",
+      "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
+    },
+    {
+      "topico": "Git obrigatório",
+      "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
+    },
+    {
+      "topico": "Sem SISOS/Supabase",
+      "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
+    },
+    {
+      "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
+      "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
+    },
+    {
+      "topico": "Empacotamento único",
+      "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-PGRTR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
+    },
+    {
+      "topico": "Latin-1 sem iconv",
+      "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
+    },
+    {
+      "topico": "Lotação pela cidade",
+      "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
+    },
+    {
+      "topico": "Ementas em 3 camadas",
+      "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
+    },
+    {
+      "topico": "Bloco 3 centralizado",
+      "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
+    },
+    {
+      "topico": "Atualização separada do diagnóstico",
+      "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
+    },
+    {
+      "topico": "Política de model por skill",
+      "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
+    },
+    {
+      "topico": "allowed-tools como garantia",
+      "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
+    },
+    {
+      "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
+      "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
+    },
+    {
+      "topico": "Detecção determinística no /aft-painel",
+      "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
+    },
+    {
+      "topico": "Bases distintas",
+      "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
+    },
+    {
+      "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
+      "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
+    },
+    {
+      "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
+      "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
+    },
+    {
+      "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
+      "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
+    },
+    {
+      "topico": "Painel virou dashboard de cards (SISOS local, offline)",
+      "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
+    },
+    {
+      "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
+      "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
+    },
+    {
+      "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
+      "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
+    },
+    {
+      "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
+      "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
+    },
+    {
+      "topico": "Painel ativo (modo interativo local)",
+      "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
+    },
+    {
+      "topico": "Extensão Chrome sincroniza o DET com o painel local",
+      "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
+    },
+    {
+      "topico": "Servidor do painel sempre ligado (padrão na instalação)",
+      "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
+    },
+    {
+      "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
+      "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
+    },
+    {
+      "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
+      "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
+    },
+    {
+      "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
+      "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
+    },
+    {
+      "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
+      "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
+    },
+    {
+      "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
+      "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
+    },
+    {
+      "topico": "Google Calendar: conector do Claude, não OAuth próprio",
+      "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
+    },
+    {
+      "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
+      "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
+    },
+    {
+      "topico": "Pasta única interdicao-embargo/ por OS",
+      "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
+    },
+    {
+      "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
+      "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
+    },
+    {
+      "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
+      "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
+    },
+    {
+      "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
+      "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
+    },
+    {
+      "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
+      "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
+    },
+    {
+      "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
+      "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
+    },
+    {
+      "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
+      "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
+    },
+    {
+      "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
+      "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
+    },
+    {
+      "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
+      "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
+    },
+    {
+      "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
+      "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
+    },
+    {
+      "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
+      "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
+    }
+  ],
+  "diferencas": [
+    {
+      "topico": "Plataforma",
+      "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
+    },
+    {
+      "topico": "Estado central",
+      "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
+    },
+    {
+      "topico": "Empacotamento",
+      "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
+    },
+    {
+      "topico": "Identidade do AFT",
+      "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
+    }
+  ],
+  "foraDoToolkit": [
+    "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
+    "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
+    "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
+    "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
+    "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
+  ],
+  "avisos": [
+    "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
+    "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
+    "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
+    "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
+    "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
+    "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
+    "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
+    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
+  ]
 };
 
 const $=s=>document.querySelector(s), el=(t,c,h)=>{const e=document.createElement(t);if(c)e.className=c;if(h!=null)e.innerHTML=h;return e;};

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -1,937 +1,955 @@
 {
- "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
- "repo": "github.com/ryckardo42/aft-toolkit",
- "data": "2026-08-24",
- "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
- "stats": {
-  "skills": 52,
-  "scripts": 42,
-  "dados": 6,
-  "commit": "ver `git log -1` — atualizado em 23/08/2026"
- },
- "atores": [
-  {
-   "nome": "AFT colega (novo usuário)",
-   "papel": "Auditor no Windows",
-   "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
+  "projeto": "AFT Toolkit — skills de fiscalização para Claude Code e Codex (Windows)",
+  "repo": "github.com/ryckardo42/aft-toolkit",
+  "data": "2026-08-25",
+  "resumo": "Repositório de distribuição que transforma o assistente de código (Claude Code no app desktop, Windows — ou o Codex) num assistente de fiscalização 100% local para Auditores-Fiscais do Trabalho. O repositório É a própria pasta ~/.claude/skills do colega, sempre, inclusive para quem só usa o Codex (é o caminho escrito dentro dos SKILL.md); o Codex enxerga a mesma pasta pelo atalho ~/.agents/skills e lê o perfil do auditor pelo atalho ~/.codex/AGENTS.md. 46 skills cobrem o fluxo completo (planejar a ação fiscal antes da visita, cadastrar a OS, narrar a inspeção, consultar ementas, redigir autos, auditar PGR e AET, analisar acidentes, revisar antes de empacotar, gerar o TXT do Sistema Auditor, manter o toolkit atualizado e relatar), apoiadas por scripts Python locais e por uma política de pseudonimização reversível. Não usa servidor nem banco: os memory.md de cada OS são o estado local e o /aft-painel é a camada de visão (SISOS-lite). Cada skill declara o modelo adequado ao seu perfil (opus 1M para auditoria documental, sonnet/haiku para o mecânico) e as skills read-only têm a restrição imposta por allowed-tools. É uma adaptação das skills pessoais do mantenedor — base distinta, nunca um link para elas.",
+  "stats": {
+    "skills": 52,
+    "scripts": 45,
+    "dados": 6,
+    "commit": "ver `git log -1` — atualizado em 23/08/2026"
   },
-  {
-   "nome": "Claude Code",
-   "papel": "Assistente técnico",
-   "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
-  },
-  {
-   "nome": "Sistema Auditor",
-   "papel": "App oficial do MTE",
-   "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
-  },
-  {
-   "nome": "NotebookLM",
-   "papel": "Fonte de ementas",
-   "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
-  },
-  {
-   "nome": "Ricardo (mantenedor)",
-   "papel": "AFT — SRTE/GO",
-   "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
-  }
- ],
- "fluxo": [
-  {
-   "who": "/aft-preparacao-acao-fiscal",
-   "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
-  },
-  {
-   "who": "/aft-nova-auditoria",
-   "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
-  },
-  {
-   "who": "/aft-painel",
-   "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
-  },
-  {
-   "who": "Visita ao estabelecimento",
-   "act": "Inspeção física presencial."
-  },
-  {
-   "who": "/aft-inspecao-fisica",
-   "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
-  },
-  {
-   "who": "/aft-auditoria-geral",
-   "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
-  },
-  {
-   "who": "/aft-revisa-auto",
-   "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
-  },
-  {
-   "who": "/aft-gera-ai",
-   "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
-  },
-  {
-   "who": "Sistema Auditor",
-   "act": "Botão imp. txt → revisão do AFT → transmissão."
-  },
-  {
-   "who": "/aft-autos-lavrados",
-   "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
-  },
-  {
-   "who": "/aft-relatorio",
-   "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
-  }
- ],
- "instalacao": [
-  {
-   "who": "Instalar o app Claude",
-   "act": "claude.com/claude-code — único passo realmente inicial."
-  },
-  {
-   "who": "Instalar o Git + reiniciar pela bandeja",
-   "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
-  },
-  {
-   "who": "Colar o prompt de instalação no </> Code",
-   "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
-  },
-  {
-   "who": "/aft-setup",
-   "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
-  },
-  {
-   "who": "Codex: dois atalhos (opcional)",
-   "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
-  }
- ],
- "camadas": [
-  {
-   "nome": "Configuração e visão geral",
-   "cor": "accent2",
-   "skills": [
+  "atores": [
     {
-     "nome": "/aft-ajuda",
-     "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
-     "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+      "nome": "AFT colega (novo usuário)",
+      "papel": "Auditor no Windows",
+      "descricao": "Instala o toolkit no próprio PC; não é programador — o Claude executa os comandos por ele. Único responsável jurídico por cada auto/termo."
     },
     {
-     "nome": "/aft-setup",
-     "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
-     "tech": "winget · pipx · uorgs.csv · model: sonnet"
+      "nome": "Claude Code",
+      "papel": "Assistente técnico",
+      "descricao": "App desktop no Windows; descobre as skills no 1º nível de ~/.claude/skills e executa os scripts locais pedindo permissão."
     },
     {
-     "nome": "/aft-doctor",
-     "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
-     "tech": "aft_doctor.py · model: sonnet"
+      "nome": "Sistema Auditor",
+      "papel": "App oficial do MTE",
+      "descricao": "Importa o TXT (botão imp. txt, latin-1) e transmite os autos; grava os PDFs transmitidos em C:\\SistemasAFT\\...\\PRO."
     },
     {
-     "nome": "/aft-erro",
-     "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
-     "tech": "erro_ticket.py · model: sonnet"
+      "nome": "NotebookLM",
+      "papel": "Fonte de ementas",
+      "descricao": "Consultado via CLI notebooklm-py (e pela skill /aft-consulta) para achar/fundamentar o código da ementa; recebe apenas a descrição da irregularidade, nunca dados pessoais."
     },
     {
-     "nome": "/aft-atualizar",
-     "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
-     "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-notebooklm-login",
-     "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
-     "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-auditoria",
-     "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
-     "tech": "cria memory.md · model: sonnet"
-    },
-    {
-     "nome": "/aft-organiza-os",
-     "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (pacotes <NN> - <COD> <data de lavratura>/, com a resposta do empregador por dia de download via det_baixar.py --reorganizar; a data de lavratura é lida do PDF) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está. FASE 6 (opcional, sempre perguntada; atende também o pedido direto 'sincroniza minhas pastas com o DET'): varredura via det_baixar.py --varredura — sync das fichas + download do pacote completo de toda notificação sem pacote local e com prazo já vencido, em todas as OS de uma vez; prazo ainda corrente (ou sem prazo na linha) = só o PDF da notificação, sem documentos e sem registrar visualização; notificação com alerta amarelo pendente NUNCA entra no lote (o alerta não se apaga sem o AFT ver): volta listada para baixa individual, uma /aft-det-baixar por código autorizado.",
-     "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
-    },
-    {
-     "nome": "/aft-painel",
-     "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
-     "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
-    },
-    {
-     "nome": "/aft-agenda-det",
-     "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
-    },
-    {
-     "nome": "/aft-det-baixar",
-     "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da OS (NN = ordem de lavratura; renumerado sozinho), com o conteúdo de cada download na subpasta 'baixada em <data>/' — o AFT sabe o que a empresa apresentou em cada dia. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
-     "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
-    },
-    {
-     "nome": "/aft-det-baixar-notificacoes",
-     "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da /aft-det-baixar (numera e corrige a data mesmo sem re-baixar), então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
-     "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
-    },
-    {
-     "nome": "/aft-nova-skill",
-     "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
-     "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+      "nome": "Ricardo (mantenedor)",
+      "papel": "AFT — SRTE/GO",
+      "descricao": "Adapta as skills pessoais para o toolkit e publica no GitHub; o template do RT segue o modelo SRTE/GO."
     }
-   ]
-  },
-  {
-   "nome": "Preparação da ação fiscal (antes da visita)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "fluxo": [
     {
-     "nome": "/aft-preparacao-acao-fiscal",
-     "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
-     "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+      "who": "/aft-preparacao-acao-fiscal",
+      "act": "Opcional, antes da visita: resolve/cria a OS (chama /aft-nova-auditoria), coleta denúncia e dados prévios, tokeniza a lista de trabalhadores se houver, destaca as ementas I3/I4 da OS que contam para a meta de regularização do projeto (com as de fácil regularização pelo empregador) e monta o checklist de documentos — encadeia /aft-NAD ao final. Salva preparacao.md."
     },
     {
-     "nome": "/aft-cnpjs-endereco",
-     "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
-     "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+      "who": "/aft-nova-auditoria",
+      "act": "Cadastra a empresa, o CNPJ, o município e o 1º DET com prazo. Cria OS ATIVAS/<NOME> <CNPJ>/ e o memory.md no esquema padrão. Começo do fluxo (direto, ou chamado por /aft-preparacao-acao-fiscal)."
     },
     {
-     "nome": "/aft-NAD",
-     "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
-     "tech": "espelha /aft-tn-nco · model: sonnet"
+      "who": "/aft-painel",
+      "act": "A qualquer momento: varre os memory.md e gera o painel.html com os prazos de DET coloridos por urgência; detecta PDFs de notificação DET nas pastas das OS ainda não cadastrados na ficha (código e datas). Opcionalmente (opt-in) publica o painel como Artifact privado na aba Artefatos. Só leitura nas fichas."
     },
     {
-     "nome": "/aft-lre-esocial",
-     "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
-     "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+      "who": "Visita ao estabelecimento",
+      "act": "Inspeção física presencial."
+    },
+    {
+      "who": "/aft-inspecao-fisica",
+      "act": "Transcreve a narrativa ditada num relato de campo estruturado (inspecao-fisica.md), fiel e sem enquadramento."
+    },
+    {
+      "who": "/aft-auditoria-geral",
+      "act": "Enquadra os achados (relato de campo + constatações da Auditoria de documentos), identifica NR/ementa (via /aft-consulta ao NotebookLM) e redige os autos. Aciona consultoras /aft-NR12 e /aft-NR18; desvia para /aft-informalidade, /aft-embargo-interdicao (risco grave), /aft-PGR-analise, /aft-aet-auditoria ou /aft-analise-acidente. Gate de dupla visita (ME/EPP)."
+    },
+    {
+      "who": "/aft-revisa-auto",
+      "act": "Gate de qualidade antes de empacotar: confere o checklist 5W1H em cada auto e, em autos de SST, garante o parágrafo de dano coletivo (Portaria MTP 667/2021). Roda automaticamente dentro do /aft-gera-ai."
+    },
+    {
+      "who": "/aft-gera-ai",
+      "act": "Empacota os autos no TXT importável (latin-1) + anexos PDF. Pseudonimização reversível: rehydrate.py re-injeta nomes/CPFs reais — nunca o LLM."
+    },
+    {
+      "who": "Sistema Auditor",
+      "act": "Botão imp. txt → revisão do AFT → transmissão."
+    },
+    {
+      "who": "/aft-autos-lavrados",
+      "act": "Lê os PDFs transmitidos em ...\\PRO, cruza com os rascunhos e marca no memory.md o que está lavrado [x] / pendente [ ]."
+    },
+    {
+      "who": "/aft-relatorio",
+      "act": "Relatório Final Simplificado: notificações, autos por tema e interdições, do memory.md — texto p/ SFITWEB + .docx p/ chefia·MPT."
     }
-   ]
-  },
-  {
-   "nome": "Inspeção e lavratura",
-   "cor": "accent",
-   "skills": [
+  ],
+  "instalacao": [
     {
-     "nome": "/aft-inspecao-fisica",
-     "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
-     "tech": "relato → memory.md · model: sonnet"
+      "who": "Instalar o app Claude",
+      "act": "claude.com/claude-code — único passo realmente inicial."
     },
     {
-     "nome": "/aft-consulta",
-     "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
-     "tech": "notebooklm ask · herda o modelo da sessão"
+      "who": "Instalar o Git + reiniciar pela bandeja",
+      "act": "git-scm.com. O app desktop exige Git para abrir sessões locais no Windows; sair pela bandeja (não só o X)."
     },
     {
-     "nome": "/aft-auditoria-geral",
-     "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
-     "tech": "orquestra consultoras · herda o modelo da sessão"
+      "who": "Colar o prompt de instalação no </> Code",
+      "act": "O próprio Claude instala o Python (winget), o notebooklm-py (pipx, repo teng-lin, com `notebooklm skill install` para registrar a skill /notebooklm) e clona este repositório direto em ~/.claude/skills, pedindo permissão a cada comando."
     },
     {
-     "nome": "/aft-informalidade",
-     "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
-     "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+      "who": "/aft-setup",
+      "act": "Cria as pastas de trabalho, coleta nome/CIF/lotação (basta a cidade — o toolkit resolve o código de 9 dígitos da UORG via uorgs.csv), instala dependências, o perfil CLAUDE.md e a deny-list de segurança (settings-aft.json)."
     },
     {
-     "nome": "/aft-PGR-analise",
-     "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-PGRTR-analise",
-     "role": "Auditoria sistemática do PGRTR (NR-31, rural) na base fixa de 33 ementas com gradação validada no ementário, com confronto campo × documento, extração delegada e citação de páginas. Consulta complementar ao ementário (key nr-31) para o que a base não cobre.",
-     "tech": "handoff p/ gera-ai · model: opus"
-    },
-    {
-     "nome": "/aft-aet-auditoria",
-     "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
-     "tech": "handoff p/ gera-ai · model: opus 1M"
-    },
-    {
-     "nome": "/aft-auditoria-AR-NR12",
-     "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
-     "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
-    },
-    {
-     "nome": "/aft-det-630",
-     "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
-     "tech": "escreve em ## Notificações DET · model: sonnet"
-    },
-    {
-     "nome": "/aft-tn-nco",
-     "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
-     "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
-    },
-    {
-     "nome": "/aft-email",
-     "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
-     "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
-    },
-    {
-     "nome": "/aft-embargo-interdicao",
-     "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
-     "tech": "template.docx SRTE/GO · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-manutencao",
-     "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
-     "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
-    },
-    {
-     "nome": "/aft-embargo-interdicao-levantamento",
-     "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
-     "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
-    },
-    {
-     "nome": "/aft-analise-acidente",
-     "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
-     "tech": "gerar_relatorio_docx.py · model: opus 1M"
+      "who": "Codex: dois atalhos (opcional)",
+      "act": "Quem usa o Codex — no lugar do Claude ou junto com ele — não instala nada diferente: cria ~/.agents/skills -> ~/.claude/skills (as skills) e ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (o perfil do auditor). Atalho, nunca cópia: o /aft-atualizar reescreve o CLAUDE.md por dentro, então o link se mantém em dia sozinho. Windows: mklink /J para a pasta e mklink /H para o arquivo (nenhum dos dois pede administrador). O Passo 0 do /aft-setup cria; o /aft-doctor confere; o roteiro para o AFT está em COMO-INSTALAR.md."
     }
-   ]
-  },
-  {
-   "nome": "Consultoras especializadas por NR",
-   "cor": "warn",
-   "skills": [
+  ],
+  "camadas": [
     {
-     "nome": "/aft-NR01",
-     "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
-     "tech": ""
+      "nome": "Configuração e visão geral",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-ajuda",
+          "role": "Ajuda de uso do proprio toolkit para o AFT novo ou travado: responde duvida sobre painel, extensao Sync DET, DET, NotebookLM, pastas, memory.md, privacidade, scripts locais e catalogo de habilidades. Antes de responder, le o estado da maquina (pasta AFT, aft-config.md, quantas OS em OS ATIVAS) para responder no caso concreto, e fecha sempre oferecendo executar o proximo passo. Tem modo tour para quem acabou de instalar, conduzido um passo por vez ate a primeira OS cadastrada e o painel aberto. Toda resposta explica na primeira mencao os termos de toolkit e de informatica que usa (references/glossario.md, que proibe explicar termo de fiscalizacao ao AFT) e fecha com uma acao concreta MAIS duas ou tres trilhas tiradas dos conceitos em que a propria resposta se apoiou. Duas advertencias que ela nunca omite: habilidade que le documento entregue pela empresa passa o conteudo pelo modelo (o AFT decide antes se ha dado sensivel no pacote), e habilidade de varredura rapida e TRIAGEM, nao auditoria. Sabe tambem que a maquina pode ter habilidades fora do toolkit (pessoais, minha-*, ou de terceiros): le o SKILL.md delas em vez de inventar. Read-only por allowed-tools: nao cria OS, nao edita ficha, nao redige documento e nao registra dia no diario.",
+          "tech": "references/ (fluxo-completo, tour-primeira-vez, painel-det-extensao, notebooklm-e-ementas, problemas-comuns, glossario, o-que-sai-da-maquina) + ajuda_arquitetura.py, que LE o arquitetura.json instalado em vez de copiar o catalogo · model: sonnet"
+        },
+        {
+          "nome": "/aft-setup",
+          "role": "Configuração inicial: pastas de trabalho, dados do auditor (CIF/UORG) e persona opcional do assessor (tratamento + nome_assessor, so no chat), perfil CLAUDE.md global (bloco gerenciado com marcadores versionados — Passo 5b), deny-list de segurança, dependências, NotebookLM. Instala POR PADRÃO o servidor do painel interativo sempre ligado (Passo 7c, instalar_servidor_painel.py) e oferece (opt-in) a rotina diária do painel (7b) e os prazos de DET no Google Calendar (7d, /aft-agenda-det). Passo 0: descobre em qual assistente está — no Codex cria os dois atalhos (~/.agents/skills e ~/.codex/AGENTS.md) e pula agentes, deny-list, vigia de sessões e gancho do diário.",
+          "tech": "winget · pipx · uorgs.csv · model: sonnet"
+        },
+        {
+          "nome": "/aft-doctor",
+          "role": "Verificação pós-instalação: confere Python, Git, descoberta das skills, config, perfil, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills (frontmatter, campo model contra models-validos.json e teste ao vivo dos modelos pinados via claude -p) — e diz em linguagem simples o que falta. Não altera arquivos, com UMA exceção: cria a pasta de trabalho (via pasta_aft.py) se faltar — e, se detectar que ela está fora da Documentos real (instalação anterior à correção de 22/07/2026), oferece migrar com consentimento (--mover), sem sobrescrever nada. Reconhece também o assistente em uso: com o Codex na máquina confere os dois atalhos e, se não houver rastro de uso do Claude Code, rebaixa a informativo os três itens que só existem naquele app (agentes, deny-list e vigia de sessões).",
+          "tech": "aft_doctor.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-erro",
+          "role": "Ticket de correção quando algo do toolkit dá errado: monta um .md em <pasta AFT>/tickets/ com o que o AFT estava fazendo, a mensagem de erro, a versão instalada e o retrato da máquina (SO, Python, programas externos, bibliotecas, serviços do painel) — já pseudonimizado, sem nome de empresa, CNPJ/CPF nem conteúdo de documento de fiscalização. Serve para o que falha SEM quebrar (skill devolveu texto torto, painel em branco) e para completar o ticket que o erro_ticket.py gerou sozinho num traceback. Nada é enviado a lugar nenhum: o arquivo fica na máquina até o AFT encaminhá-lo.",
+          "tech": "erro_ticket.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-atualizar",
+          "role": "Atualiza as skills (git pull no repositório) e o comando notebooklm (notebooklm-py, se houver versão nova no PyPI). Antes do pull, o checar_diff.py varre o diff por sinais de adulteração. Em usuários existentes: oferece a rotina diária do painel uma vez (2b), GARANTE o servidor do painel sempre ligado — agora padrão, instala em quem não tem (2c) —, oferece o Google Calendar uma vez (2d) e re-sincroniza o perfil CLAUDE.md automaticamente pelo bloco marcado (2e, sync_perfil.py; instalação antiga sem marcador recebe uma oferta de adoção). Ao final roda o /aft-doctor para confirmar que nada quebrou.",
+          "tech": "git pull · pipx upgrade · checar_diff.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-notebooklm-login",
+          "role": "Conecta/reconecta o NotebookLM à conta Google com mínima intervenção (cookies do navegador ou um único login em janela do Edge/Chrome) — o Claude conduz tudo, sem terminal.",
+          "tech": "notebooklm auth · NOTEBOOKLM_REFRESH_CMD · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-auditoria",
+          "role": "Cadastra uma auditoria (nome livre — razão social, fantasia ou o que o AFT preferir; CNPJ/CPF opcional, município, RI opcional com aviso de que sem ele o sync do DET não importa notificações desta OS, DET com prazo) — o começo do fluxo. Idempotente.",
+          "tech": "cria memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-organiza-os",
+          "role": "Importa uma pasta bagunçada de fiscalização pré-toolkit jogada em OS ATIVAS: classifica os documentos pela 1ª página (notificação DET, relação de autos do Sistema Auditor, resposta do empregador, fotos), extrai empregador/CNPJ-CPF/prazos/autos lavrados, apresenta plano antes-e-depois e — só com aprovação — renomeia a pasta para o padrão, cria o memory.md completo e move os arquivos para as duas caixas do layout padrão: NOTIFICACOES/ (pacotes <NN> - <COD> <data de lavratura>/, com a resposta do empregador por dia de download via det_baixar.py --reorganizar; a data de lavratura é lida do PDF) e AUTOS/ (lotes de autos + Relacao de autos/) — os .md de trabalho (memory.md, autos-lavrados.md, análises) ficam sempre na raiz, nunca nas caixas. Detecta e migra layout antigo sozinho. Nunca apaga nada; não identificado fica onde está. FASE 6 (opcional, sempre perguntada; atende também o pedido direto 'sincroniza minhas pastas com o DET'): varredura via det_baixar.py --varredura — sync das fichas + download do pacote completo de toda notificação sem pacote local e com prazo já vencido, em todas as OS de uma vez; prazo ainda corrente (ou sem prazo na linha) = só o PDF da notificação, sem documentos e sem registrar visualização; notificação com alerta amarelo pendente NUNCA entra no lote (o alerta não se apaga sem o AFT ver): volta listada para baixa individual, uma /aft-det-baixar por código autorizado.",
+          "tech": "pdftotext/pdfplumber (1ª página) · checar_pii.py · gerar_painel.py p/ conferir · model: opus"
+        },
+        {
+          "nome": "/aft-painel",
+          "role": "Dashboard local em cards (estilo SisOS, sem servidor/nuvem): um card por OS colorido pela urgência do DET; clique abre o detalhe (modal central amplo) — DETs, relato da inspeção física completo (inspecao-fisica.md, só na versão local por conter PII), TODOS os autos lavrados em grade (nº do AI, ementa, constatação), autos substituídos, pendências e atividades. Detecta notificações DET não cadastradas; com --scan puxa os autos ao vivo do Sistema Auditor (Windows/Mac+Parallels), degradando para o último autos-lavrados.md. Rotina diária opcional (launchd/Task Scheduler) regenera o painel de manhã sem gastar IA. Publicação como Artifact segue opt-in. Bloco 'Próximos vencimentos' abaixo dos contadores: agenda consolidada de todas as OS (DETs abertos + pendências com 'prazo <data>' no texto), ordenada por vencimento, com selo de urgência e botão 'agendar no Google Calendar' por notificação — URL de template pré-preenchida, sem login e sem API (o AFT só clica em Salvar).",
+          "tech": "gerar_painel.py (parser tolerante aos 2 schemas de memory.md + autos-lavrados.md + scan_autos.py) · model: haiku · allowed-tools sem Write/Edit"
+        },
+        {
+          "nome": "/aft-agenda-det",
+          "role": "Espelha os prazos das notificações DET no Google Calendar do AFT, pelo conector oficial do Claude (login único do Google pela interface do Claude — nenhuma senha ou token passa pelo toolkit): um evento de DIA INTEIRO por notificação, título na convenção 'DET <código> <12 primeiros caracteres do empregador>'. Reconciliação idempotente pelo código (chave única): cria só o que falta (e só prazo de hoje em diante — evento no passado não notifica ninguém), atualiza a data quando o prazo é prorrogado e renomeia com ✓ quando a notificação é marcada como checada no memory.md. Nunca apaga eventos nem toca em eventos fora do padrão 'DET ...'. Consome o campo 'vencimentos' do JSON do gerar_painel.py — a lista já sai pronta e determinística do script; o modelo só executa a reconciliação. Direção única memory.md → calendário (nunca escreve nas fichas). Oferecida no /aft-setup (Passo 7d) e /aft-atualizar (Passo 2d), chave agenda_det no aft-config.md."
+        },
+        {
+          "nome": "/aft-det-baixar",
+          "role": "Baixa da API do DET, em segundos e sem navegador, os arquivos de uma notificação: o PDF, o Relatório de Atendimento e os itens entregues pelo empregador, tudo no pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da OS (NN = ordem de lavratura; renumerado sozinho), com o conteúdo de cada download na subpasta 'baixada em <data>/' — o AFT sabe o que a empresa apresentou em cada dia. Usa o servidor do painel (POST /api/det-baixar) com o token que o Sincronizar da extensão abastece por 25 min — o mesmo motor do botão '⬇ baixar arquivos' do cartão. Aceita código, CNPJ ou nome do empregador; idempotente; registra o download na ficha.",
+          "tech": "det_baixar.py --via-painel · servir_painel.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-det-baixar-notificacoes",
+          "role": "Baixa SÓ o documento (PDF) de cada notificação de uma empresa — sem os arquivos entregues pelo empregador, sem o Relatório de Atendimento e sem o canal. Serve para ler o que foi notificado ou montar o histórico da empresa sem puxar anexos de centenas de MB. Grava no MESMO pacote NOTIFICACOES/<NN> - <COD> <data de lavratura>/ da /aft-det-baixar (numera e corrige a data mesmo sem re-baixar), então o download completo depois se acumula sem duplicar. NÃO registra a visualização no DET: o alerta amarelo continua na tela, porque o AFT não olhou o que a empresa entregou.",
+          "tech": "det_baixar.py --so-notificacao (baixar_so_notificacao) · GET /notificacoes/{uid}/pdf?numeroDeLinhas=0 · model: sonnet"
+        },
+        {
+          "nome": "/aft-nova-skill",
+          "role": "Ajuda o AFT (leigo) a criar uma skill PRÓPRIA para uma tarefa que o toolkit oficial não cobre: coleta objetivo, gatilhos e passos em linguagem simples e grava ~/.claude/skills/minha-<nome>/SKILL.md com frontmatter válido. Só cria/edita skills próprias (prefixo minha-), nunca as oficiais.",
+          "tech": "prefixo reservado minha- (1o nível, git-ignorado) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR12",
-     "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Preparação da ação fiscal (antes da visita)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-preparacao-acao-fiscal",
+          "role": "Planeja a fiscalização ANTES de ir a campo: resolve/cria a OS (via /aft-nova-auditoria), coleta denúncia e dados prévios (texto colado, PDF anexado ou salvo na pasta), tokeniza qualquer lista nominal de trabalhadores antes de processá-la, classifica as ementas da OS pela gradação (FASE 1.16, scripts/metas_regularizacao.py + base local do ementário SST) destacando as I3/I4 que contam para a meta de regularização e as de fácil regularização pelo empregador (dúvida técnica é da /aft-consulta, não desta) e monta o checklist de documentos a solicitar para aprovação do AFT — encadeia /aft-NAD ao final. Consulta os outros CNPJs do endereço (FASE 4.6, via /aft-cnpjs-endereco). Salva preparacao.md na pasta da OS.",
+          "tech": "chama /aft-nova-auditoria · .depara_[CNPJ].json na raiz da OS · model: opus"
+        },
+        {
+          "nome": "/aft-cnpjs-endereco",
+          "role": "Descobre os outros CNPJs registrados no endereço da fiscalização (cenário da terceirização ampla: várias pessoas jurídicas no mesmo lote) e cruza os cadastros públicos em busca de indícios de grupo econômico: mesmo lote com endereço normalizado (QUADRA027 = QD 27), CNAE de apoio administrativo em série, telefone/e-mail/sócios compartilhados entre raízes de CNPJ distintas, aberturas escalonadas. Descoberta por CEP na Casa dos Dados via navegador embutido (só o CEP é enviado); aceita também consulta de sistema interno colada (--parse). CEP não é lote: em CEP de distrito industrial ou via longa a descoberta é inconclusiva (centenas de CNPJs, 20 por página) e o caminho é o cruzamento cadastral com os CNPJs já conhecidos. Tudo indício, a confirmar em campo. Chamada pela /aft-preparacao-acao-fiscal (FASE 4.6).",
+          "tech": "cnpjs_endereco.py (urllib puro; APIs abertas minhareceita.org/BrasilAPI, só o CNPJ é enviado) · navegador embutido com extração via JavaScript (nunca página crua) · CEP digitado por teclado real (form_input não sensibiliza o formulário Vue e a busca sai sem filtro) + conferência de sanidade da contagem antes de usar qualquer linha · grava ## CNPJs no mesmo endereço no memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-NAD",
+          "role": "Notificação para Apresentação de Documentos — documentos que se presume existir (verbo central: Apresentar). Introdução fixa (art. 630 §§3º/4º CLT c/c art. 23 Lei 8.036/90 c/c art. 18, IV/V, Dec. 4.552/02) + um item por documento (NR ou artigo de lei) + ementa via NotebookLM só quando existir, bloco a bloco para colar no DET. Origem natural: /aft-preparacao-acao-fiscal; também standalone.",
+          "tech": "espelha /aft-tn-nco · model: sonnet"
+        },
+        {
+          "nome": "/aft-lre-esocial",
+          "role": "Transforma o LRE do eSocial baixado no SISFGTS em painel navegavel dentro da pasta da OS: busca por nome/CPF/matricula/cargo, filtros (ativos, desligados, indicio, PCD), CSV dos vinculos e resumo desidentificado que aparece em Relatorios da OS no /aft-painel. Aponta indicio de registro tardio com tres salvaguardas: recorte a partir de 02/01/2026 (quando o registro eletronico passou a ser obrigatorio para todas as empresas), campo dhrecepcao em vez de processamento_datahora, e so admissao nova (cedido/transferido/sucessao carregam a data de admissao original e nao sao atraso). Indicio, nunca constatacao. Read-only sobre o SISFGTS. Com o download 'LRE e demais registros' do SISFGTS, oferece duas analises derivadas: auditoria de FERIAS (periodos aquisitivos reconstituidos da admissao; aponta ferias vencidas - dobra do art. 137 -, gozo fora do prazo - Sumula 81 do TST -, prazo vencendo, conferir abono e fracionamento; so audita periodos iniciados na janela de dados da empresa e, em sucessao/cessao, do vinculo) e auditoria da FOLHA declarada (grade mensal da base de FGTS por vinculo; aponta buraco sem afastamento que justifique, ano sem 13o, ultimos 3 meses abaixo do contratual e dispensado sem base rescisoria; base declarada nao e recolhimento - debito e com o SISFGTS). Nos derivados (ferias e folha) o CPF sai mascarado (***.***.NNN-NN) e o painel de ferias abre com a secao Leitura da auditoria: os indicios caso a caso em frases prontas, com aviso de 'em gozo neste momento' quando ha ferias em aberto.",
+          "tech": "lre_esocial.py + lre_ferias.py + lre_folha.py + cbo.json · cartao eSocial no /aft-painel (rotas /lre, /ferias e /folha no modo interativo) · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-NR18",
-     "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
-     "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+      "nome": "Inspeção e lavratura",
+      "cor": "accent",
+      "skills": [
+        {
+          "nome": "/aft-inspecao-fisica",
+          "role": "Transforma a narrativa ditada da visita num relato de campo estruturado (inspecao-fisica.md) — fiel, sem enquadramento.",
+          "tech": "relato → memory.md · model: sonnet"
+        },
+        {
+          "nome": "/aft-consulta",
+          "role": "Consulta os ementários do NotebookLM com missão tripla: identifica a ementa, fundamenta capitulação/gradação/notas e redige a minuta do campo Histórico anti-nulidade. Só consulta — não lavra.",
+          "tech": "notebooklm ask · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-auditoria-geral",
+          "role": "Enquadra e redige os autos (NRs + CLT) a partir de DUAS fontes — o relato de campo (inspecao-fisica.md) e a Auditoria de documentos do memory.md (constatações da análise documental). Identifica NR/ementa via /aft-consulta, com gate de dupla visita.",
+          "tech": "orquestra consultoras · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-informalidade",
+          "role": "Autos de falta de registro (art. 41 CLT) + falta de anotação na CTPS (art. 29 CLT) + exame admissional (NR-07).",
+          "tech": "data de admissão dd/mm/aaaa · model: sonnet"
+        },
+        {
+          "nome": "/aft-PGR-analise",
+          "role": "Auditoria sistemática do PGR (NR-01) nas 7 ementas, com confronto campo × documento e citação de páginas.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-PGRTR-analise",
+          "role": "Auditoria sistemática do PGRTR (NR-31, rural) na base fixa de 33 ementas com gradação validada no ementário, com confronto campo × documento, extração delegada e citação de páginas. Consulta complementar ao ementário (key nr-31) para o que a base não cobre.",
+          "tech": "handoff p/ gera-ai · model: opus"
+        },
+        {
+          "nome": "/aft-aet-auditoria",
+          "role": "Auditoria da Análise Ergonômica do Trabalho (AET) sob a NR-17 nas 5 ementas (17.3.3, 17.3.8, 17.4.1, 17.4.2, 17.4.3), com citação de página/folha e a AET anexada a cada auto.",
+          "tech": "handoff p/ gera-ai · model: opus 1M"
+        },
+        {
+          "nome": "/aft-auditoria-AR-NR12",
+          "role": "Julga o laudo de adequação à NR-12 / apreciação de riscos (ABNT NBR ISO 12100) apresentado pela empresa, em pedido de suspensão de interdição ou resposta a notificação. Checklist de 6 blocos (método de estimativa; HRN como priorização, não substituto; categoria de segurança S/F/P → B-1-2-3-4, sempre na saída; requisitos NR-12 dependentes da apreciação — redundância 12.4.14, IHM, rearme, monitoramento 12.5.2-e; PLH/ART/TRT com recusa ancorada em atividade × atribuição; interface de segurança relé/CLP) e entrega resumo + análise didática + parecer (APTO / APTO COM RESSALVAS / INSUFICIENTE). Saída numerada auditoria-X-AR-NR12.md por OS.",
+          "tech": "notebooklm NR-12 (opcional, fallback) · handoff p/ /aft-tn-nco e /aft-embargo-interdicao-manutencao · model: opus 1M"
+        },
+        {
+          "nome": "/aft-det-630",
+          "role": "Auto por omissão de documentos notificados via DET (ementa 001168-1, art. 630 §4º CLT).",
+          "tech": "escreve em ## Notificações DET · model: sonnet"
+        },
+        {
+          "nome": "/aft-tn-nco",
+          "role": "Redige a Notificação para Correção de Irregularidades — SÓ para o que NÃO tem auto de infração lavrado (o auto já coage sozinho; a FASE 0.5 consulta o Sistema Auditor para EXCLUIR o já autuado, caso típico: dupla visita) — e GRAVA OS PARÂMETROS DELA no front-matter do .md (prazo, tipo do item, retorno, pré-assinalado, tipos de arquivo, exceções item a item) — antes o texto saía perfeito e mudo, e prazo/retorno morriam com a conversa. Padrão: obrigação · digital · 16 dias · pré-assinalado. Todo item com retorno digital/impresso leva FECHO DE COMPROVAÇÃO (máquina da NR-12: laudo com ART e registro fotográfico; demais 'adequar': documento com registro fotográfico). Continua entregando bloco a bloco para colar no DET; com o painel no ar, o rascunho pode ser montado pela API (det_criar.py), sempre revisado pelo aft-revisor-notificacao antes e lavrado só pelo AFT, no site. Gera também um .docx da notificação em NOTIFICACOES/ (leitura e arquivo; ao DET vai o texto puro).",
+          "tech": "front-matter det: · det_criar.py · agents/aft-revisor-notificacao · limite 1000 char/campo · model: sonnet"
+        },
+        {
+          "nome": "/aft-email",
+          "role": "E-mail formal que acompanha o ato da fiscalização (notificação lavrada no DET, Termo de Interdição/Embargo, adequação de documento analisado): resume o ato, prazos explícitos, consequência do descumprimento e canal oficial (blocos fixos DET e SEI, dupla visita só quando o AFT disser). Sempre duas versões (direta p/ empresário, técnica p/ jurídico) + feedback do texto; com o OK do AFT grava no email.md da OS, que o /aft-painel mostra com botão de copiar. Não envia nada e nunca cita empresa, CNPJ ou trabalhador.",
+          "tech": "email.md acumulativo · cartão de e-mails no painel (só versão local) · model: haiku"
+        },
+        {
+          "nome": "/aft-embargo-interdicao",
+          "role": "Relatório Técnico de Interdição/Embargo em .docx + autos derivados das ementas (risco grave e iminente, NR-03).",
+          "tech": "template.docx SRTE/GO · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-manutencao",
+          "role": "Relatório Técnico de Manutenção de Interdição/Embargo em .docx: analisa o requerimento de suspensão do empregador (documentos solicitados × apresentados, cumprimento das medidas de proteção, resultado da inspeção física se houve) e conclui pela manutenção da medida quando o único ou todos os objetos são mantidos. NUNCA deduz os argumentos do auditor — pergunta. Estrutura: 1) OBJETIVO, 2) DA ANÁLISE DOS DOCUMENTOS SOLICITADOS E APRESENTADOS E DO CUMPRIMENTO DAS MEDIDAS, 3) CONCLUSÃO (texto padrão de manutenção + observação SEI), 4) REQUISITOS PARA NOVO REQUERIMENTO (opcional). Reaproveita o parecer da /aft-auditoria-AR-NR12 como núcleo da seção 2.",
+          "tech": "montar_rt_manutencao.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao; stdlib, roda no Git Bash) · model: opus 1M"
+        },
+        {
+          "nome": "/aft-embargo-interdicao-levantamento",
+          "role": "Relatório Técnico de LEVANTAMENTO TOTAL de interdição/embargo em .docx — o oposto da manutenção: analisa o requerimento de suspensão no SEI, conclui que as exigências foram cumpridas e que o risco grave e iminente foi afastado, e levanta a medida por inteiro. Encadeia depois da /aft-auditoria-AR-NR12 com parecer favorável. Quem decide levantar é sempre o AFT.",
+          "tech": "montar_rt_levantamento.py (reusa o cabeçalho do template.docx do /aft-embargo-interdicao, localizado por texto e não por posição fixa; stdlib) · model: sonnet"
+        },
+        {
+          "nome": "/aft-analise-acidente",
+          "role": "Analisa acidente/doença do trabalho (IN GMTP/MTP nº 2/2022): varre CAT, RAI/BO, laudos e PGR, propõe fatores causais (códigos SFIT 251–260) e gera o Relatório de Análise em .docx; ao final, oferece encadear /aft-auditoria-geral + /aft-gera-ai.",
+          "tech": "gerar_relatorio_docx.py · model: opus 1M"
+        }
+      ]
     },
     {
-     "nome": "/aft-cnae-grau-risco-nr04",
-     "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
-     "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+      "nome": "Consultoras especializadas por NR",
+      "cor": "warn",
+      "skills": [
+        {
+          "nome": "/aft-NR01",
+          "role": "Consultora de disposicoes gerais e gerenciamento de riscos ocupacionais (NR-01): identifica a ementa e entrega o bloco II - IRREGULARIDADE do auto. Tres camadas locais antes de qualquer consulta externa (catalogo curado de 9 ementas, ementario completo da NR-01 com ~79 ementas e o texto integral da norma), com o NotebookLM (chave nr-01) so como ultimo recurso. Nao produz linha de RT nem fragmento de interdicao: a NR-01, isolada, nunca fundamenta risco grave e iminente. Delega o conteudo de PGR apresentado a /aft-PGR-analise, ficando com o PGR inexistente (101058-1) e o sem data/assinatura (101111-1).",
+          "tech": ""
+        },
+        {
+          "nome": "/aft-NR12",
+          "role": "Máquinas e equipamentos: identifica a ementa (catálogo de 16 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE, a linha do RT e o fragmento de interdição.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-NR18",
+          "role": "Indústria da construção: separa as ementas de obra (catálogo de 29 + NotebookLM) e entrega o bloco 2) IRREGULARIDADE e a linha do RT.",
+          "tech": "references/ementas-comuns.md · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cnae-grau-risco-nr04",
+          "role": "Enquadra a atividade no grau de risco (1 a 4) do Anexo I da NR-04, por código CNAE (qualquer formato, reduzindo subclasse a classe) ou por descrição, de forma determinística. Lembra a regra do maior GR (item 4.5.1) e encadeia para o dimensionamento do SESMT.",
+          "tech": "scripts/enquadrar_cnae.py · base cnae_gr.json (673 códigos do Anexo I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-dimensionamento-sesmt-nr04",
+          "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
+          "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-cipa-nr05-dimensionamento",
+          "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
+          "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-nr24-dimensionamento",
+          "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
+          "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-dimensionamento-sesmt-nr04",
-     "role": "Calcula a composição mínima do SESMT (Anexo II da NR-04) a partir do grau de risco e do nº de trabalhadores — quantidade e regime por profissional, regra de N > 5.000 e Observações A/B (saúde), com memória de cálculo. Também confere subdimensionamento em fiscalização.",
-     "tech": "scripts/dimensionar_sesmt.py (Anexo II) · herda o modelo da sessão"
+      "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
+      "cor": "accent2",
+      "skills": [
+        {
+          "nome": "/aft-jornada-analise",
+          "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
+          "tech": "roteador · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-valida-afd-aej",
+          "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
+          "tech": "validar.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-jornada-atestado",
+          "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
+          "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+        },
+        {
+          "nome": "/aft-jornada-auto-afd-aej",
+          "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
+          "tech": "handoff p/ gera-ai · model: sonnet"
+        }
+      ]
     },
     {
-     "nome": "/aft-cipa-nr05-dimensionamento",
-     "role": "Dimensiona a CIPA (Quadro I da NR-05) a partir do grau de risco e do nº de empregados. Devolve os dois níveis — quantitativo por bancada (efetivos/suplentes de cada representação) e total paritário (dobro: eleitos + designados) —, com a regra de grupos de 2.500 acima de 10.000, e orienta qual número comparar com cada documento na verificação fiscal.",
-     "tech": "scripts/dimensionar_cipa.py (Quadro I) · herda o modelo da sessão"
-    },
-    {
-     "nome": "/aft-nr24-dimensionamento",
-     "role": "Dimensiona as instalações da NR-24 (bacias sanitárias, mictórios, lavatórios, chuveiros, área de vestiário e armários, bebedouros, local de refeições, alojamento) a partir do número de homens e mulheres — ou direto da Relação de Vínculos Ativos do SFIT. Cobre também as áreas de vivência de canteiro de obras e frente de trabalho pela NR-18 (item 18.5), que prevalece na construção. O cálculo nunca é feito de cabeça: sai do script determinístico.",
-     "tech": "dimensionar_nr24.py + references/nr24_parametros.md · model: sonnet"
+      "nome": "Empacotamento, rastreamento e relatórios",
+      "cor": "ok",
+      "skills": [
+        {
+          "nome": "/aft-revisa-auto",
+          "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
+          "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+        },
+        {
+          "nome": "/aft-gera-ai",
+          "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
+          "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-lavrados",
+          "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
+          "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+        },
+        {
+          "nome": "/aft-autos-pdf-reunidos",
+          "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
+          "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio",
+          "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
+          "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-relatorio-acidentes",
+          "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
+          "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
+        },
+        {
+          "nome": "/aft-cat-trabalhador",
+          "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
+          "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
+        },
+        {
+          "nome": "/aft-modelo-docx",
+          "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
+          "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
+        },
+        {
+          "nome": "/aft-sessoes-os",
+          "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
+          "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+        }
+      ]
     }
-   ]
-  },
-  {
-   "nome": "Jornada / ponto eletrônico (Portaria 671/2021)",
-   "cor": "accent2",
-   "skills": [
+  ],
+  "scripts": [
     {
-     "nome": "/aft-jornada-analise",
-     "role": "Orquestrador: tria o pacote entregue (AFD/AEJ/atestados) e consolida os pareceres.",
-     "tech": "roteador · model: sonnet"
+      "nome": "rehydrate.py",
+      "caminho": "_scripts/rehydrate.py",
+      "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-valida-afd-aej",
-     "role": "Validador determinístico do AEJ: estrutura, trailer, integridade referencial, decimais e jornada flexível calibrados pelo sistema oficial.",
-     "tech": "validar.py · model: sonnet"
+      "nome": "bloco3_inject.py",
+      "caminho": "_scripts/bloco3_inject.py",
+      "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-atestado",
-     "role": "Auditoria do Atestado Técnico/Termo de Responsabilidade do REP/PTRP (art. 89), com inspeção de assinatura por código.",
-     "tech": "inspecionar_assinatura.py · herda o modelo da sessão"
+      "nome": "validar_txt.py",
+      "caminho": "_scripts/validar_txt.py",
+      "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
+      "runtime": "Python stdlib"
     },
     {
-     "nome": "/aft-jornada-auto-afd-aej",
-     "role": "Autos por AFD/AEJ ausente ou fora do padrão (ementas 002279-9 / 002280-2).",
-     "tech": "handoff p/ gera-ai · model: sonnet"
+      "nome": "checar_pii.py",
+      "caminho": "_scripts/checar_pii.py",
+      "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_diff.py",
+      "caminho": "_scripts/checar_diff.py",
+      "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivo_aberto.py",
+      "caminho": "_scripts/checar_arquivo_aberto.py",
+      "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "backup_arquivo.py",
+      "caminho": "_scripts/backup_arquivo.py",
+      "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_rt_autos.py",
+      "caminho": "_scripts/checar_rt_autos.py",
+      "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
+      "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
+    },
+    {
+      "nome": "gerar_painel.py",
+      "caminho": "_scripts/gerar_painel.py",
+      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+      "runtime": "Python stdlib (+pdfplumber opcional)"
+    },
+    {
+      "nome": "servir_painel.py",
+      "caminho": "_scripts/servir_painel.py",
+      "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e desde 24/08/2026 o /api/det-sync também aceita corpo SEM token (usa o da RAM; 409 se não houver) — é como a varredura da /aft-organiza-os dispara o sync das fichas, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_sync.py",
+      "caminho": "_scripts/det_sync.py",
+      "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto. Desde 24/08/2026 também resume o status de cada item na sub-linha com o marcador 📋 (resumo_itens): UMA requisição GET /itens-notificacao?uidNotificacao= — cada item já traz o campo status, o mesmo número da coluna Status da tela do DET (verificado na API), traduzido pelo enum STATUS_ITEM reaproveitado do det_baixar; não é preciso varrer /eventos-item. Sai '📋 itens: 5 aguardando avaliação de prazo' (ou a contagem por estado); o gerar_painel lê o marcador (RE_DET_ITENS) e mostra no dossiê, e conta os 'aguardando avaliação' num selo do card da grade ('📋 5 itens aguardam sua decisão'). O GATE é a notificação estar EM ABERTO na ficha (codigos_abertos, checkbox '- [ ]'), NÃO o triângulo itemAtualizado: corrigido em 25/08/2026 (caso BUENO 28) porque o triângulo é alerta de NOVIDADE — some quando o AFT o dispensa no painel ou abre a notificação no DET — e levava junto o ESTADO dos itens, que continua verdadeiro depois de visto. Custo medido: 12 requisições extras por sync nas 11 OS ativas. Best-effort.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_baixar.py",
+      "caminho": "_scripts/det_baixar.py",
+      "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<NN> - <COD> <dd-mm-aaaa>/ (convenção do AFT, 24/08/2026 — NN é a ordem de LAVRATURA, renumerada sozinha via renumerar_pacotes() quando uma antiga chega depois, e a data é a de LAVRATURA, o dataEnvio da pesquisa): o PDF da notificação e canal-comunicacao/ na raiz do pacote, e o resto na subpasta do dia 'baixada em <data>/' — relatório de atendimento (fotografia daquele dia), historico-itens.md e item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote, cada dia na sua subpasta; legados migram sozinhos (pacote notificacao-<COD> ou <COD> <data> é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro; migrar_pacote_para_dias() desce o conteúdo da raiz do pacote para o dia da data de modificação de cada arquivo; tudo conta em movidos; modo --reorganizar faz o mesmo sem rede, para a /aft-organiza-os). Modo --varredura (FASE 6 da /aft-organiza-os): POST /api/det-sync sem corpo (token da RAM) para atualizar as fichas e, por OS, download completo dos códigos sem pacote local, sem alerta pendente E com prazo vencido — pendente ('atualização pendente' na sub-linha) nunca entra no lote (regra do AFT de 24/08/2026: o triângulo só se apaga em baixa individual) e volta no campo pendentes; prazo corrente ou desconhecido (datas da linha checkbox, parseadas em codigos_da_ficha) recebe no máximo o PDF via modo só-notificação e volta no campo no_prazo; cancelada pula, em dia fica quieta; token vencido devolve token_expirado com o parcial, e rodar de novo é seguro; conexão recusada (painel caído) ganha nova tentativa após 15 s — o vigia o reergue sozinho. Idempotente por existência do arquivo em qualquer subpasta de dia (_ja_baixado); nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "det_criar.py",
+      "caminho": "_scripts/det_criar.py",
+      "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_rotina_painel.py",
+      "caminho": "_scripts/instalar_rotina_painel.py",
+      "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_servidor_painel.py",
+      "caminho": "_scripts/instalar_servidor_painel.py",
+      "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "aft_doctor.py",
+      "caminho": "_scripts/aft_doctor.py",
+      "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "fotos_para_pdf.py",
+      "caminho": "_scripts/fotos_para_pdf.py",
+      "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
+      "runtime": "Python · pillow"
+    },
+    {
+      "nome": "comprimir_pdf.py",
+      "caminho": "_scripts/comprimir_pdf.py",
+      "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
+      "runtime": "Python · pikepdf/pypdf"
+    },
+    {
+      "nome": "docx_pack.py / docx_unpack.py",
+      "caminho": "_scripts/docx_*.py",
+      "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "nome": "scan_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
+      "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
+      "runtime": "Python · pypdf"
+    },
+    {
+      "nome": "gera_relacao_autos.py",
+      "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
+      "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
+      "runtime": "Python (python-docx)"
+    },
+    {
+      "nome": "inspecionar_assinatura.py",
+      "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
+      "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
+      "runtime": "Python"
+    },
+    {
+      "nome": "validar.py",
+      "caminho": "aft-jornada-valida-afd-aej/validar.py",
+      "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "gerar_relatorio_docx.py",
+      "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
+      "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
+      "runtime": "Python stdlib · zipfile"
+    },
+    {
+      "runtime": "Python stdlib",
+      "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
+      "nome": "pasta_aft.py",
+      "caminho": "_scripts/pasta_aft.py"
+    },
+    {
+      "nome": "instalar_agentes.py",
+      "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
+    },
+    {
+      "nome": "erro_ticket.py",
+      "caminho": "_scripts/erro_ticket.py",
+      "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sync_perfil.py",
+      "caminho": "_scripts/sync_perfil.py",
+      "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "sessoes_os.py",
+      "caminho": "_scripts/sessoes_os.py",
+      "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "instalar_vigia_sessoes.py",
+      "caminho": "_scripts/instalar_vigia_sessoes.py",
+      "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
+      "runtime": "Python stdlib (+ PowerShell no Windows)"
+    },
+    {
+      "nome": "checar_acentos.py",
+      "caminho": "_scripts/checar_acentos.py",
+      "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "checar_arquivos_internos.py",
+      "caminho": "_scripts/checar_arquivos_internos.py",
+      "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "indenta_quebras.py",
+      "caminho": "_scripts/indenta_quebras.py",
+      "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "ajuda_arquitetura.py",
+      "caminho": "_scripts/ajuda_arquitetura.py",
+      "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebook_id.py",
+      "caminho": "_scripts/notebook_id.py",
+      "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
+      "runtime": "python (stdlib) + CLI notebooklm na sondagem"
+    },
+    {
+      "nome": "sincronizar_notebooks.py",
+      "caminho": "_scripts/sincronizar_notebooks.py",
+      "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
+      "runtime": "python (stdlib)"
+    },
+    {
+      "nome": "notebooklm_consulta.py",
+      "caminho": "_scripts/notebooklm_consulta.py",
+      "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
+      "runtime": "python (stdlib) + CLI notebooklm"
+    },
+    {
+      "nome": "lre_esocial.py",
+      "caminho": "_scripts/lre_esocial.py",
+      "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_ferias.py",
+      "caminho": "_scripts/lre_ferias.py",
+      "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "lre_folha.py",
+      "caminho": "_scripts/lre_folha.py",
+      "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "cbo.json",
+      "caminho": "_scripts/cbo.json",
+      "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
+      "runtime": "dado (JSON)"
+    },
+    {
+      "nome": "consulta_cnpj.py",
+      "caminho": "_scripts/consulta_cnpj.py",
+      "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "tokenizar.py",
+      "caminho": "_scripts/tokenizar.py",
+      "papel": "Sentido de IDA da pseudonimização: monta o de-para .depara_<CNPJ>.json, troca nome real por [[TRAB_NN]]/[[AUTUADA]] no arquivo e confere se sobrou nome real, token órfão ou CPF. Recusa CPF de trabalhador no mapa e nunca renumera token já usado. Complementa o rehydrate.py, que faz a volta.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "conferir_rastreamento.py",
+      "caminho": "_scripts/conferir_rastreamento.py",
+      "papel": "Acha CONTRADIÇÃO entre os registros de auto do memory.md (checkbox [x] com texto dizendo pendente, [x] sem número de AI, [ ] com número, afirmação de auto lavrado em `## Ementas da OS` sem respaldo). Só aponta divergência: não prova qual registro está certo, e nunca escreve no memory.md.",
+      "runtime": "Python stdlib"
+    },
+    {
+      "nome": "conferir_cotejo.py",
+      "caminho": "_scripts/conferir_cotejo.py",
+      "papel": "Cotejo de encerramento: lista documento e foto que entraram na OS e nunca foram mencionados em nenhuma análise. Antes de encerrar, ou o documento é confrontado, ou o motivo de não o ser é declarado ao AFT.",
+      "runtime": "Python stdlib"
     }
-   ]
-  },
-  {
-   "nome": "Empacotamento, rastreamento e relatórios",
-   "cor": "ok",
-   "skills": [
+  ],
+  "dados": [
     {
-     "nome": "/aft-revisa-auto",
-     "role": "Gate de qualidade antes do empacotamento: checklist 5W1H em cada auto e parágrafo de dano coletivo obrigatório em SST (Portaria MTP 667/2021). Roda dentro do /aft-gera-ai, mas pode ser chamada isolada. Desde 28/07/2026 despacha a revisão para o agente isolado aft-revisor-autos (olhos frescos: o revisor não vê a conversa que redigiu os autos); sem o agente instalado, executa inline como antes.",
-     "tech": "gate dentro do /aft-gera-ai · model: sonnet"
+      "arquivo": "config/notebooks.json",
+      "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
+      "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
     },
     {
-     "nome": "/aft-gera-ai",
-     "role": "Empacota os autos redigidos no TXT importável pelo Sistema Auditor (latin-1), com anexos em PDF e pseudonimização reversível, dentro de AUTOS/Autos DD-MM/ (layout padrão) ou na raiz em OS ainda não migradas. Ponto único de empacotamento — é aqui que o CNPJ/CPF da fiscalizada se torna obrigatório: se a OS ainda não tinha, o gera-ai pergunta, grava no memory.md e renomeia a pasta prefixando o CNPJ na frente do nome original.",
-     "tech": "rehydrate.py · bloco3_inject.py · validar_txt.py · model: sonnet"
+      "arquivo": "config/uorgs.csv",
+      "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
+      "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
     },
     {
-     "nome": "/aft-autos-lavrados",
-     "role": "Lê os PDFs já transmitidos (C:\\SistemasAFT\\...\\PRO) e cruza com os rascunhos em AUTOS/Autos DD-MM/ (ou na raiz, em OS não migradas), marcando no memory.md [x]/[ ] — read-only sobre o Sistema Auditor; allowed-tools sem rede (os PDFs trazem dados pessoais). Acha a pasta pelos 8 primeiros dígitos do CNPJ/CPF (sufixo padrão do Sistema Auditor); se a OS não tiver identificador, pergunta os 8 dígitos ao AFT. No relatório, cada auto é identificado pelo número do AI (derivado do nome do PDF AI_<9díg>, ex.: 23.284.209-4), único por auto. A \"Relação de autos lavrados\" (.docx, sem PDF) é gravada em AUTOS/Relacao de autos/ quando a caixa AUTOS/ existe, senão no lugar antigo (raiz). Desde 28/07/2026 a varredura pesada (Passos 2-6) roda no agente isolado aft-autos-lavrados (em segundo plano no modo lote); decisões do AFT voltam na seção 'Decisões pendentes' e são conduzidas na conversa principal; sem o agente, executa inline como antes.",
-     "tech": "scan_autos.py (autodetecta pasta PRO no Windows e no Mac+Parallels via /Volumes/*) · pypdf/pdftotext · model: sonnet"
+      "arquivo": "config/CLAUDE-aft.md",
+      "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
+      "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
     },
     {
-     "nome": "/aft-autos-pdf-reunidos",
-     "role": "Reúne os PDFs dos autos já transmitidos de uma empresa num único PDF, com os anexos de cada auto logo depois dele — o dossiê para juntar ao processo. Oferece modo Completo (anexos inteiros) ou Econômico (10 páginas por anexo). Read-only sobre o Sistema Auditor; o PDF final vai para a pasta da OS.",
-     "tech": "reune_autos_pdf.py (pypdf) · allowed-tools sem rede · model: sonnet"
+      "arquivo": "config/blocos_auto.md",
+      "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
+      "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
     },
     {
-     "nome": "/aft-relatorio",
-     "role": "Relatório Final Simplificado: notificações, autos por tema e interdições — texto p/ SFITWEB + .docx p/ chefia·MPT.",
-     "tech": "lê memory.md, autos-lavrados.md e interdicao-embargo/ · gera .docx · model: sonnet"
+      "arquivo": "config/settings-aft.json",
+      "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
+      "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
     },
     {
-     "nome": "/aft-relatorio-acidentes",
-     "role": "Levanta o histórico de CATs de um CNPJ (lesão, parte do corpo, CID, agente causador, óbitos) por dois caminhos: CSV do Portal AFT anexado, ou varredura da base estadual de CATs (uma planilha .xlsx por ano). No modo --doencas lista as CATs de doença ocupacional e caça as cadastradas como acidente típico cujo CID sugere doença mascarada. Levanta o histórico; a análise de mérito de um acidente é da /aft-analise-acidente.",
-     "tech": "relatorio_acidentes.py (openpyxl) · planilhas em <PASTA_AFT>/CATs (sincronizar_cats.py) · .docx pelo /aft-modelo-docx · model: sonnet"
-    },
-    {
-     "nome": "/aft-cat-trabalhador",
-     "role": "Dossiê individual de CATs de UM trabalhador, buscado por CPF ou nome, varrendo a mesma base estadual de CATs: PDF pronto no leiaute do formulário CAT do eSocial, com uma ficha completa por CAT em ordem cronológica. Busca por nome ambígua devolve a lista para o AFT escolher; no chat o CPF sai sempre mascarado.",
-     "tech": "cat_trabalhador.py (openpyxl + reportlab) · reusa a base e a configuração da /aft-relatorio-acidentes · model: sonnet"
-    },
-    {
-     "nome": "/aft-modelo-docx",
-     "role": "Padrão visual de todo .docx do toolkit: template com cabeçalho AFT·SIT, Times 12, azul institucional, tabelas zebradas.",
-     "tech": "biblioteca modelo_docx.py (python-docx) + template-cabecalho.docx · usada pelo /aft-relatorio e docs avulsos · model: sonnet"
-    },
-    {
-     "nome": "/aft-sessoes-os",
-     "role": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS' — automática: o vigia de sessões aplica sozinho quando o app fecha; vínculo sessao_claude no memory.md.",
-     "tech": "sessoes_os.py --vigia (serviço: LaunchAgent/Tarefa Agendada via instalar_vigia_sessoes.py) · escreve no armazenamento interno do app só com ele fechado · backup + --desfazer · model: sonnet"
+      "arquivo": "config/models-validos.json",
+      "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
+      "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
     }
-   ]
-  }
- ],
- "scripts": [
-  {
-   "nome": "rehydrate.py",
-   "caminho": "_scripts/rehydrate.py",
-   "papel": "Re-injeta nomes/CPFs reais no TXT tokenizado e grava direto em ISO-8859-1. Aborta em valor ausente, CPF inválido, token órfão ou caractere fora do latin-1. Nunca é o LLM que re-hidrata.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "bloco3_inject.py",
-   "caminho": "_scripts/bloco3_inject.py",
-   "papel": "Injeta o Subtítulo 3 (OBSERVAÇÕES) canônico — lido de config/blocos_auto.md — em todo auto, byte a byte idêntico. As skills de redação não escrevem mais esse bloco; só o /aft-gera-ai injeta.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "validar_txt.py",
-   "caminho": "_scripts/validar_txt.py",
-   "papel": "Valida o TXT do Sistema Auditor ANTES da importação: pega erros de encoding/formato que travariam o botão imp. txt, antes mesmo do AFT tentar.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_pii.py",
-   "caminho": "_scripts/checar_pii.py",
-   "papel": "Guard-rail de PII de alto dano: varre um relato/texto/pasta e avisa (não bloqueia) se houver CPF ou PIS/PASEP com dígito verificador válido escapando da anonimização.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_diff.py",
-   "caminho": "_scripts/checar_diff.py",
-   "papel": "Guard-rail de supply-chain: varre o diff de uma atualização (linhas que chegam) por Unicode invisível e padrões de exfiltração/execução remota, e avisa antes do git pull (chamado pelo /aft-atualizar). Só alarme — quem decide é o AFT.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivo_aberto.py",
-   "caminho": "_scripts/checar_arquivo_aberto.py",
-   "papel": "Detecta se um .docx (RT, autos) está aberto/bloqueado no Word antes de tentar sobrescrevê-lo no Windows — evita erro silencioso de gravação.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "backup_arquivo.py",
-   "caminho": "_scripts/backup_arquivo.py",
-   "papel": "Cópia de segurança automática antes de editar um arquivo legal já existente (.docx do RT, autos) — convenção do toolkit para nunca perder uma versão anterior.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_rt_autos.py",
-   "caminho": "_scripts/checar_rt_autos.py",
-   "papel": "Confere a coerência entre a Seção 4 do RT (.docx ou .pdf) e os autos (autos.md) — pega divergência quando um é editado e o outro não acompanha.",
-   "runtime": "Python stdlib + pdfplumber (só para RT em PDF)"
-  },
-  {
-   "nome": "gerar_painel.py",
-   "caminho": "_scripts/gerar_painel.py",
-   "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
-   "runtime": "Python stdlib (+pdfplumber opcional)"
-  },
-  {
-   "nome": "servir_painel.py",
-   "caminho": "_scripts/servir_painel.py",
-   "papel": "Modo INTERATIVO do painel: mini-servidor http.server em 127.0.0.1:8347 que serve o painel recém-gerado e aceita 10 ações mecânicas por clique (marcar/reabrir DET respondida, dispensar alerta de atualização pendente do DET, registrar/resolver pendência, registrar/editar constatação da auditoria de documentos, reescrever o relato de campo, registrar atividade, mudar status, alternar embargo/interdição vigente/suspenso), cada uma com backup prévio (backup_arquivo.py) e edição cirúrgica da linha exata do memory.md — a única exceção é o relato de campo, que grava o inspecao-fisica.md inteiro (ARQUIVO_DA_ACAO). Só escuta localhost; valida pasta contra path-traversal; ações de julgamento nunca passam por ele — o painel oferece botões que copiam o comando pronto para o Claude Code. Desde 21/08/2026 também guarda em RAM, por 25 min, o token que o Sincronizar da extensão entrega no /api/det-sync, e desde 24/08/2026 o /api/det-sync também aceita corpo SEM token (usa o da RAM; 409 se não houver) — é como a varredura da /aft-organiza-os dispara o sync das fichas, e expõe POST /api/det-baixar (botão '⬇ baixar arquivos' do cartão DET e skill /aft-det-baixar): chama o det_baixar.py para baixar os PDFs e os arquivos entregues direto na pasta da OS; sem token fresco responde 409 mandando sincronizar de novo. Token nunca em disco. v3.0 da extensão: novo POST /api/det-token (canal leve, só guarda o token na RAM) recebe o token empurrado a cada navegação do AFT no DET; o cache passou a valer pelo exp real do JWT (não 25 min fixos), então o /aft-det-baixar fica pronto sem o Sincronizar manual. Escrita no DET (21/08/2026, experimental): POST /api/det-criar (rascunho de notificação, prévia/criação, nunca lavra) e GET /api/det-molde?codigo= (leitura de uma notificação, usada na descoberta do molde) — ambos via det_criar.py, com o token do cache. Erro INESPERADO em qualquer rota (24/08/2026) passa por `_falha()`: grava o ticket de correção com o traceback já redigido e responde uma frase que começa por 'não consegui ...' com o que o AFT tentou fazer, mais o caminho do ticket — o `sys.excepthook` do erro_ticket nunca via esses erros, porque cada rota captura a própria exceção para responder JSON, e o painel era o único lugar do toolkit que quebrava sem ticket. Um ticket por (rota, erro) enquanto o servidor estiver no ar, para o botão que falha a cada clique não encher a pasta de tickets iguais.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_sync.py",
-   "caminho": "_scripts/det_sync.py",
-   "papel": "Sync local do DET (espelho do sync do SisOS): recebe o token de sessão do DET capturado pela extensão Chrome 'Sync DET' (v2.0; antes 'SisOS — Sync DET') via POST /api/det-sync do servir_painel.py, consulta a API oficial de pesquisa de notificações por CNPJ/CPF e filtra o resultado pelo RI da OS — a pesquisa por CNPJ devolve notificações de TODAS as fiscalizações já feitas naquele empregador, inclusive antigas já concluídas (bug real corrigido, ver decisão 'notificações de fiscalizações antigas'). RIs desta OS = SOMENTE o(s) declarado(s) no campo ri: do front-matter (aceita mais de um, separados por vírgula, para OS com duas fiscalizações simultâneas do mesmo empregador) — endurecido em 22/07/2026 removendo a união com RIs 'já registrados no memory.md', que deixava um RI contaminar a OS permanentemente (caso real CONSORCIO SQ). Sem ri: preenchido, adota o da notificação mais recente (ri_mais_recente) e grava. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe. Atualiza ## Notificações DET: notificação nova vira linha '- [ ] <COD> — prazo <data>'; um prazo alterado só atualiza a linha quando ela tem exatamente UM 'prazo'/'entrega até' escrito — linha com 2+ fica intocada. O alerta '⚠️ atualização pendente' (itemAtualizado da API, que pode continuar true mesmo após o triângulo sumir da tela do DET) é dispensável: a ação det_visto do painel grava <!-- visto: <última entrega> --> na sub-linha, e o alerta só reaparece se a empresa fizer entrega nova. Checkbox [ ]/[x] nunca muda; backup antes de cada escrita; token só em memória. Funções de edição puras e testáveis sem rede (consultar injetável); AFT_DET_DEBUG/AFT_DET_DRYRUN para inspecionar sem gravar. Com o envelope ✉️ aceso, busca a última mensagem do empregador no canal (uma requisição extra por notificação com pendência) e grava o trecho (90 chars) na sub-linha — o chip do painel exibe o texto. Desde 24/08/2026 também resume o status de cada item na sub-linha com o marcador 📋 (resumo_itens): UMA requisição GET /itens-notificacao?uidNotificacao= — cada item já traz o campo status, o mesmo número da coluna Status da tela do DET (verificado na API), traduzido pelo enum STATUS_ITEM reaproveitado do det_baixar; não é preciso varrer /eventos-item. Sai '📋 itens: 5 aguardando avaliação de prazo' (ou a contagem por estado); o gerar_painel lê o marcador (RE_DET_ITENS) e mostra no dossiê, e conta os 'aguardando avaliação' num selo do card da grade ('📋 5 itens aguardam sua decisão'). O GATE é a notificação estar EM ABERTO na ficha (codigos_abertos, checkbox '- [ ]'), NÃO o triângulo itemAtualizado: corrigido em 25/08/2026 (caso BUENO 28) porque o triângulo é alerta de NOVIDADE — some quando o AFT o dispensa no painel ou abre a notificação no DET — e levava junto o ESTADO dos itens, que continua verdadeiro depois de visto. Custo medido: 12 requisições extras por sync nas 11 OS ativas. Best-effort.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_baixar.py",
-   "caminho": "_scripts/det_baixar.py",
-   "papel": "Download dos arquivos de uma notificação DET pela API oficial (mesma via do det_sync.py, com o token que a extensão empresta): pesquisa pelo código (chave única, isSomenteMinhas=False), baixa o PDF da notificação (GET /notificacoes/{uid}/pdf?numeroDeLinhas=0), o Relatório de Atendimento (GET .../pdf-relatorio-atendimento) e os arquivos entregues item a item (GET /itens-notificacao + /arquivos-item + /arquivos-item/{uid}/blob) — endpoints lidos do bundle público do front do DET (chunk 251) em 21/08/2026. Dispensa o ZIP do site (URL volátil, sem estrutura): TUDO mora no pacote NOTIFICACOES/<NN> - <COD> <dd-mm-aaaa>/ (convenção do AFT, 24/08/2026 — NN é a ordem de LAVRATURA, renumerada sozinha via renumerar_pacotes() quando uma antiga chega depois, e a data é a de LAVRATURA, o dataEnvio da pesquisa): o PDF da notificação e canal-comunicacao/ na raiz do pacote, e o resto na subpasta do dia 'baixada em <data>/' — relatório de atendimento (fotografia daquele dia), historico-itens.md e item<N>_<descrição oficial>/, com rejeitados/dispensados (status 2/3 do enum do front) em invalidados/. Downloads repetidos (entrega parcelada, prorrogação) acumulam no mesmo pacote, cada dia na sua subpasta; legados migram sozinhos (pacote notificacao-<COD> ou <COD> <data> é renomeado ao padrão, preservando sufixo descritivo do AFT; PDF solto é movido para dentro; migrar_pacote_para_dias() desce o conteúdo da raiz do pacote para o dia da data de modificação de cada arquivo; tudo conta em movidos; modo --reorganizar faz o mesmo sem rede, para a /aft-organiza-os). Modo --varredura (FASE 6 da /aft-organiza-os): POST /api/det-sync sem corpo (token da RAM) para atualizar as fichas e, por OS, download completo dos códigos sem pacote local, sem alerta pendente E com prazo vencido — pendente ('atualização pendente' na sub-linha) nunca entra no lote (regra do AFT de 24/08/2026: o triângulo só se apaga em baixa individual) e volta no campo pendentes; prazo corrente ou desconhecido (datas da linha checkbox, parseadas em codigos_da_ficha) recebe no máximo o PDF via modo só-notificação e volta no campo no_prazo; cancelada pula, em dia fica quieta; token vencido devolve token_expirado com o parcial, e rodar de novo é seguro; conexão recusada (painel caído) ganha nova tentativa após 15 s — o vigia o reergue sozinho. Idempotente por existência do arquivo em qualquer subpasta de dia (_ja_baixado); nomes saneados para Windows; linha no Registro de atividades com backup prévio; token só em memória; 401/403 vira TokenExpirado para o servir_painel avisar o AFT. Substitui o fluxo antigo de dirigir o Chrome clique a clique (minutos -> segundos). Chamado pelo POST /api/det-baixar do servir_painel.py (botão '⬇ baixar arquivos' do cartão e skill /aft-det-baixar). Ao final do download registra a VISUALIZAÇÃO no DET (GET do detalhe da notificação + GET de cada item, as mesmas chamadas do site ao abrir a tela): é o que apaga o triângulo 'Existe atualização pendente' — confirmado em produção em 21/08/2026; best-effort, visto_no_det no resultado. Desde a 3ª rodada de 21/08/2026 também traz o histórico de eventos de cada item (prorrogações/justificativas → historico-itens.md), o canal de comunicação (canal-comunicacao/: mensagens.md + anexos + historico-canal.pdf; somente leitura) e refresca o Relatório de Atendimento a cada download.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "det_criar.py",
-   "caminho": "_scripts/det_criar.py",
-   "papel": "ESCRITA no DET (a primeira do toolkit): redige um RASCUNHO de notificação para um RI existente. Cria a casca (POST /notificacoes, status EM_ELABORACAO, auditor lido do próprio JWT) e preenche o rascunho (PUT /notificacoes/{uid}/rascunho) com os itens de uma TN-NCO (.md; tipo 1 Cumprimento de Obrigação, retorno 1 digital, prazo padrão), a introdução/observações de um modelo do AFT (POST /modelos-notificacao por idModelo -> GET detalhe) e o endereço do RI (GET /fiscalizacoes/detalhe/{ri}, prefere tipo 2 com uf). NUNCA lavra (PUT .../lavratura é ato do AFT no site). Cada item leva todos os campos do molde, os de data em null, senão a tela de EDIÇÃO do DET (form reativo) quebra em isDatasPadraoValidas/addControl (constatado no console via Claude in Chrome, 21/08/2026). Endpoint POST /api/det-criar: sem confirmar=true devolve a prévia; com confirmar=true cria. Ainda sem skill/botão — só o endpoint (experimental). Todo texto de introdução/observação entra por UMA normalização (_normalizar_observacoes): numera `ordem` numa sequência única (introdução antes das observações) e completa `uid` vazio e `textoInformativoPadrao` — os blocos do detalhe de um modelo vêm sem esses três campos, e adotá-los crus quebrava a prévia do painel (KeyError: 'ordem', 24/08/2026) e mandaria ao DET texto sem posição. O modelo completa o .md GRUPO A GRUPO (introdução do modelo se o arquivo não trouxe introdução; observações se não trouxe observações) — tudo-ou-nada fazia a introdução fixa da NAD descartar em silêncio todas as observações do modelo. `revisar_payload` barra texto fora da sequência 1..N, e `python det_criar.py --autoteste` confere isso sem rede.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_rotina_painel.py",
-   "caminho": "_scripts/instalar_rotina_painel.py",
-   "papel": "Instala/remove/aft-consulta a rotina DIÁRIA do painel (regenera o painel.html estático 1x/dia, --scan incluso) como agendamento do SO — launchd no macOS, Agendador de Tarefas no Windows. Diferente do instalar_servidor_painel.py: aqui o processo roda, termina e some; não mantém nada no ar entre execuções. Oferecido no /aft-setup (Passo 7b) e /aft-atualizar (Passo 2b, uma única vez).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_servidor_painel.py",
-   "caminho": "_scripts/instalar_servidor_painel.py",
-   "papel": "Instala/remove/aft-consulta o SERVIDOR interativo do painel (servir_painel.py) como serviço em segundo plano do sistema operacional — diferente do instalar_rotina_painel.py, que só regenera o painel.html estático 1x/dia, este mantém o servidor SEMPRE ATIVO. macOS: LaunchAgent com RunAtLoad+KeepAlive (reinicia sozinho se cair). Windows: Tarefa Agendada via PowerShell Register-ScheduledTask com gatilho 'ao fazer logon' e RestartCount/RestartInterval (schtasks.exe básico não expõe reinício automático), usando pythonw.exe para não abrir janela de console. Necessário para os controles do painel funcionarem sem terminal aberto e para o sync automático do DET pela extensão Chrome. Oferecido opcionalmente no /aft-setup (Passo 7c) e /aft-atualizar (Passo 2c, uma única vez).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "aft_doctor.py",
-   "caminho": "_scripts/aft_doctor.py",
-   "papel": "Verificação pós-instalação: checa Python, Git, descoberta das skills, config do repo, perfil, deny-list, pasta de trabalho, bibliotecas, NotebookLM e a saúde das skills — frontmatter (name = pasta), campo model contra config/models-validos.json e teste ao vivo dos modelos pinados (claude -p, 1 chamada por ID; falha de login/rede é inconclusiva, nunca veredito). Emite relatório legível + JSON. Só leitura.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "fotos_para_pdf.py",
-   "caminho": "_scripts/fotos_para_pdf.py",
-   "papel": "Converte as fotos da inspeção em PDF (anexo do auto).",
-   "runtime": "Python · pillow"
-  },
-  {
-   "nome": "comprimir_pdf.py",
-   "caminho": "_scripts/comprimir_pdf.py",
-   "papel": "Comprime PDFs grandes para caber no limite de tamanho do Sistema Auditor.",
-   "runtime": "Python · pikepdf/pypdf"
-  },
-  {
-   "nome": "docx_pack.py / docx_unpack.py",
-   "caminho": "_scripts/docx_*.py",
-   "papel": "Empacota e desempacota .docx (geração e validação de RT/relatórios sem libs externas).",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "nome": "scan_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/scan_autos.py",
-   "papel": "Extrai texto dos PDFs transmitidos (pypdf; pdftotext se no PATH) e parseia AI_[NUM]_[CNPJ]_[sufixo].PDF para o cruzamento.",
-   "runtime": "Python · pypdf"
-  },
-  {
-   "nome": "gera_relacao_autos.py",
-   "caminho": "aft-autos-lavrados/scripts/gera_relacao_autos.py",
-   "papel": "Gera a 'Relação de autos lavrados' (.docx) a partir do autos-lavrados.md — só os autos válidos (seção Detalhamento), agrupados por data do mais antigo ao mais recente. Usa template-relacao-autos.docx (cabeçalho SIT/AFT fixo, nunca alterado); Times New Roman 12pt, texto justificado, filetes e barra lateral navy. Não converte para PDF (ver decisão 'Relação de autos é .docx, sem PDF').",
-   "runtime": "Python (python-docx)"
-  },
-  {
-   "nome": "inspecionar_assinatura.py",
-   "caminho": "aft-jornada-atestado/scripts/inspecionar_assinatura.py",
-   "papel": "Inspeciona a assinatura/identificação do atestado técnico do REP por código.",
-   "runtime": "Python"
-  },
-  {
-   "nome": "validar.py",
-   "caminho": "aft-jornada-valida-afd-aej/validar.py",
-   "papel": "Valida a estrutura, o trailer e a integridade referencial do AEJ — calibrado pelos decimais e pela jornada flexível do sistema oficial.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "gerar_relatorio_docx.py",
-   "caminho": "aft-analise-acidente/scripts/gerar_relatorio_docx.py",
-   "papel": "Gera o Relatório de Análise de Acidente em .docx, no roteiro fixo de 6 seções da IN GMTP/MTP nº 2/2022.",
-   "runtime": "Python stdlib · zipfile"
-  },
-  {
-   "runtime": "Python stdlib",
-   "papel": "Resolve a pasta de trabalho do AFT de verdade: no Windows le a pasta Documentos no registro (cobre OneDrive e idioma), preserva instalacao existente e cria AFT/OS ATIVAS e OS ARQUIVADAS. Usado por aft_doctor, painel, servidor e vigia de sessoes.",
-   "nome": "pasta_aft.py",
-   "caminho": "_scripts/pasta_aft.py"
-  },
-  {
-   "nome": "instalar_agentes.py",
-   "papel": "Copia os agentes do toolkit (agents/*.md do repositório, que É ~/.claude/skills) para ~/.claude/agents/, onde o Claude Code os descobre. Idempotente (compara bytes, só copia o que mudou), saída JSON (instalados/atualizados/em_dia/erros), modo 'status' só relata. Chamado pelo /aft-setup e /aft-atualizar; o /aft-doctor faz a mesma comparação em modo leitura."
-  },
-  {
-   "nome": "erro_ticket.py",
-   "caminho": "_scripts/erro_ticket.py",
-   "papel": "Rede de segurança do toolkit: todo script chama ativar() no começo; se morrer com exceção não tratada, em vez de traceback cru o AFT recebe um TICKET DE CORREÇÃO pronto em <pasta AFT>/tickets/ — erro, versão do toolkit e retrato da máquina, com empresa/CNPJ/caminhos trocados por <EMPRESA>/<INSCRICAO>/<PASTA AFT>. Base da skill /aft-erro.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sync_perfil.py",
-   "caminho": "_scripts/sync_perfil.py",
-   "papel": "Re-sincroniza o perfil do auditor (~/.claude/CLAUDE.md) com o template config/CLAUDE-aft.md, substituindo SÓ o miolo entre os marcadores versionados (AFT-TOOLKIT-PERFIL:INICIO vN … :FIM) e preservando o que o AFT escreveu fora deles. --status devolve EM_DIA/DESATUALIZADO/SEM_MARCADOR/SEM_ARQUIVO; instalação antiga sem marcador recebe oferta de adoção (--adotar-substituir / --adotar-acrescentar). Chamado pelo /aft-atualizar (Passo 2e).",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "sessoes_os.py",
-   "caminho": "_scripts/sessoes_os.py",
-   "papel": "Uma sessão do app por empresa fiscalizada, no grupo 'OS ATIVAS', com o vínculo sessao_claude: no front-matter do memory.md. Escreve no armazenamento interno do app (não documentado: claude_desktop_config.json para os grupos, claude-code-sessions/… para as sessões) e SÓ com o app fechado, porque o app regrava o config enquanto está aberto — daí o modo --vigia. Backup antes de cada escrita e --desfazer.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "instalar_vigia_sessoes.py",
-   "caminho": "_scripts/instalar_vigia_sessoes.py",
-   "papel": "Instala/remove/consulta o vigia de sessões (sessoes_os.py --vigia) como serviço do SO — LaunchAgent com RunAtLoad+KeepAlive no macOS, Tarefa Agendada 'ao fazer logon' com reinício automático no Windows. É o que torna as sessões por empresa 100% automáticas: quando o app fecha, o vigia aplica as pendências e as sessões novas aparecem na próxima abertura. Parte padrão da instalação (/aft-setup e /aft-atualizar Passo 2f).",
-   "runtime": "Python stdlib (+ PowerShell no Windows)"
-  },
-  {
-   "nome": "checar_acentos.py",
-   "caminho": "_scripts/checar_acentos.py",
-   "papel": "Pega minuta de auto escrita 'chapada' (sem acentuação) antes do empacotamento. Não é exigência de encoding — o latin-1 do Sistema Auditor aceita todos os acentos do português; o que ele não aceita é travessão, aspas curvas e emoji. Texto sem acento é falha de qualidade do auto, detectada aqui de forma determinística e com quase zero falso-positivo.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "checar_arquivos_internos.py",
-   "caminho": "_scripts/checar_arquivos_internos.py",
-   "papel": "Impede que o ambiente de trabalho do AFT vaze para dentro do auto: o auto é documento legal entregue ao autuado, e inspecao-fisica.md, memory.md, .depara_*.json, 'OS ATIVAS', nomes de skill /aft-* e caminhos do computador não são elementos de convicção. Varre a minuta e avisa, com atenção especial ao subtítulo ELEMENTOS DE CONVICÇÃO.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "indenta_quebras.py",
-   "caminho": "_scripts/indenta_quebras.py",
-   "papel": "Recuo de primeira linha nos autos do Sistema Auditor: o campo é uma linha única em que a quebra é o comando #13#10, e sem recuo os parágrafos chegam grudados na importação. Insere 8 espaços após cada #13#10 que precede texto real, poupando o marcador ' . ' de linha em branco entre subtítulos.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "ajuda_arquitetura.py",
-   "caminho": "_scripts/ajuda_arquitetura.py",
-   "papel": "Recorta um bloco do arquitetura.json (camadas, scripts, anonimizacao, dados, avisos, decisoes) ou busca um termo nele, para a /aft-ajuda responder sem copiar o catalogo das habilidades para dentro dela. Evita jogar os 88 KB do JSON no contexto a cada pergunta.",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebook_id.py",
-   "caminho": "_scripts/notebook_id.py",
-   "papel": "Traduz a key de um notebook (nr-12, ementario-sst) no ID que a conta DESTE AFT enxerga. Unico lugar do toolkit que sabe o que e cohort: as treze skills que consultam o ementario so perguntam pela key. Descobre a cohort pelo aft-config.md ou sondando em duas etapas (os IDs ja na colecao da conta; se ela estiver vazia, qual dos dois o servidor entrega ao metadata - o caso de quem acabou de se cadastrar), e grava o resultado. Codigo de saida 3 = o notebook nao existe para esta cohort, e a skill segue sem alarde.",
-   "runtime": "python (stdlib) + CLI notebooklm na sondagem"
-  },
-  {
-   "nome": "sincronizar_notebooks.py",
-   "caminho": "_scripts/sincronizar_notebooks.py",
-   "papel": "Ferramenta do mantenedor: traz os IDs por cohort do mapa do portal (assets/notebooks-map.json) para o config/notebooks.json, sem tocar em title, essencial nem publico. Existe porque as duas copias do mapa ja haviam divergido em silencio (14 chaves com nome diferente, notebooks so de um lado).",
-   "runtime": "python (stdlib)"
-  },
-  {
-   "nome": "notebooklm_consulta.py",
-   "caminho": "_scripts/notebooklm_consulta.py",
-   "papel": "Consulta um notebook pela CHAVE: resolve o ID da cohort (notebook_id.py), roda o notebooklm ask e TRADUZ a falha em vez de deixar tudo virar 'NotebookLM indisponivel'. Codigo 5 = primeiro acesso pendente (devolve titulo e link para o AFT dar o 'oi' e a skill repetir a consulta); 6 = sessao caida; 3 = nao existe para a cohort. Substituiu os onze pontos de chamada do ask espalhados pelas skills.",
-   "runtime": "python (stdlib) + CLI notebooklm"
-  },
-  {
-   "nome": "lre_esocial.py",
-   "caminho": "_scripts/lre_esocial.py",
-   "papel": "Le o Livro de Registro de Empregados que o SISFGTS baixou do eSocial (JSON em latin-1, apesar da extensao .txt) e gera, na subpasta eSocial/ da OS, o painel navegavel LRE_painel.html, o CSV dos vinculos, o resumo lre-esocial.md (sem nome e sem CPF) e o resumo.json que o /aft-painel le. Apura indicio de registro tardio por dhrecepcao (nunca por processamento_datahora, que produz falso positivo grosseiro), so para admissao nova (tpadmissao=1) e so a partir do marco de 02/01/2026. Read-only sobre o SISFGTS.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_ferias.py",
-   "caminho": "_scripts/lre_ferias.py",
-   "papel": "Auditoria de ferias da /aft-lre-esocial: cruza o LRE (idA) com os afastamentos (idK) do SISFGTS, reconstitui os periodos aquisitivos de cada vinculo e grava Ferias_painel.html, Ferias_analise.csv, ferias.md e ferias_resumo.json na eSocial/ da OS. Classifica cada periodo: vencida (dobra art. 137), fora-prazo (S. 81 TST), vencendo, abono (art. 143), zerado (art. 133 IV). Quatro protecoes contra falso positivo: janela de dados da empresa, janela propria do vinculo transferido (sucessaovinc_dttransf), abono presumido a favor da empresa (dobra firme so com gozo < 20 dias, bloco tardio so completa o periodo ate 20) e alocacao FIFO que exclui periodos anteriores a janela.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "lre_folha.py",
-   "caminho": "_scripts/lre_folha.py",
-   "papel": "Auditoria da remuneracao declarada da /aft-lre-esocial: cruza o LRE (idA) com as bases de FGTS da folha (idM) e os afastamentos (idK) e grava Folha_painel.html, Folha_analise.csv, folha.md e folha_resumo.json na eSocial/ da OS. Grade mensal por vinculo (tpValor 11); aponta buraco (mes sem base e sem afastamento >= 20 dias), ano sem 13o (tpValor 12), ultimos 3 meses < 90% do salario contratual (compara presente com presente: mes antigo abaixo do salario atual e normal em quem teve aumento) e dispensa pelo empregador (mtv 02/03) sem base rescisoria (tpValor 21/22). Vinculo transferido conta a partir do sucessaovinc_dttransf.",
-   "runtime": "Python stdlib"
-  },
-  {
-   "nome": "cbo.json",
-   "caminho": "_scripts/cbo.json",
-   "papel": "Tabela de ocupacoes CBO usada pelo lre_esocial.py para nomear o cargo de cada vinculo no painel do LRE.",
-   "runtime": "dado (JSON)"
-  },
-  {
-   "nome": "consulta_cnpj.py",
-   "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
-   "runtime": "Python stdlib"
-  }
- ],
- "dados": [
-  {
-   "arquivo": "config/notebooks.json",
-   "conteudo": "47 notebooks do NotebookLM, cada um com um ID por COHORT (1 = originais; 2 = cópias, criadas quando os originais bateram o teto de 1.000 leitores). Cinco de link público têm ID único.",
-   "uso": "Consulta de ementa pelas skills. Ninguém lê este arquivo direto: o ID sai de _scripts/notebook_id.py, que sabe a cohort do AFT."
-  },
-  {
-   "arquivo": "config/uorgs.csv",
-   "conteudo": "1012 UORGs oficiais (CDUORG;NOME;UF;MUNICIPIO;...)",
-   "uso": "O /aft-setup resolve o código de 9 dígitos pela cidade informada."
-  },
-  {
-   "arquivo": "config/CLAUDE-aft.md",
-   "conteudo": "Perfil do Auditor-Fiscal + regras de trabalho, privacidade, roteamento das skills e persona opcional do assessor (campos tratamento/nome_assessor do aft-config.md; vale so no chat, nunca em documento)",
-   "uso": "Instalado pelo /aft-setup em ~/.claude/CLAUDE.md (carregado em toda conversa)."
-  },
-  {
-   "arquivo": "config/blocos_auto.md",
-   "conteudo": "Texto fixo e literal do Subtítulo 3 (OBSERVAÇÕES) do auto de infração",
-   "uso": "Fonte única lida pelo bloco3_inject.py — nenhuma skill de redação escreve esse bloco na mão."
-  },
-  {
-   "arquivo": "config/settings-aft.json",
-   "conteudo": "Deny-list de segurança: bloqueia leitura de credenciais (~/.ssh, ~/.aws, .env), dos mapas .depara_*.json e comandos de acesso remoto (ssh/scp/nc)",
-   "uso": "Instalada pelo /aft-setup em ~/.claude/settings.json — última linha de defesa contra exfiltração induzida por documento."
-  },
-  {
-   "arquivo": "config/models-validos.json",
-   "conteudo": "Apelidos e IDs de modelo aceitos no campo model: dos SKILL.md",
-   "uso": "O aft_doctor.py valida os frontmatters contra ela; quando um modelo for descontinuado, o mantenedor atualiza a lista e as skills, e os AFTs recebem via /aft-atualizar."
-  }
- ],
- "ementas": [
-  {
-   "camada": "1. NotebookLM (recomendado)",
-   "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
-  },
-  {
-   "camada": "2. Google Drive compartilhado",
-   "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
-  },
-  {
-   "camada": "3. O AFT informa o código",
-   "txt": "Formato XXXXXX-X, conferido no ementário oficial."
-  }
- ],
- "anonimizacao": [
-  "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
-  "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
-  "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
-  "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
-  "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
-  "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
-  "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
- ],
- "decisoes": [
-  {
-   "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
-   "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
-  },
-  {
-   "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
-   "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
-  },
-  {
-   "topico": "Relação de autos é .docx, sem PDF",
-   "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
-  },
-  {
-   "topico": "Nomes das skills",
-   "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
-  },
-  {
-   "topico": "Instalação",
-   "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
-  },
-  {
-   "topico": "Git obrigatório",
-   "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
-  },
-  {
-   "topico": "Sem SISOS/Supabase",
-   "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
-  },
-  {
-   "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
-   "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
-  },
-  {
-   "topico": "Empacotamento único",
-   "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-PGRTR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
-  },
-  {
-   "topico": "Latin-1 sem iconv",
-   "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
-  },
-  {
-   "topico": "Lotação pela cidade",
-   "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
-  },
-  {
-   "topico": "Ementas em 3 camadas",
-   "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
-  },
-  {
-   "topico": "Bloco 3 centralizado",
-   "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
-  },
-  {
-   "topico": "Atualização separada do diagnóstico",
-   "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
-  },
-  {
-   "topico": "Política de model por skill",
-   "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
-  },
-  {
-   "topico": "allowed-tools como garantia",
-   "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
-  },
-  {
-   "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
-   "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
-  },
-  {
-   "topico": "Detecção determinística no /aft-painel",
-   "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
-  },
-  {
-   "topico": "Bases distintas",
-   "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
-  },
-  {
-   "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
-   "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
-  },
-  {
-   "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
-   "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
-  },
-  {
-   "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
-   "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
-  },
-  {
-   "topico": "Painel virou dashboard de cards (SISOS local, offline)",
-   "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
-  },
-  {
-   "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
-   "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
-  },
-  {
-   "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
-   "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
-  },
-  {
-   "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
-   "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
-  },
-  {
-   "topico": "Painel ativo (modo interativo local)",
-   "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
-  },
-  {
-   "topico": "Extensão Chrome sincroniza o DET com o painel local",
-   "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
-  },
-  {
-   "topico": "Servidor do painel sempre ligado (padrão na instalação)",
-   "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
-  },
-  {
-   "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
-   "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
-  },
-  {
-   "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
-   "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
-  },
-  {
-   "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
-   "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
-  },
-  {
-   "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
-   "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
-  },
-  {
-   "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
-   "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
-  },
-  {
-   "topico": "Google Calendar: conector do Claude, não OAuth próprio",
-   "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
-  },
-  {
-   "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
-   "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
-  },
-  {
-   "topico": "Pasta única interdicao-embargo/ por OS",
-   "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
-  },
-  {
-   "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
-   "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
-  },
-  {
-   "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
-   "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
-  },
-  {
-   "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
-   "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
-  },
-  {
-   "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
-   "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
-  },
-  {
-   "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
-   "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
-  },
-  {
-   "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
-   "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
-  },
-  {
-   "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
-   "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
-  },
-  {
-   "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
-   "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
-  },
-  {
-   "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
-   "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
-  },
-  {
-   "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
-   "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
-  }
- ],
- "diferencas": [
-  {
-   "topico": "Plataforma",
-   "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
-  },
-  {
-   "topico": "Estado central",
-   "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
-  },
-  {
-   "topico": "Empacotamento",
-   "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
-  },
-  {
-   "topico": "Identidade do AFT",
-   "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
-  }
- ],
- "foraDoToolkit": [
-  "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
-  "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
-  "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
-  "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
-  "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
- ],
- "avisos": [
-  "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
-  "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
-  "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
-  "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
-  "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
-  "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
-  "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
-  "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
-  "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
- ]
+  ],
+  "ementas": [
+    {
+      "camada": "1. NotebookLM (recomendado)",
+      "txt": "CLI notebooklm-py via _scripts/notebooklm_consulta.py <key> (resolve o ID pela cohort do AFT a partir de config/notebooks.json e traduz a falha: codigo 5 = primeiro acesso pendente, com o link para o 'oi'); skill /aft-consulta; acesso em notebooks-aft.vercel.app. Envia so a descricao da irregularidade. Cota da conta gratuita: ~50 consultas/dia, e o proprio 'oi' do primeiro acesso conta."
+    },
+    {
+      "camada": "2. Google Drive compartilhado",
+      "txt": "Ementários por NR em Markdown, pasta pública — fallback quando o NotebookLM falha."
+    },
+    {
+      "camada": "3. O AFT informa o código",
+      "txt": "Formato XXXXXX-X, conferido no ementário oficial."
+    }
+  ],
+  "anonimizacao": [
+    "No chat e nas consultas à IA, trabalhadores viram tokens [[TRAB_NN]] / [[CPF_NN]] e a empresa vira [[AUTUADA]]; o CNPJ nunca é tokenizado.",
+    "O mapa token↔dados reais fica em .depara_<CNPJ>.json (sensível: não exibir, não compartilhar, não commitar).",
+    "Os dados reais entram no TXT final apenas pelo script determinístico rehydrate.py — nunca pelo modelo. Um nome/CPF trocado num documento legal é inaceitável.",
+    "A cópia *.tokenized.txt é a única versão segura para compartilhar com colegas.",
+    "Guard-rail extra: checar_pii.py varre relatos/pastas e avisa se um CPF ou PIS/PASEP com dígito verificador válido escapou da anonimização (não bloqueia — a troca real continua só pelo rehydrate.py).",
+    "Nada de fiscalização vai para serviços externos: compressão de PDF, conversão de fotos e validação são scripts Python locais. Única exceção, opt-in e com consentimento por sessão: o /aft-painel pode publicar o painel (empresas e prazos, sem dados de trabalhador) como Artifact privado na conta claude.ai do AFT.",
+    "Dois modos de processar um documento, e a diferenca importa: por SCRIPT LOCAL, quando o conteudo nunca entra no contexto (Relacao de Vinculos Ativos, AFD/AEJ, planilhas de CAT, PDFs dos autos transmitidos, rehydrate.py); ou pela LEITURA DO PROPRIO MODELO, quando a skill precisa compreender o documento (auditoria de PGR/AET/laudo NR-12, analise de acidente, triagem de resposta ao DET) - ai o conteudo do documento e enviado ao modelo. O criterio de cuidado e o CONTEUDO, nao o tipo: a LGPD (Lei 13.709/2018, arts. 1o e 5o, I) protege pessoa natural e NAO alcanca pessoa juridica, entao PGR, AET e laudo de maquina nao sao dado pessoal; ASO, atestado, laudo com CID, CAT, lista nominal, folha de ponto e ficha de registro sao. Ao rodar essas skills sobre um LOTE entregue pela empresa, cabe ao AFT conferir antes o que ha no pacote. O script local nao e ressalva, e o caminho DESENHADO para dado pessoal: onde ha nome, CPF, PIS, salario ou jornada, o toolkit resolve por script de proposito - havendo escolha, para dado de pessoa fisica a skill que calcula por script e a preferivel a que le o documento."
+  ],
+  "decisoes": [
+    {
+      "topico": "O toolkit deixa de ser só do Claude Code: AGENTS.md e os dois atalhos do Codex (14/08/2026)",
+      "txt": "O contexto de agente passou a morar em AGENTS.md (nome que Claude Code, Codex e outros leem), com o CLAUDE.md ao lado como mero ponteiro @AGENTS.md — uma informação, dois nomes. A instalação ganhou os dois caminhos de Codex: quem já usa o Claude cria dois atalhos e passa a ter os dois assistentes sobre os MESMOS arquivos; quem começa do zero no Codex faz a instalação de sempre com três trocas. A decisão de fundo é que a pasta física das skills continua sendo ~/.claude/skills mesmo para quem nunca abrir o Claude: esse caminho está escrito dentro de 45 SKILL.md e de 8 scripts, e duplicar a pasta seria garantir divergência. Quatro integrações são exclusivas do app do Claude — agentes de ~/.claude/agents, deny-list do settings.json, vigia de sessões e o gancho PostToolUse do diário — e o /aft-setup (Passo 0) e o /aft-atualizar agora as pulam quando estão no Codex. O /aft-doctor deduz o assistente pelos rastros que o app deixa em ~/.claude (projects, .claude.json, statsig, history.jsonl): sem sinal de Claude e com ~/.codex presente, esses três itens viram informativo em vez de aviso, e entra a checagem 'Atalhos do Codex' (samefile, que reconhece symlink, junction e hardlink). Quem usa os dois continua vendo os avisos, porque para ele são pendências de verdade."
+    },
+    {
+      "topico": "Renomeação de 5 skills: auditoria, embargo/interdição e informalidade (10/08/2026)",
+      "txt": "Os nomes passaram a descrever a tarefa do auditor, não a sigla interna. (1) /aft-nova-os -> /aft-nova-auditoria: uma Ordem de Serviço pode gerar VÁRIOS Relatórios de Inspeção — num mesmo estabelecimento convivem dois, três ou mais CNPJs, e o AFT abre uma auditoria (um RI) para cada empresa; o que a skill cadastra é a auditoria, não a OS. A pasta de trabalho continua se chamando 'OS ATIVAS'/'OS ARQUIVADAS' (nada foi movido no disco) e o front-matter ri: do memory.md segue sendo o identificador da auditoria. (2) /aft-rt-rgi -> /aft-embargo-interdicao, /aft-rt-manutencao -> /aft-embargo-interdicao-manutencao e /aft-levantamento-total -> /aft-embargo-interdicao-levantamento: 'RGI' só é legível para quem já conhece a sigla, e o prefixo comum faz as três aparecerem juntas ao digitar /aft-embargo. (3) /aft-registro -> /aft-informalidade, que é o tema real da skill (falta de registro, CTPS e exame admissional). Renomeação de pastas + referências (git mv, sem tocar no conteúdo das skills): o template.docx do RT foi junto com a pasta e os três montadores apontam para o novo caminho. O NOVIDADES.md guarda a tabela de-para; entradas antigas do changelog mantêm os nomes da época, de propósito. O perfil do auditor (config/CLAUDE-aft.md) foi para v13 — é o que leva os nomes novos às máquinas já instaladas."
+    },
+    {
+      "topico": "Relação de autos é .docx, sem PDF",
+      "txt": "A Relação de autos lavrados sai só em .docx (29/07/2026). A conversão automática para PDF foi retirada junto com o _scripts/docx_para_pdf.py, que era seu único consumidor. Motivo: o documento que vai ao processo já é o .docx, então o PDF nunca foi exigência — era conveniência. Em troca, ele obrigava a existir LibreOffice ou automação COM do Word, e o /aft-doctor passou a acusar 'nem LibreOffice nem Word encontrados' em máquina Windows COM Word instalado: a checagem olhava uma única chave de registro (App Paths\\winword.exe) numa única visão de 32/64 bits, então Python 64 bits + Office 32 bits dava falso negativo. Vários colegas reportaram o aviso. Em vez de endurecer a detecção (mais código para sustentar uma conversão dispensável), removeu-se a exigência inteira: a checagem saiu do /aft-doctor e quem quiser PDF usa Arquivo > Salvar como... > PDF no Word. Menos dependência de máquina, menos aviso assustando o AFT."
+    },
+    {
+      "topico": "Nomes das skills",
+      "txt": "Toda skill oficial usa o prefixo `aft-` (26/07/2026): /NR12 virou /aft-NR12, /gera-ai virou /aft-gera-ai etc. Sem prefixo comum, as skills do toolkit ficavam espalhadas no menu / do Claude Code, misturadas ao que o AFT tem instalado; agora digitar /aft reúne todas em bloco. Corte seco, sem alias do nome antigo — a tabela de-para vai no NOVIDADES.md, que o /aft-atualizar mostra a cada usuário, e o disparo por linguagem natural continua igual. O namespace `minha-` das skills próprias do AFT não é afetado. Como ~/.claude/skills É o clone do repo, o git pull renomeia as pastas sozinho, sem script de migração."
+    },
+    {
+      "topico": "Instalação",
+      "txt": "O repositório É a pasta ~/.claude/skills do colega (clone direto). O Claude Code só descobre skills no 1º nível dessa pasta — clone aninhado deixa todas invisíveis."
+    },
+    {
+      "topico": "Git obrigatório",
+      "txt": "O app desktop Windows exige Git antes de abrir sessão local; Git é passo manual (galinha-e-ovo); o Claude instala só Python/toolkit."
+    },
+    {
+      "topico": "Sem SISOS/Supabase",
+      "txt": "O toolkit é offline: os memory.md são o banco local e o /aft-painel é a camada de visão (SISOS-lite, só leitura). Cadastro pelo /aft-nova-auditoria."
+    },
+    {
+      "topico": "Pasta de trabalho fixa — resolvida de verdade (OneDrive/idioma)",
+      "txt": "Documents/AFT/OS ATIVAS/ é o único lugar onde moram as pastas das empresas fiscalizadas — criada pelo /aft-setup (Passo 2), populada pelo /aft-nova-auditoria, conferida e CRIADA se faltar pelo /aft-doctor, e lida por todas as skills que tocam a pasta da OS. Ao lado, OS ARQUIVADAS/ recebe as fiscalizações encerradas. Até 21/07/2026 o caminho era um mkdir cru (~/Documents/AFT) hardcoded em 4 scripts — no Windows isso falha silenciosamente sempre que o OneDrive redireciona 'Documentos' (comum em backup de pastas) ou o Windows está em português ('Documentos', não 'Documents'): a pasta nascia órfã, o AFT nunca a achava pelo Explorer (caso real 22/07/2026). Corrigido com _scripts/pasta_aft.py: le a chave User Shell Folders\\\\Personal do registro do Windows (cobre OneDrive e idioma de uma vez), com fallback por variável OneDrive e por candidatos diretos; prioriza SEMPRE uma pasta AFT que já tenha dados (nunca orfanando instalação anterior); expõe diagnostico() e mover_para_canonico() (--mover) para quem já instalou no lugar errado migrar com consentimento, sem sobrescrever nada. gerar_painel.py, servir_painel.py e sessoes_os.py foram religados ao mesmo resolvedor."
+    },
+    {
+      "topico": "Empacotamento único",
+      "txt": "Todo TXT é gerado no /aft-gera-ai; /aft-informalidade, /aft-PGR-analise, /aft-PGRTR-analise, /aft-aet-auditoria e a jornada só redigem e fazem handoff (diferente das versões pessoais)."
+    },
+    {
+      "topico": "Latin-1 sem iconv",
+      "txt": "rehydrate.py grava o TXT final direto em ISO-8859-1 — iconv/sips não existem garantidamente no Windows."
+    },
+    {
+      "topico": "Lotação pela cidade",
+      "txt": "O /aft-setup resolve o código da UORG pela cidade (uorgs.csv) — o AFT raramente sabe o código de 9 dígitos."
+    },
+    {
+      "topico": "Ementas em 3 camadas",
+      "txt": "NotebookLM (via /aft-consulta) primeiro → Drive compartilhado → o AFT digita o código. Nunca inventar ementa."
+    },
+    {
+      "topico": "Bloco 3 centralizado",
+      "txt": "O Subtítulo 3 (OBSERVAÇÕES) de todo auto vem de config/blocos_auto.md, injetado só pelo /aft-gera-ai (bloco3_inject.py) — nenhuma skill de redação o escreve na mão, evitando divergência e economizando tokens."
+    },
+    {
+      "topico": "Atualização separada do diagnóstico",
+      "txt": "/aft-doctor só lê (nunca instala); quem efetivamente atualiza skills e o notebooklm-py é o /aft-atualizar, que chama o /aft-doctor ao final para confirmar."
+    },
+    {
+      "topico": "Política de model por skill",
+      "txt": "Três faixas: claude-opus-4-8[1m] para auditoria de documento longo (/aft-PGR-analise, /aft-aet-auditoria, /aft-analise-acidente); sonnet/haiku para o formular e o mecânico (empacotar, validar, painel, setup); sem pin nas skills de redação jurídica pesada (herdam o melhor modelo da sessão do AFT — um pin de opus quebraria em plano sem acesso). O /aft-doctor valida os pins contra config/models-validos.json e testa a disponibilidade ao vivo."
+    },
+    {
+      "topico": "allowed-tools como garantia",
+      "txt": "Promessa de 'somente leitura' virou restrição técnica: /aft-doctor e /aft-painel rodam sem Write/Edit (frontmatter allowed-tools); /aft-autos-lavrados precisa escrever (relatório + memory.md), então seu fence corta as ferramentas de rede — ela processa PDFs com dados pessoais."
+    },
+    {
+      "topico": "Tokenização antes da lavratura (.depara na raiz da OS)",
+      "txt": "Até 2026-07-13, o .depara_[CNPJ].json (mapa token↔dado real de trabalhador) só nascia dentro da pasta Autos DD-MM/, criado pelo /aft-gera-ai. Com /aft-preparacao-acao-fiscal, a tokenização pode acontecer ANTES de qualquer lavratura, então o mapa passou a poder viver também na raiz da pasta da OS. O /aft-gera-ai foi ajustado (FASE 2.5 Passo 1) para procurar nos dois locais — raiz da OS primeiro, depois lavraturas anteriores — e reaproveitar, nunca recriar do zero se já existir."
+    },
+    {
+      "topico": "Detecção determinística no /aft-painel",
+      "txt": "A identificação de notificações DET não cadastradas é do script (regex de código + 1ª página via pdfplumber, comparada ao memory.md) — o modelo (haiku) só relata o que o script achou e encaminha o cadastro ao /aft-nova-auditoria. Heurística: o painel apresenta como 'confira e cadastre', nunca como fato."
+    },
+    {
+      "topico": "Bases distintas",
+      "txt": "Nunca mexer nas skills pessoais do mantenedor (~/.claude/skills do Ricardo) ao trabalhar no toolkit; o toolkit é uma adaptação à parte."
+    },
+    {
+      "topico": "CNPJ/CPF opcional na /aft-nova-auditoria, obrigatório só no /aft-gera-ai",
+      "txt": "A /aft-nova-auditoria deixou de exigir CNPJ/CPF: o AFT nomeia a auditoria livremente (razão social, fantasia, com ou sem identificador). O CNPJ/CPF só se torna obrigatório no /aft-gera-ai (exigência do próprio Sistema Auditor para o TXT) — se a OS ainda não tiver, o gera-ai pergunta, grava no memory.md e RENOMEIA a pasta da OS prefixando o CNPJ na frente do nome original (mv, não recria). Reflexo no .depara: quando a tokenização de trabalhadores (preparacao-acao-fiscal) roda antes do CNPJ ser conhecido, o arquivo nasce como .depara.json (sem sufixo) e o gera-ai sabe procurar os dois nomes."
+    },
+    {
+      "topico": "autos-lavrados: Mac+Parallels e match por 8 dígitos",
+      "txt": "scan_autos.py passou a autodetectar a pasta PRO do Sistema Auditor também no Mac com Parallels (glob em /Volumes/*/SistemasAFT/Auditor/Docs/AutosDeInfracao/PRO, o disco C: da VM montado no Finder), além do padrão Windows e do 3º argumento manual. E aceita identificador de 8, 11 ou 14 dígitos (antes exigia 14, o que rejeitava CPF/CAEPF) — como toda pasta do Sistema Auditor termina com os 8 primeiros dígitos do CNPJ/CPF, esse prefixo basta para achar os autos. Reflexo da /aft-nova-auditoria sem CNPJ: quando a OS não tem identificador, a skill pergunta os 8 dígitos ao AFT (modo OS única) ou pula a OS com aviso (modo lote)."
+    },
+    {
+      "topico": "autos-lavrados: uma ementa = um auto válido (dedup por re-lavratura)",
+      "txt": "Em regra cada ementa corresponde a um único auto: quando o AFT erra e re-lavra, o PDF cancelado resiste na pasta. Como a numeração dos autos é crescente (último dígito = verificador), scan_autos.py agrupa por ementa e marca status_duplicidade: mantido_ultimo (maior número-base = válido) vs cancelado_presumido (substituido_por). Exceções fixas no script: 001960-7 nunca deduplica (todos válidos); 001775-2/001774-4/002270-5/002269-1 avisam e o AFT decide (relacionar todos ou só o último). No relatório, cancelados vão numa seção 'Autos substituídos' à parte; no memory.md as linhas [x] passam a ser chaveadas pelo número do AI (permite ementas legitimamente repetidas)."
+    },
+    {
+      "topico": "Painel virou dashboard de cards (SISOS local, offline)",
+      "txt": "O /aft-painel deixou de ser tabela e virou dashboard de cards com detalhe por auditoria, espelhando o SisOS pessoal do Ricardo mas 100% local (sem Vercel/Supabase): os memory.md são o banco, o autos-lavrados.md dá os autos com constatação, e o scan_autos.py (--scan) dá a lista fria ao vivo do Sistema Auditor — mesclados por número de AI, com degradação graciosa quando a pasta PRO está inacessível. Atualização diária é agendador do SO (launchd/schtasks) rodando o script determinístico, sem gastar tokens. No Mac a pasta das OS é perguntada uma vez e gravada como pasta_os: no aft-config.md; no Windows é o padrão."
+    },
+    {
+      "topico": "Rotina diária do painel entra no /aft-setup e no /aft-atualizar",
+      "txt": "Criado _scripts/instalar_rotina_painel.py (cross-platform: launchd no macOS, Agendador de Tarefas no Windows) para instalar/remover/consultar a rotina do /aft-painel sem gastar tokens (chama gerar_painel.py --scan direto pelo SO). O /aft-setup passou a oferecer isso (opt-in) no Passo 7b, usando o python_path e a pasta OS ATIVAS já coletados. O /aft-atualizar oferece a mesma coisa, uma única vez, para quem instalou o toolkit antes dessa novidade — controla isso com o campo rotina_painel no aft-config.md (vazio = já perguntado e recusado; HH:MM = instalado) para nunca perguntar duas vezes."
+    },
+    {
+      "topico": "Skills próprias do colega, à prova de atualização (namespace minha-)",
+      "txt": "O toolkit passou a suportar skills criadas pelo próprio AFT/colega. Como o Claude Code só descobre skills no 1o nível de ~/.claude/skills (o repo É essa pasta), uma pasta 'Minhas Skills' aninhada não funcionaria — as skills ficariam invisíveis. Solução: namespace reservado 'minha-' (nenhuma skill oficial começa assim) + '.gitignore' com 'minha-*/'. Isso mantém a skill própria no 1o nível (visível), fora do versionamento e intocada pelo git pull do /aft-atualizar. O aft_doctor valida essas skills à parte, com tolerância (aviso, não erro) e confirma a proteção. A skill oficial /aft-nova-skill faz o scaffold guiado para leigos. CLAUDE-aft.md instrui o Claude a tratar minha-* como primeira classe e a nunca editar skill oficial a título de personalização."
+    },
+    {
+      "topico": "Onboarding de pastas pré-toolkit (/aft-organiza-os) + layout NOTIFICACOES/AUTOS",
+      "txt": "O colega chega ao toolkit com fiscalizações em andamento e documentos acumulados numa pasta do jeito dele. A /aft-organiza-os faz o onboarding: joga-se a pasta em OS ATIVAS, ela lê a 1ª página de cada PDF, classifica (notificação DET, relação de autos do Sistema Auditor — que já alimenta a seção Autos lavrados do memory.md —, resposta do empregador item1..N, fotos), extrai empregador/identificador/prazos e propõe um plano antes-e-depois que só executa com aprovação. Nada é apagado; arquivo não identificado fica intocado e listado. Convenção de pastas revista em 22/07/2026 (caso real: uma OS com 38 itens soltos na raiz): antes cada notificação e cada lote de autos vivia solto na raiz da OS; agora existem duas caixas — NOTIFICACOES/ (PDF de notificação, relatório de atendimento e a subpasta de resposta do empregador, sufixo descritivo preservado) e AUTOS/ (os lotes 'Autos DD-MM/', movidos e NUNCA renomeados porque o nome é citado no memory.md, e a 'Relacao de autos/'). Regra dura descoberta na prática: os .md (autos-lavrados.md, analise-preliminar-*.md, jornada-analise-*.md) NUNCA entram nas caixas — gerar_painel.py lê autos-lavrados.md num caminho fixo na raiz e lista os demais .md com glob de 1º nível; um .md movido para dentro de uma caixa some do painel (confirmado empiricamente antes de fechar a migração real da OS CONSORCIO SQ). Migração é só mkdir+mv sobre OS já organizadas; nada é renomeado; OS antigas não migradas continuam funcionando (gera_relacao_autos.py e /aft-autos-lavrados checam os dois layouts)."
+    },
+    {
+      "topico": "Painel ativo (modo interativo local)",
+      "txt": "O painel deixou de ser só visualização: o servir_painel.py serve o MESMO painel.html em http://127.0.0.1:8347 e, aberto por esse endereço, os cards ganham ações mecânicas — marcar DET respondida, resolver pendência, registrar atividade, status e embargo/interdição (campo embargo_interdicao do front-matter, preservando a descrição) — gravadas direto no memory.md com backup prévio. Divisão de responsabilidade: mecânico = servidor local (zero tokens); julgamento = botões 📋 que copiam o comando pronto (/aft-gera-ai, /aft-autos-lavrados, /aft-det-630, /aft-inspecao-fisica) para colar no Claude Code. Aberto pelo arquivo (file://) os controles somem — continua leitura pura. Custo: ~20 MB de RAM ocioso, CPU zero, só localhost."
+    },
+    {
+      "topico": "Extensão Chrome sincroniza o DET com o painel local",
+      "txt": "A extensão 'SisOS — Sync DET' (Chrome Web Store, código no repo SisOS) ganhou na v1.1 um segundo destino: além do SisOS na Vercel, um modo 'Painel local (AFT Toolkit)' opcional que envia o mesmo token de sessão do DET ao servir_painel.py (POST /api/det-sync, fetch feito no service worker da extensão — sem CORS). O det_sync.py replica em Python a lógica do sync do SisOS (lib/det/api-client + sync), trocando o Supabase pelos memory.md. Com isso um colega SEM SisOS/Vercel/Supabase instala a mesma extensão da loja, liga só o modo local e tem notificações e prazos do DET fluindo direto para as fichas — 100% na máquina dele. Decidido: quem consulta a API do DET é o servidor local (não a extensão), o gatilho é manual (botão), e o SisOS virou opcional na configuração da extensão."
+    },
+    {
+      "topico": "Servidor do painel sempre ligado (padrão na instalação)",
+      "txt": "O servidor interativo (servir_painel.py) nasceu manual: só rodava enquanto o AFT mantivesse um terminal aberto. Como a sincronização automática do DET pela extensão Chrome depende do servidor estar no ar, e a maioria dos AFTs usa Windows, criamos o instalar_servidor_painel.py: instala como serviço do SO, subindo sozinho no login. No Windows isso exige PowerShell (Register-ScheduledTask com RestartCount/RestartInterval), já que o schtasks.exe básico usado na rotina diária não sustenta reinício automático; usa pythonw.exe para não abrir janela. No macOS, LaunchAgent com KeepAlive=true. Testado ciclo completo no Mac: instala, serve, sobrevive a kill -9 (respawn do launchd), remove, para de responder. Começou opcional, mas a pedido do Ricardo (19/07) virou PADRÃO: o /aft-setup Passo 7c instala sem perguntar, e o /aft-atualizar Passo 2c garante que quem ainda não tem passe a ter (inclusive quem havia recusado antes) — o painel estático e os controles interativos deixaram de depender de o AFT ter dito sim. Continua com escape hatch: instalar_servidor_painel.py remover desliga, se o AFT pedir. Roda só em 127.0.0.1."
+    },
+    {
+      "topico": "Bug crítico corrigido: notificações de fiscalizações antigas vazavam para a OS errada",
+      "txt": "No primeiro teste real da extensão, o clique em Sincronizar importou 4 notificações numa OS, mas 3 eram de uma fiscalização de anos atrás, já concluída — a pesquisa no DET é por CNPJ do empregador, então devolve notificações de TODAS as fiscalizações já feitas naquele CNPJ, não só a atual. Investigação com os dados reais da API (campos ri, situacaoRi, dataEnvio) descartou duas hipóteses erradas: (a) filtrar por situacaoRi — várias OS legítimas em OS ATIVAS têm TODAS as notificações como FISC_CONCLUIDA_E_AFERIDA (a fiscalização encerrou, a pasta ainda não foi arquivada), e filtrar por isso apagaria dado real; (b) assumir 1 RI por OS de forma rígida — existe o caso real de uma OS que acompanha duas fiscalizações do mesmo CNPJ com RIs distintos (a ação fiscal normal e a investigação de um acidente, conduzida com outro AFT). Solução: filtro por RI, onde RIs conhecidos = ri: do front-matter ∪ RIs das notificações já registradas no memory.md (a união cobre o caso multi-RI); sem RI conhecido, adota o da notificação mais recente. Notificação de RI alheio nunca é descartada em silêncio — volta em ignoradas_detalhe e no toast da extensão ('↳ N de outra fiscalização'). As linhas contaminadas foram removidas do memory.md afetado (com backup) e o filtro foi validado por replay dos dados reais capturados (servidor rodado com AFT_DET_DEBUG + AFT_DET_DRYRUN antes de qualquer escrita). Armadilha descoberta no caminho: enquanto as linhas erradas estavam na ficha, elas faziam o RI antigo virar 'conhecido' — a contaminação se auto-perpetuava, então a limpeza tem de vir antes do filtro. ENDURECIDO em 22/07/2026 (caso real CONSORCIO SQ, RI alheio 319969819 importado mesmo com o filtro acima): a união com 'RIs já registrados no memory.md' foi removida — um RI registrado um dia (por engano, ou de uma varredura antiga) virava 'conhecido' para sempre e continuava puxando notificações irmãs. Regra atual: o campo ri: do front-matter é o ÚNICO identificador da auditoria (aceita mais de um RI, separados por vírgula, para o caso real de duas fiscalizações do mesmo CNPJ); nada é inferido de notificações já na ficha. Sem ri: preenchido, adota o da notificação mais recente e grava — daí em diante vale a regra estrita. Para reduzir esse atrito de origem, o /aft-nova-auditoria passou a coletar o RI (opcional) já no cadastro, avisando que sem ele o sync automático não importa nada da OS."
+    },
+    {
+      "topico": "Bug corrigido: sync de prazo corrompia linha com dois prazos na mesma notificação",
+      "txt": "Segundo bug real: uma linha de DET escrita à mão continha dois prazos distintos para itens diferentes da mesma NAD (um item já vencido, outro com prazo futuro). O det_sync original achava o primeiro 'prazo dd/mm/aaaa' da linha por regex e sobrescrevia com o itemDataProximaEntrega da API (que é por NOTIFICAÇÃO, não por item) — trocou a data do item vencido pela do outro, corrompendo dado real. Efeito colateral no mesmo teste: numa linha sem a palavra 'prazo' mas que já citava a data em outra frase ('...vistoria de dd/mm/aaaa'), o script colava '— prazo dd/mm/aaaa' redundante no fim. Corrigido com duas guardas: (1) só atualiza a data quando a linha tem exatamente UM 'prazo'/'entrega até' — linha ambígua (2+) fica intocada, o AFT decide manualmente; (2) só acrescenta '— prazo X' quando essa data não aparece em NENHUMA forma na linha (BR ou ISO), evitando duplicar informação já escrita. As linhas reais corrompidas foram corrigidas manualmente (com backup); o conserto foi validado com 4 casos (linha ambígua intocada, data já presente não duplica, caso normal continua atualizando, linha sem prazo nenhum recebe o novo normalmente)."
+    },
+    {
+      "topico": "Extensão Chrome 2.0: independente do SisOS de fato (nome, permissões, código morto)",
+      "txt": "Antes de publicar a v2.0 na Chrome Web Store, auditoria encontrou duas pendências que atrapalhariam a revisão do Google: a permissão notifications declarada mas nunca usada (o toast é HTML injetado na página, não a API chrome.notifications), e o injected.js (captura de token da v1, substituída pelo webRequest do background.js) ainda exposto via web_accessible_resources sem que nada o injetasse — código morto e superfície de permissão desnecessária. Ambos removidos. Também renomeada de 'SisOS — Sync DET' para 'Sync DET — SisOS / AFT Toolkit' (manifest name, default_title, título e cabeçalho do popup) — o nome antigo sugeria SisOS obrigatório, quando a v1.1 já o tinha tornado opcional. Empacotada como sisos-sync-det-v2.0.0.zip (15 KB), com roteiro de publicação documentado, incluindo os textos de justificativa de permissão exigidos pela revisão do Google (em especial host_permissions para 127.0.0.1/localhost, incomum na loja)."
+    },
+    {
+      "topico": "Testes reais de ponta a ponta do sync do DET (2 novas OS)",
+      "txt": "Para validar os dois bugs corrigidos, duas OS novas foram criadas como campo de prova real (não simulado): uma via /aft-organiza-os (testou o caminho 'RI já conhecido' e expôs o bug da linha com dois prazos) e outra via /aft-nova-auditoria + /aft-inspecao-fisica, sem nenhuma notificação DET ainda (testou o caminho 'RI desconhecido, adota o da notificação mais recente'). De quebra, o /aft-organiza-os teve o model pinado trocado de opus para sonnet (mais barato, suficiente para a classificação/extração da skill)."
+    },
+    {
+      "topico": "Subtítulos dos autos em algarismos romanos (I -, II -, III -)",
+      "txt": "A pedido do Ricardo, os subtítulos dos autos de infração deixaram de ser '1) DA FISCALIZAÇÃO' / '2) IRREGULARIDADE' / '3) OBSERVAÇÕES' e passaram a 'I - DA FISCALIZAÇÃO:' / 'II - IRREGULARIDADE:' / 'III - OBSERVAÇÕES:', sempre com quebra de linha após o subtítulo — no TXT do Sistema Auditor isso é o separador '#13#10 . #13#10' (a linha com ponto é o 'espaço em branco', já que o sistema não renderiza linha vazia). A mudança tocou 16 arquivos, mas foi barata porque o formato tem fonte única: o bloco 3 canônico vive em config/blocos_auto.md (injetado pelo bloco3_inject.py, cujo detector de 'já tem bloco 3' agora reconhece os dois formatos para nunca duplicar) e as regras de #13#10 vivem na FASE 3 do /aft-gera-ai. Compatibilidade com o legado: rascunho antigo redigido com '1)/2)/3)' é NORMALIZADO pelo /aft-gera-ai na hora de empacotar o TXT (troca determinística de subtítulo) — todo TXT sai no formato novo, mesmo de auto redigido antes da mudança."
+    },
+    {
+      "topico": "Google Calendar: conector do Claude, não OAuth próprio",
+      "txt": "Para levar os prazos de DET ao Google Calendar foram avaliados três caminhos: (A) o conector Google Calendar do próprio Claude, (B) OAuth próprio contra a API do Google e (C) botões de URL de template no painel, sem login. O caminho B foi rejeitado para um toolkit distribuído: exigiria projeto Google Cloud do mantenedor, app 'não verificado' (tela de aviso), limite de 100 usuários de teste cadastrados por e-mail um a um e credencial de cliente num repositório público. Ficou A+C: a skill /aft-agenda-det usa o conector (autenticação delegada à interface do Claude, zero segredo no repo) para a sincronização de verdade — criar, atualizar prazo prorrogado e marcar ✓ ao responder —, e o painel ganhou o botão 'agendar no Google Calendar' por notificação (URL de template, funciona sem login nenhum). Assinatura de .ics foi descartada porque os servidores do Google não alcançam 127.0.0.1. Regras de segurança da skill: nunca apagar eventos, nunca tocar em evento fora do padrão 'DET ...', evento carrega apenas código + nome do empregador (nada de CNPJ, RI ou conteúdo da fiscalização na nuvem do Google)."
+    },
+    {
+      "topico": "Relatórios ad-hoc (fora das skills): .docx, não markdown solto",
+      "txt": "Quando o AFT pede um documento/relatório que não corresponde a nenhuma skill do toolkit, o Claude gera o arquivo final em .docx (python-docx, já usado no /aft-autos-lavrados e na apostila) em vez de só despejar texto em markdown no chat ou salvar um .md. Isso é regra de comportamento (CLAUDE-aft.md), não uma skill nova: não há um gerador genérico de docx no _scripts, o Claude monta o documento com python-docx caso a caso, como foi feito para a apostila. Ficou de fora do escopo o memory.md (estado interno, lido por regex pelas skills e pelo gerar_painel.py — virar .docx quebraria isso) e os textos que as skills já produzem para copiar e colar (ex.: /aft-NAD e /aft-tn-nco, que já usam bloco de código no chat, texto puro, para o AFT colar direto no campo do DET sem sobra de markdown)."
+    },
+    {
+      "topico": "Pasta única interdicao-embargo/ por OS",
+      "txt": "Toda a documentação de interdição/embargo de uma auditoria mora numa pasta única 'interdicao-embargo/' (sem sufixo de data): o termo assinado, o RT que a fundamenta (/aft-embargo-interdicao) e seus autos derivados (autos.md + TXT do /aft-gera-ai + termo anexo), o RT de manutenção (/aft-embargo-interdicao-manutencao) e o requerimento de suspensão com os juntados do empregador. Substituiu a antiga 'Autos TE-TI DD-MM/'. O /aft-organiza-os classifica arquivos com 'interdicao'/'embargo'/'TE-TI' no nome (ou 'TERMO DE INTERDIÇÃO/EMBARGO/MANUTENÇÃO' na 1ª página) e os roteia para lá; /aft-embargo-interdicao e /aft-embargo-interdicao-manutencao escrevem direto nela. Com 2+ termos na mesma OS, sufixam-se os arquivos com o nº do termo (RT_Interdicao_<termo>.docx) para não sobrescrever."
+    },
+    {
+      "topico": "CLAUDE.md do AFT: bloco gerenciado com marcadores, atualizado sozinho",
+      "txt": "O perfil ~/.claude/CLAUDE.md é cópia do template config/CLAUDE-aft.md e nunca foi tocado pelo git pull — então quem instalava cedo ficava sem as regras acrescentadas depois (a defesa anti-prompt-injection de 28/06, a robustez de Windows, o namespace minha-*, skills novas no roteador). O template dobrou (84->214 linhas) desde a 1ª versão. Solução: o conteúdo do toolkit passa a ser cercado por marcadores invisíveis (comentários HTML AFT-TOOLKIT-PERFIL:INICIO vN / :FIM) com número de versão, e o script _scripts/sync_perfil.py compara a versão instalada com a do template. O /aft-atualizar (Passo 2e) roda --status e: EM_DIA não faz nada; DESATUALIZADO roda --aplicar automaticamente (backup + troca só o miolo entre os marcadores, preservando o que o AFT escreveu fora deles — sem perguntar, é obrigatório e seguro); SEM_MARCADOR (instalação antiga, sem como isolar o texto velho do que é do AFT) dispara UMA oferta de adoção (--adotar-substituir troca o arquivo todo, ou --adotar-acrescentar anexa o bloco, mesma escolha a/b/c do /aft-setup Passo 5b), e dali em diante vira automática. Por que marcadores em vez de sobrescrever o arquivo todo: a propriedade 'quem personalizou não perde nada' só existe porque o toolkit sabe exatamente onde começa e termina o pedaço dele; sem os marcadores, atualização silenciosa = sobrescrever = perder as edições do colega. O /aft-setup instala o perfil já marcado (o cp e a opção append carregam os marcadores do próprio template)."
+    },
+    {
+      "topico": "Alerta 'atualização pendente' do DET é dispensável, não permanente",
+      "txt": "Constatado em produção (19–22/07/2026, casos SPE CAMETA e CONSORCIO SQ): o campo itemAtualizado da API do DET (o triângulo amarelo 'Existe atualização pendente') pode continuar true mesmo depois de o triângulo sumir da tela — a tela apaga quando o AFT abre a notificação lá; o campo da API, não necessariamente. Sem tratamento, o alerta ficava aceso para sempre na sub-linha de detalhes do memory.md e no painel. Solução: o alerta virou dispensável — clique no painel (ação det_visto) grava <!-- visto: <última entrega> --> na sub-linha, e det_sync.py só volta a mostrar o alerta se itemDataUltimaEntrega mudar (entrega nova da empresa = novidade real). O marcador visto: é preservado a cada regravação da sub-linha pelo sync."
+    },
+    {
+      "topico": "Agentes isolados: revisor de autos e varredura do Sistema Auditor (28/07/2026)",
+      "txt": "O toolkit ganhou a camada de agentes (subagentes do Claude Code, instalados em ~/.claude/agents/ a partir de agents/ do repositório). Dois primeiros: aft-revisor-autos (a revisão 5W1H do /aft-revisa-auto roda num contexto isolado, sem ver a conversa que redigiu os autos — revisão com olhos frescos, como lerá o julgador) e aft-autos-lavrados (a varredura dos PDFs do Sistema Auditor roda fora da conversa principal; só o relatório volta, e o modo lote pode rodar em segundo plano). Desenho: as skills continuam sendo a porta de entrada e viram despachantes — o SKILL.md instalado é a fonte única das instruções (o agente o lê e executa o miolo; guarda anti-recursão marca as seções de despacho). Agente nunca pergunta: não recebe a tool AskUserQuestion (garantia dura); pontos de decisão aplicam a semântica conservadora de lote e voltam numa seção 'Decisões pendentes do AFT', que a conversa principal conduz com o auditor — 'você sugere, o AFT decide' fica intacto, só muda de sala. Bônus de segurança: os documentos periciados são lidos numa sala com ferramentas restritas (revisor: Read/Edit/Bash, sem Write), reduzindo o raio de ação de eventual texto malicioso embutido. Fallback obrigatório: se o agente não estiver instalado, a skill executa inline como sempre — nada trava. Encanamento: _scripts/instalar_agentes.py copia agents/*.md para ~/.claude/agents/ (idempotente, JSON); chamado pelo /aft-setup (Passo 2b) e /aft-atualizar (Passo 2g); o /aft-doctor confere a cópia (aviso, nunca erro). Em 22/08/2026 entrou o quarto: aft-revisor-notificacao, que lê a prévia de uma notificação DET antes de ela virar rascunho e julga o que regra automática não julga (o retorno combina com o que o item pede? o prazo é exequível? falta o fecho de comprovação?)."
+    },
+    {
+      "topico": "Cohorts do NotebookLM: o teto de 1.000 leitores e o resolvedor de ID (22/08/2026)",
+      "txt": "Cada notebook do NotebookLM comporta 1.000 leitores; os originais lotaram em 19/08/2026 e o catalogo inteiro foi duplicado — quem se cadastra desde entao entra na cohort 2 e enxerga as copias. Nao existe mais 'o ID da NR-12': existe o ID da NR-12 para a cohort do AFT. Treze SKILL.md carregavam a sua copia da mesma linha lendo o ID direto do notebooks.json; para um AFT da cohort 2 toda consulta responderia not found e as skills cairiam no modo sem ementario SEM dizer por que. A correcao nao foi trocar IDs: foi tirar dos SKILL.md a competencia de saber o que e um ID. Agora ha um resolvedor (_scripts/notebook_id.py), o notebooks.json perdeu o campo notebook_id de proposito (leitor esquecido quebra visivelmente em vez de servir o ID errado calado) e o codigo de saida 3 diz 'nao existe para esta cohort', que a skill trata como degradacao silenciosa — a mesma regra que a /aft-embargo-interdicao ja usava para a key interdicoes. A cohort e sondada pelo notebooklm list (o endpoint do portal que a sabe exige o JWT do Supabase, que o CLI nao tem) e gravada no aft-config.md. Cinco notebooks de link publico nao foram duplicados e valem para todas as cohorts. A sondagem tem duas etapas: o notebooklm list (o que o AFT ja abriu) e, quando a colecao esta vazia - o colega que se cadastrou hoje e ainda nao abriu nada -, o notebooklm metadata, que responde pelo compartilhamento e nao depende do primeiro acesso. Inverter o padrao para a cohort ativa nao servia: consertaria o recem-chegado e quebraria o AFT de cohort 1 que reinstala numa maquina nova. Segunda frente, no mesmo trabalho: o registro do primeiro acesso deixou de ser licao de casa. O Google so poe o notebook na conta depois de uma INTERACAO COM O CHAT (abrir o link nao basta), e essa interacao gasta uma das ~50 consultas diarias da conta gratuita - o mesmo custo do 'oi' manual. Pedir 13 no dia da instalacao queimava 13 da cota antes de o AFT trabalhar; automatizar os 47 queimava o dia. Entao o front-load caiu para 2 (os dois ementarios) e o resto virou SOB DEMANDA, sustentado pelo notebooklm_consulta.py, que distingue o not found (primeiro acesso pendente) das demais falhas e devolve o link na hora do uso. No caminho caiu o ultimo ID cravado do repositorio, na /aft-analise-acidente."
+    },
+    {
+      "topico": "Parâmetros do DET dentro da TN-NCO, e revisão em duas camadas (22/08/2026)",
+      "txt": "A /aft-tn-nco passou a gravar, no front-matter do .md que gera, os parâmetros que fazem a notificação existir no DET: prazo, tipo do item, tipo de retorno, pré-assinalado e tipos de arquivo aceitos, mais as exceções item a item. Antes o texto saía perfeito e mudo — prazo e retorno vinham da conversa e sumiam com ela. Padrão do toolkit: obrigação, retorno digital, 16 dias corridos, pré-assinalado. A precedência é chamada > front-matter > padrão, para o arquivo ser memória sem virar camisa de força. Junto veio a revisão em DUAS camadas: a mecânica no código (det_criar.revisar_payload, chamada pela própria criar_rascunho — item sem prazo, texto acima de 1000 caracteres, prazo no passado, item que pede documento sem aceitar arquivo e notificação sem introdução barram a escrita, e nada é enviado ao DET), e a de julgamento no subagente aft-revisor-notificacao (o retorno combina com o que o item pede? o prazo é exequível? a exigência é verificável?). A garantia NÃO foi confiada ao subagente: subagente pode ser pulado; a função no código, não."
+    },
+    {
+      "topico": "NAD preliminar: a notificação que se leva em mãos (22/08/2026)",
+      "txt": "A /aft-preparacao-acao-fiscal passou a oferecer, NO FIM, a NAD preliminar — a notificação que o AFT entrega na empresa e tem assinada durante a inspeção. No fim, e não no começo, porque só depois de levantar CNAE, grau de risco, acidentes e temas da denúncia se sabe se aquela OS pede documento além do padrão. O fluxo abre o DET no navegador do assistente para o AFT logar, puxa os itens do MODELO de notificação do DET (o toolkit passou a ler `modelositem`, que nunca tinha lido), passa pela prévia e pelo revisor, cria o rascunho e baixa o PDF DO RASCUNHO com 5 linhas em branco para impressão. Modelo canônico de fábrica: 11301/358070, trocável no aft-config.md. Corrigido junto o filtro de busca de modelos, que estava em 'somente meus modelos' e nunca achava modelo de colega."
+    },
+    {
+      "topico": "LRE do eSocial: painel na pasta da OS e o indicio de registro tardio (23/08/2026)",
+      "txt": "Nova /aft-lre-esocial le o arquivo que o SISFGTS grava ao baixar o eSocial (eSocial_idA_LRE_*.txt - JSON em latin-1, apesar da extensao .txt) e monta um painel navegavel na subpasta eSocial/ da OS, com cartao no /aft-painel. O indicio de registro tardio tem tres salvaguardas, todas nascidas de falso positivo real: (1) so admissoes a partir de 02/01/2026, quando o registro eletronico passou a valer para todas as empresas - antes a obrigatoriedade era escalonada por grupo, e apontar atraso ali faria o AFT perseguir vinculo talvez nao obrigado; (2) o campo e dhrecepcao (quando o eSocial recebeu o evento), nunca processamento_datahora, que e processamento interno e chegou a acusar 792 dias de atraso onde o real foram 4; (3) so admissao nova (tpadmissao=1), porque cedido, transferido de mesmo grupo, sucessao e mudanca de CPF carregam a data de admissao ORIGINAL - num caso real, 26 de 38 indicios eram cessao. O numero nunca e relatado sem o recorte temporal: '12 indicios entre as admissoes desde 02/01/2026', jamais '12 indicios'."
+    },
+    {
+      "topico": "Cadastro da Receita por CNPJ: via publica, nao a API do SIT (23/08/2026)",
+      "txt": "A /aft-nova-auditoria (Passo 1.5) e a /aft-preparacao-acao-fiscal (FASE 1.15) passaram a puxar sozinhas o cadastro da empresa na RFB quando ha CNPJ: razao social, situacao cadastral, CNAE principal e secundarios, endereco, telefones, natureza juridica, porte e Simples. O SISFGTS faz essa consulta pela API interna do SIT (apicpfcnpj.sit.trabalho.gov.br/api/v1.2/Empresas), mas ela exige token OAuth2 emitido com o client_id do aplicativo oficial - um script do toolkit usando esse client_id estaria se identificando ao SSO federal como se fosse o SISFGTS. Descartado por legitimidade, nao por dificuldade tecnica. A via publica (dados abertos da RFB, mesmo conteudo do cartao CNPJ) dispensa credencial e ainda traz QSA e CNAEs secundarios, que a rota do SIT nao retorna. Nao traz o e-mail do empregador (a RFB nao distribui esse campo no dado aberto: o mesmo dado aparece como ENDERECO ELETRONICO no cartao CNPJ) nem a data do lote - por isso as duas skills mandam confirmar na fonte oficial para ato com efeito legal. O dado do cadastro nunca sobrescreve o que o AFT informou: em divergencia prevalece o dele, com aviso de uma linha."
+    },
+    {
+      "topico": "Ferias e folha do eSocial: as duas analises derivadas do LRE (23/08/2026)",
+      "txt": "O download 'LRE e demais registros' do SISFGTS traz tambem afastamentos (idK) e bases de FGTS da folha (idM). Dois scripts novos os cruzam com o LRE: lre_ferias.py audita ferias (vencidas/dobra, gozo fora do prazo, vencendo, abono, fracionamento) e lre_folha.py audita a remuneracao declarada (buracos, 13o, contratual, bases rescisorias). A licao do teste com empresa real: a conta ingenua de ferias produzia 105 indicios, dos quais so 2 sobreviveram as protecoes (janela de dados, janela do vinculo transferido, abono presumido, minimo certo) - em dado de sucessao, quase tudo que parece dobra e ferias gozada no empregador anterior, fora do arquivo. tpValor 21/22 = bases rescisorias foi conferido empiricamente (so desligados; 61 de 62 dispensas sem justa causa); tpValor 13/14 seguem sem rotulo por falta de leiaute confirmado. Nota tecnica: lre-esocial-skill.md."
+    },
+    {
+      "topico": "Lições de uma fiscalização real: NCO exclui o autuado, autos padronizados, validador de forma (23/08/2026)",
+      "txt": "O PR 37 (Diego Negrão) trouxe um pacote de correções colhidas em fiscalização de verdade. A /aft-tn-nco inverteu a relação com os autos lavrados: a consulta ao Sistema Auditor (FASE 0.5) deixou de alimentar o checklist e passou a EXCLUIR dele o que já tem auto válido — o auto já é meio de coerção indireto, e notificar de novo o mesmo fato confunde a empresa; o caso típico da NCO vira a dupla visita, com autuação diferida. A /aft-auditoria-geral padronizou a leva: frase de abertura fixa por fonte (campo vs. documental), fechamento de enquadramento uniforme, máquina nomeada em cada auto (conferida na fonte primária) e trava de bis in idem entre ementa geral e específica da mesma NR. O validar_txt.py ganhou três checagens de forma que o Sistema Auditor importa sem reclamar (subtítulos I/II/III presentes, acentuação FISCALIZAÇÃO/OBSERVAÇÕES, recuo do indenta_quebras.py aplicado) — defeitos reais de 17/08/2026 que só apareciam conferindo o auto importado. O scan_autos.py passou a extrair porte econômico e nº de trabalhadores do primeiro auto lavrado e a completar o memory.md sem sobrescrever o que o AFT escreveu. E as três skills de documento longo (PGR/AET/AR-NR12) não reextraem documento cujo extrato já está na pasta da OS."
+    }
+  ],
+  "diferencas": [
+    {
+      "topico": "Plataforma",
+      "txt": "Pessoal: macOS/Parallels (iconv, sips). Toolkit: Windows, tudo em Python stdlib e latin-1 direto."
+    },
+    {
+      "topico": "Estado central",
+      "txt": "Pessoal: SISOS (Next.js + Supabase + Vercel) + cron de DET. Toolkit: memory.md locais + /aft-painel, sem servidor."
+    },
+    {
+      "topico": "Empacotamento",
+      "txt": "Pessoal: cada skill empacota. Toolkit: centralizado no /aft-gera-ai, com /aft-revisa-auto como gate de qualidade antes."
+    },
+    {
+      "topico": "Identidade do AFT",
+      "txt": "Pessoal: dados SRTE/GO hardcoded. Toolkit: aft-config.md + UORG resolvida pela cidade."
+    }
+  ],
+  "foraDoToolkit": [
+    "nad-tn — eixo B (--conteudo=docs, modo=texto) adaptado no toolkit como /aft-NAD (2026-07-13); o eixo A (--modo=template, automação Chrome+DET) e o eixo A de correção (--conteudo=correcao, que no toolkit já é a /aft-tn-nco) permanecem infra pessoal, não distribuídos.",
+    "det-baixar-empregador (Chrome + credenciais) — fase futura possível.",
+    "analise-preliminar (triagem de resposta documental ao DET) — infra pessoal, não distribuída.",
+    "cowork-ingest / cowork-manifest / cowork-ementas — pipeline RAG do NotebookLM (ecossistema pessoal).",
+    "cowork-sync / sisos-sync / notebooklm-conf / aft-grant — infra pessoal, não distribuída."
+  ],
+  "avisos": [
+    "As skills são apoio à redação e organização; o conteúdo jurídico de cada auto, termo e relatório é responsabilidade do AFT, que revisa tudo antes de transmitir.",
+    "Nunca aceite código de ementa, item de NR ou capitulação sem conferir no ementário oficial.",
+    "/aft-autos-lavrados: a extração por pypdf precisa de calibração/verificação na 1ª execução contra os PDFs reais do Sistema Auditor.",
+    "O template do RT (aft-embargo-interdicao/template.docx) segue o modelo SRTE/GO — auditores de outras SRTEs ajustam o cabeçalho.",
+    "/aft-atualizar atualiza o notebooklm-py automaticamente, sem perguntar antes — é uma dependência de terceiro (teng-lin/notebooklm-py) fora do controle de versão do toolkit.",
+    "As skills com model: claude-opus-4-8[1m] dependem do plano do AFT ter acesso ao modelo — o /aft-doctor testa e explica em linguagem simples se faltar.",
+    "A detecção de notificações DET do /aft-painel é heurística (pode dar falso positivo) — o AFT confere antes de cadastrar.",
+    "Validação end-to-end de /aft-NR12, /aft-NR18, /aft-tn-nco e do fluxo de Artifact do /aft-painel depende de interação e de máquina real com o app logado; testar no Windows real.",
+    "No Codex o model: de cada skill é ignorado (lá o modelo vale para a conversa inteira): as skills que julgam documento da empresa — PGR, AET, acidente, laudo de NR-12 e manutenção de interdição — avisam em uma linha que pedem o modelo mais forte e esperam o AFT trocar com /model."
+  ]
 }

--- a/novidades/2026-08-25-02-conferencias-antes-de-encerrar.md
+++ b/novidades/2026-08-25-02-conferencias-antes-de-encerrar.md
@@ -1,0 +1,10 @@
+## 25/08/2026
+<!-- commit: conferencias-antes-de-encerrar -->
+
+**Duas conferências novas, para nada passar batido no fim de uma fiscalização.** A primeira compara os registros de auto do `memory.md` entre si e mostra onde eles se contradizem: caixa marcada com o texto ao lado dizendo "pendente de importação", caixa marcada sem número de auto, caixa vazia com o número já escrito. Numa fiscalização real dois desses registros discordaram, e a contradição só apareceu tarde. A conferência não decide nada nem escreve no seu arquivo: ela aponta, e quem corrige é você.
+
+A segunda faz o cotejo do que entrou na auditoria: lista o documento e a foto que a empresa entregou e que nunca foram mencionados em análise nenhuma. É o caso do anexo que chega junto com quinze outros e some do radar. Antes de encerrar, ou o documento é confrontado, ou fica registrado por que não foi.
+
+Peça "confere o rastreamento dos autos dessa OS" ou "o que entrou nessa auditoria e nunca foi analisado".
+
+---

--- a/novidades/2026-08-25-03-tokenizar-nomes.md
+++ b/novidades/2026-08-25-03-tokenizar-nomes.md
@@ -1,0 +1,8 @@
+## 25/08/2026
+<!-- commit: tokenizar-nomes -->
+
+**A troca do nome do trabalhador pelo apelido `[[TRAB_01]]` deixou de ser feita à mão.** O caminho de volta já era automático: na hora de gerar o arquivo do Sistema Auditor, um programa troca o apelido pelo nome verdadeiro, letra por letra, sem o assistente participar — porque um nome errado num auto é inaceitável. O caminho de ida, porém, dependia de o assistente digitar o nome no arquivo de correspondência. Agora ele também é feito por programa: você informa o nome, o programa cria o apelido, substitui no texto e depois confere se sobrou algum nome verdadeiro ou algum CPF perdido no arquivo.
+
+A conferência responde APROVADO ou REPROVADO antes de o texto virar auto. Ela recusa CPF de trabalhador no arquivo de correspondência (o Sistema Auditor não usa esse campo) e nunca renumera um apelido já usado num auto.
+
+---

--- a/novidades/2026-08-25-04-extrato-pdf-fim-do-documento.md
+++ b/novidades/2026-08-25-04-extrato-pdf-fim-do-documento.md
@@ -1,0 +1,8 @@
+## 25/08/2026
+<!-- commit: extrato-pdf-fim-do-documento -->
+
+**O extrato de um PDF agora termina dizendo que terminou.** Quando um documento longo é preparado para leitura, o texto extraído passa a se encerrar com uma linha de fecho que traz o nome do arquivo, o número de páginas e o tamanho. Sem ela, uma leitura interrompida no meio era indistinguível de uma leitura completa — e nada no texto denunciava a diferença. Foi o que aconteceu com um requerimento de fiscalização lido até o meio da segunda página: a lista de pedidos foi dada por encerrada com cinco itens, e tinha oito.
+
+Se essa linha de fecho não aparecer, faltou documento.
+
+---

--- a/novidades/2026-08-25-05-acentos-na-tela-e-ajuda.md
+++ b/novidades/2026-08-25-05-acentos-na-tela-e-ajuda.md
@@ -1,0 +1,10 @@
+## 25/08/2026
+<!-- commit: acentos-na-tela-e-ajuda -->
+
+**Três incômodos pequenos do dia a dia, resolvidos.** A consulta de CNPJ mostrava a razão social e a descrição da atividade com os acentos corrompidos na tela do Windows ("Fabricação" virava "Fabrica??ão"). O dado sempre chegou correto: estragava só na hora de aparecer — o problema é que quem copiava da tela para um documento levava a corrupção junto. Agora a tela mostra o texto certo.
+
+O detector de palavras sem acento nas minutas ficou mais fino: passou a ignorar a razão social da empresa (que é escrita como está no cartão do CNPJ, não como o português pediria), reconhece mais 42 palavras de segurança e saúde, e parou de acusar "analise", que tanto pode ser o verbo quanto o substantivo.
+
+E as ferramentas internas passaram a responder à pergunta "como se usa isto?" com a ajuda, em vez de registrarem um defeito do toolkit. Antes, perguntar como usar gerava um relato de erro.
+
+---

--- a/novidades/2026-08-25-06-tn-nco-ordem-e-revisao.md
+++ b/novidades/2026-08-25-06-tn-nco-ordem-e-revisao.md
@@ -1,0 +1,8 @@
+## 25/08/2026
+<!-- commit: tn-nco-ordem-e-revisao -->
+
+**A notificação para correção sai organizada por norma, e revisada antes de chegar até você.** Os itens agora vêm agrupados em ordem crescente de NR, da NR-01 à NR-38. Numa fiscalização real a notificação saiu com as normas embaralhadas e foi devolvida como "muito confusa"; agrupada, o empregador enxerga de uma vez o que resolve com cada consultoria — o PGR num bloco, o PCMSO noutro, as máquinas noutro. Item que só tem CLT ou Portaria na base legal vai para o fim, e você é avisado: nunca se inventa uma NR só para o item caber na ordem.
+
+A revisão da notificação também mudou de lugar. Ela rodava depois de você já ter lido e aprovado o texto — o que transformava o Auditor-Fiscal em revisor de primeira linha. Agora roda antes, e o parecer chega junto com o teor. Numa fiscalização real isso teria apanhado um item cujo cumprimento dependia do produto de outro item, com os dois correndo o mesmo prazo em paralelo.
+
+---


### PR DESCRIPTION
## Resumo

Conjunto de scripts e ajustes internos, do uso real do toolkit em 25/08/2026:

- `aft-tn-nco`: itens da notificação saem em ordem crescente de NR.
- `consulta_cnpj.py`: reconfigura stdout para UTF-8 (acentos corretos na tela).
- `checar_acentos.py`: ignora a razão social ao conferir acentuação, acrescenta rede de palavras por terminação, +42 palavras de SST, corrige saída de "analise" (que é verbo), e `-h/--help` responde com ajuda em vez de gerar ticket de erro.
- `conferir_rastreamento.py` (novo): acha contradição nos registros de auto entre memory.md, Relação Provisória e autos-lavrados; pasta sem memory.md vira erro de uso, não falso positivo.
- `conferir_cotejo.py` (novo): acha documento e foto que nunca foram analisados na auditoria.
- `tokenizar.py` (novo): fecha o sentido de IDA da pseudonimização (monta o de-para, em vez de só a volta via rehydrate.py).
- `pdf_texto_paginado.py`: fecha o extrato com marcador de FIM DO DOCUMENTO.
- `_scripts` (geral): `-h/--help` responde com ajuda, não com ticket de erro.

## Nota sobre o histórico

Mesma situação de PRs anteriores: a branch foi recriada por cima do `main` atual (rebase manual via cherry-pick) porque o repositório local havia divergido do `origin/main`. Conteúdo idêntico ao que já rodava localmente, só os hashes mudaram.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)