### PR TITLE
docs(aft-ajuda): instalação da Sync DET v4, sem a caixa "Painel local"

### DIFF
--- a/aft-ajuda/SKILL.md
+++ b/aft-ajuda/SKILL.md
@@ -7,7 +7,9 @@ description: >
   Use quando o AFT tiver duvida sobre como o proprio AFT Toolkit funciona, ou
   quando estiver perdido nele. Acione com "/aft-ajuda", "como funciona isso",
   "por onde eu comeco", "o que eu faco agora", "nao sei usar", "me explica o
-  painel", "como funciona a extensao do navegador", "o que e o DET aqui",
+  painel", "como funciona a extensao do navegador", "como instalo a extensao",
+  "instalar a extensao do chrome", "o botao sincronizar nao aparece",
+  "o que e o DET aqui",
   "o que e esse NotebookLM", "de onde vem a ementa", "onde ficam meus
   arquivos", "o que e o memory.md", "meus dados vao para a internet?", "que
   programas rodam na minha maquina", "qual habilidade faz tal coisa", "que

--- a/aft-ajuda/references/painel-det-extensao.md
+++ b/aft-ajuda/references/painel-det-extensao.md
@@ -60,17 +60,41 @@ O **servidor do painel precisa estar ligado**. Quem instalou pelo `/aft-setup` j
 
 ### Instalando (uma vez só)
 
-1. Abrir a página da extensão na loja do Chrome e clicar em **Usar no Chrome**:
-   `https://chromewebstore.google.com/detail/sync-det-%E2%80%94-sisos-aft-tool/khmecjbidgcndmgmkbpfncjgmmfehiem`
-   No **Microsoft Edge** o caminho é o mesmo link — a loja pede só uma confirmação a mais ("Permitir extensões de outras lojas") e o botão vira **Instalar**.
-2. **Fixar na barra do navegador**: clicar no ícone de quebra-cabeça (🧩) e depois no alfinete ao lado de "Sync DET". Assim ela fica sempre à vista.
-3. Clicar no ícone da extensão. Na primeira abertura aparece a tela de configuração: **marcar a caixa PAINEL LOCAL (AFT TOOLKIT)** e clicar em **Salvar**. É a única configuração necessária.
-4. Os campos **URL do SisOS** e **Token de acesso** ficam **em branco** — pertencem a outro modo de uso (o SisOS, um sistema na nuvem), desnecessário com o painel local. O endereço `http://127.0.0.1:8347` que já aparece no campo do painel é o padrão: não mexer.
+São quatro passos, e **nenhuma configuração**: desde a versão 4.0 a extensão já
+chega pronta, porque o painel do computador é o único destino que ela conhece.
+
+**Passo 1 — abrir a página da extensão na loja:**
+
+```
+https://chromewebstore.google.com/detail/sync-det-%E2%80%94-aft-toolkit/khmecjbidgcndmgmkbpfncjgmmfehiem?authuser=0&hl=pt-BR
+```
+
+**Passo 2 — clicar em "Usar no Chrome"** e confirmar em **Adicionar extensão**.
+No **Microsoft Edge** é o mesmo link: a loja pede uma confirmação a mais
+("Permitir extensões de outras lojas") e o botão passa a ser **Instalar**.
+
+**Passo 3 — conferir se ela ficou ativada.** Abrir `chrome://extensions` (no
+Edge, `edge://extensions`) e procurar **Sync DET — AFT Toolkit**: a chavinha do
+canto do cartão tem de estar **azul/ligada**. Vale também fixá-la na barra:
+clicar no ícone de quebra-cabeça (🧩) e depois no alfinete ao lado do nome.
+
+**Passo 4 — testar no DET.** Entrar no DET (`auditor-det.sit.trabalho.gov.br`)
+com o login **gov.br** e olhar o **canto inferior direito** da tela: tem de
+aparecer um botão flutuante escrito **Sincronizar**. Apareceu, está funcionando.
+
+Se o botão não aparecer, é quase sempre uma destas três coisas: a extensão não
+está ativada (passo 3), a página do DET foi aberta **antes** de a extensão ser
+instalada (basta apertar F5) ou o login do gov.br ainda não foi concluído.
 
 ### Usando no dia a dia
 
 1. Entrar no DET normalmente (`auditor-det.sit.trabalho.gov.br`), com o login **gov.br**. Só de navegar logado, a extensão captura sozinha a **chave de sessão** que o próprio site já usa — pense nela como o crachá que o DET entrega na entrada. O AFT não copia, não cola e **não digita senha nenhuma na extensão**.
-2. Clicar no botão flutuante **Sincronizar**, no canto direito, no final da página do DET.
+2. Na maior parte do tempo **não é preciso clicar em nada**: enquanto o DET
+   estiver aberto, a extensão entrega a chave ao painel sozinha, e o painel
+   mantém as fichas em dia. O botão flutuante **Sincronizar**, no **canto
+   inferior direito** da página do DET, força a varredura completa de todas as
+   OS na hora — útil quando o AFT acabou de lavrar uma notificação e quer vê-la
+   no painel imediatamente.
 
 ### O que acontece e o que aparece
 
@@ -151,6 +175,7 @@ Espelha no Google Calendar do AFT os prazos das notificações DET de todas as O
 | **"Token DET não capturado"** | A extensão ainda não viu o AFT navegar logado. | Abrir qualquer página interna do DET (a lista de notificações, por exemplo) e clicar em **Sincronizar** de novo. |
 | **Sincronizou, mas a notificação não apareceu** | A OS não tem como ser ligada ao empregador, ou a notificação é de outro RI. | Conferir se a ficha (`memory.md`) da OS tem o **CNPJ ou CPF**: sem ele o painel não sabe qual empregador consultar no DET. Se o aviso disse que houve notificações **ignoradas**, é o caso de RI de outra fiscalização — conferir o campo `ri:` da ficha. |
 | **Botões do painel não respondem** | O painel foi aberto por duplo clique no arquivo, e não pelo endereço do servidor — nesse modo ele é somente leitura. | Abrir pelo endereço `http://127.0.0.1:8347`, com o servidor ligado. |
+| **O botão flutuante sumiu, ou parou de responder, depois de uma atualização** | O Chrome atualiza extensões sozinho, em segundo plano. Se isso acontecer com a página do DET já aberta, a parte da extensão que vive dentro daquela página fica desligada. | **Apertar F5 na página do DET.** É só isso. A extensão avisa isso na própria tela quando o AFT clica em Sincronizar. |
 | **`/aft-det-baixar` diz que o token expirou** | A chave de sessão vale ~25 minutos. | Voltar à aba do DET, logado, e clicar em **Sincronizar**; depois repetir o download. |
 
 ---

--- a/novidades/2026-08-24-07-extensao-sync-det-v4.md
+++ b/novidades/2026-08-24-07-extensao-sync-det-v4.md
@@ -1,0 +1,43 @@
+## 24/08/2026
+
+<!-- commit: extensao-sync-det-v4 -->
+
+**A extensão do navegador ficou mais simples: agora é só instalar.** A Sync DET
+— a extensão que traz as notificações do DET para o painel — foi republicada na
+Chrome Web Store na **versão 4.0**, e a instalação deixou de ter configuração
+nenhuma.
+
+Antes, depois de instalar, você ainda precisava clicar no ícone da extensão e
+marcar uma caixa chamada "Painel local" para ela começar a funcionar. Quem não
+marcasse ficava com uma extensão instalada que não fazia nada, sem nenhum aviso
+do porquê. Essa caixa existia porque a extensão podia mandar os dados para dois
+lugares: o seu computador ou um sistema na nuvem. **O modo nuvem foi removido**
+— agora o único destino é o painel na sua máquina, então não havia mais nada a
+escolher. A caixa saiu.
+
+São quatro passos, e o último é só conferir que deu certo:
+
+1. abrir a página da extensão na loja;
+2. clicar em "Usar no Chrome" e confirmar;
+3. conferir em `chrome://extensions` que ela está ativada;
+4. entrar no DET e ver se aparece o botão flutuante **Sincronizar**, no canto
+   inferior direito da tela.
+
+O passo a passo completo, com o link e o que fazer se o botão não aparecer, está
+no `/aft-ajuda` — é só perguntar "como instalo a extensão".
+
+**Duas melhorias que vêm junto**, e que você não precisa fazer nada para ter:
+
+- A extensão passou a **enviar sozinha**, enquanto você navega no DET. O botão
+  Sincronizar continua lá, para forçar a atualização de todas as fichas na hora,
+  mas no dia a dia não é mais preciso clicar em nada.
+- Quando o Chrome atualiza a extensão em segundo plano e você está com o DET
+  aberto, a parte dela que vive dentro daquela página fica desligada. Antes isso
+  fazia a sincronização parar **em silêncio**. Agora a extensão percebe e avisa
+  na própria tela: recarregue a página (F5) e pronto.
+
+Ela continua sendo 100% local: nada é enviado para a internet, e a política de
+privacidade agora mora no próprio toolkit
+(https://ryckardo42.github.io/aft-toolkit/privacidade.html).
+
+---


### PR DESCRIPTION
A extensão Sync DET foi republicada na Chrome Web Store na **versão 4.0** e a instalação deixou de ter configuração: o modo nuvem saiu, o painel local virou o único destino, e a caixa que era preciso marcar depois de instalar deixou de existir. A `arquitetura/Extensao Chrome/` já registrava a v4 — faltava o lado do AFT.

- **`references/painel-det-extensao.md`**: os quatro passos da instalação, sendo o passo 4 a **conferência** (o botão flutuante aparece no DET?) e as três causas de ele não aparecer. O quadro de problemas ganha a atualização silenciosa do Chrome, que desliga a parte da extensão que vive na página já aberta — o conserto é F5, e antes disso a sincronização parava sem avisar.
- **`SKILL.md`**: o `description` passa a casar com "como instalo a extensão", "instalar a extensão do chrome" e "o botão sincronizar não aparece", que são as frases com que o AFT chega a essa dúvida.
- **`novidades/`**: a entrada do changelog.

Só documentação — nenhum script muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)