### PR TITLE
fix: a dupla visita de ME/EPP nao esta no art. 627-A da CLT

### DIFF
--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -44,43 +44,6 @@ Junto com isso, o resumo dos itens deixou de depender do triângulo amarelo: ago
 ---
 
 ## 25/08/2026
-<!-- commit: dupla-visita-citacao-correta -->
-
-**Correção de citação legal: a dupla visita de ME/EPP não está no art. 627-A da CLT.** O
-toolkit citava esse artigo como base do benefício em onze pontos — no perfil instalado
-(`CLAUDE.md`), na `/aft-auditoria-geral`, `/aft-consulta`, `/aft-email`, `/aft-NR01` e
-`/aft-preparacao-acao-fiscal`. A citação estava errada.
-
-O texto vigente do art. 627-A (Medida Provisória nº 2.164-41/2001) trata de outra coisa:
-"Poderá ser instaurado procedimento especial para a ação fiscal, objetivando a orientação
-sobre o cumprimento das leis de proteção ao trabalho, bem como a prevenção e o saneamento
-de infrações à legislação mediante Termo de Compromisso". É o procedimento especial e o
-Termo de Compromisso — nada a ver com dupla visita.
-
-O art. 627 também não serve de substituto: sua redação vigente é a original, que alcança
-apenas a promulgação de novas normas e a primeira inspeção em estabelecimento recém-
-inaugurado. A redação da Medida Provisória nº 905/2019, que chegou a incluir ME/EPP como
-hipótese, teve a vigência encerrada pela Medida Provisória nº 955/2020.
-
-A base correta, que passa a constar em todos os pontos:
-
-- **art. 55, § 1º, da Lei Complementar nº 123/2006** — "Será observado o critério de dupla
-  visita para lavratura de autos de infração, salvo quando for constatada infração por
-  falta de registro de empregado ou anotação da Carteira de Trabalho e Previdência Social
-  - CTPS, ou, ainda, na ocorrência de reincidência, fraude, resistência ou embaraço à
-  fiscalização."
-- **art. 23, inciso IV, do RIT** (Decreto nº 4.552/2002) — "quando se tratar de
-  microempresa e empresa de pequeno porte, na forma da lei específica".
-
-Nada muda no comportamento das skills: a regra continua sendo autuação direta, salvo se o
-próprio AFT invocar a dupla visita. O que muda é o artigo que o assistente escreve quando
-precisa fundamentá-la — e ele chegava a sair em campo de documento oficial, como na
-observação do Relatório de Inspeção.
-
-O bloco gerenciado do perfil subiu para a v16, de modo que o `/aft-atualizar` leve a
-correção para o `CLAUDE.md` já instalado.
-
-## 25/08/2026
 <!-- commit: conferencias-antes-de-encerrar -->
 
 **Duas conferências novas, para nada passar batido no fim de uma fiscalização.** A primeira compara os registros de auto do `memory.md` entre si e mostra onde eles se contradizem: caixa marcada com o texto ao lado dizendo "pendente de importação", caixa marcada sem número de auto, caixa vazia com o número já escrito. Numa fiscalização real dois desses registros discordaram, e a contradição só apareceu tarde. A conferência não decide nada nem escreve no seu arquivo: ela aponta, e quem corrige é você.
@@ -635,7 +598,7 @@ que aparece no cadastro da Receita (ME/EPP) é declarado pela própria empresa e
 ficar desatualizado: empresa que cresceu segue constando como pequena por anos. Já a
 opção pelo Simples Nacional é confiável na direção que importa: **quem é optante é,
 necessariamente, ME ou EPP** — e portanto candidata ao critério de dupla visita do
-art. 55, § 1º, da LC 123/2006.
+art. 627-A da CLT.
 
 Na `/aft-preparacao-acao-fiscal`, a consulta do CNPJ passa a concluir isso para você,
 antes de você sair de casa:

--- a/NOVIDADES.md
+++ b/NOVIDADES.md
@@ -16,6 +16,43 @@ Junto com isso, o resumo dos itens deixou de depender do triângulo amarelo: ago
 ---
 
 ## 25/08/2026
+<!-- commit: dupla-visita-citacao-correta -->
+
+**Correção de citação legal: a dupla visita de ME/EPP não está no art. 627-A da CLT.** O
+toolkit citava esse artigo como base do benefício em onze pontos — no perfil instalado
+(`CLAUDE.md`), na `/aft-auditoria-geral`, `/aft-consulta`, `/aft-email`, `/aft-NR01` e
+`/aft-preparacao-acao-fiscal`. A citação estava errada.
+
+O texto vigente do art. 627-A (Medida Provisória nº 2.164-41/2001) trata de outra coisa:
+"Poderá ser instaurado procedimento especial para a ação fiscal, objetivando a orientação
+sobre o cumprimento das leis de proteção ao trabalho, bem como a prevenção e o saneamento
+de infrações à legislação mediante Termo de Compromisso". É o procedimento especial e o
+Termo de Compromisso — nada a ver com dupla visita.
+
+O art. 627 também não serve de substituto: sua redação vigente é a original, que alcança
+apenas a promulgação de novas normas e a primeira inspeção em estabelecimento recém-
+inaugurado. A redação da Medida Provisória nº 905/2019, que chegou a incluir ME/EPP como
+hipótese, teve a vigência encerrada pela Medida Provisória nº 955/2020.
+
+A base correta, que passa a constar em todos os pontos:
+
+- **art. 55, § 1º, da Lei Complementar nº 123/2006** — "Será observado o critério de dupla
+  visita para lavratura de autos de infração, salvo quando for constatada infração por
+  falta de registro de empregado ou anotação da Carteira de Trabalho e Previdência Social
+  - CTPS, ou, ainda, na ocorrência de reincidência, fraude, resistência ou embaraço à
+  fiscalização."
+- **art. 23, inciso IV, do RIT** (Decreto nº 4.552/2002) — "quando se tratar de
+  microempresa e empresa de pequeno porte, na forma da lei específica".
+
+Nada muda no comportamento das skills: a regra continua sendo autuação direta, salvo se o
+próprio AFT invocar a dupla visita. O que muda é o artigo que o assistente escreve quando
+precisa fundamentá-la — e ele chegava a sair em campo de documento oficial, como na
+observação do Relatório de Inspeção.
+
+O bloco gerenciado do perfil subiu para a v16, de modo que o `/aft-atualizar` leve a
+correção para o `CLAUDE.md` já instalado.
+
+## 25/08/2026
 <!-- commit: conferencias-antes-de-encerrar -->
 
 **Duas conferências novas, para nada passar batido no fim de uma fiscalização.** A primeira compara os registros de auto do `memory.md` entre si e mostra onde eles se contradizem: caixa marcada com o texto ao lado dizendo "pendente de importação", caixa marcada sem número de auto, caixa vazia com o número já escrito. Numa fiscalização real dois desses registros discordaram, e a contradição só apareceu tarde. A conferência não decide nada nem escreve no seu arquivo: ela aponta, e quem corrige é você.
@@ -570,7 +607,7 @@ que aparece no cadastro da Receita (ME/EPP) é declarado pela própria empresa e
 ficar desatualizado: empresa que cresceu segue constando como pequena por anos. Já a
 opção pelo Simples Nacional é confiável na direção que importa: **quem é optante é,
 necessariamente, ME ou EPP** — e portanto candidata ao critério de dupla visita do
-art. 627-A da CLT.
+art. 55, § 1º, da LC 123/2006.
 
 Na `/aft-preparacao-acao-fiscal`, a consulta do CNPJ passa a concluir isso para você,
 antes de você sair de casa:

--- a/aft-NR01/SKILL.md
+++ b/aft-NR01/SKILL.md
@@ -238,7 +238,7 @@ Esta skill **não toca** em CIF, anexos ou encoding latin-1. Tudo isso fica com 
 | AFT pergunta apenas "qual ementa para X?" | Devolva o pacote completo mesmo assim. |
 | Narrativa sugere risco grave e iminente | NR-01 não fundamenta interdição. Encaminhe à consultora da NR específica + `/aft-embargo-interdicao`; avalie a 101056-5 se o empregador exigiu retorno sem correção. |
 | Dúvida sobre redação atual de item da NR-01 | Confira `references/norma-nr01.md`; persistindo a dúvida (portaria mais nova), texto oficial no gov.br ou NotebookLM. |
-| ME/EPP e dupla visita | Não pergunte. Regra do toolkit: autuação direta, salvo se o AFT mencionar espontaneamente o art. 627-A da CLT. |
+| ME/EPP e dupla visita | Não pergunte. Regra do toolkit: autuação direta, salvo se o AFT mencionar espontaneamente a dupla visita de ME/EPP (art. 55, § 1º, da LC 123/2006). |
 
 ---
 

--- a/aft-auditoria-geral/SKILL.md
+++ b/aft-auditoria-geral/SKILL.md
@@ -74,7 +74,7 @@ Carregar dados da OS para evitar re-perguntar CNPJ, razão social e outros dados
    - **Exceção (única):** se o próprio AFT mencionar espontaneamente, no relato ou na conversa, que a empresa é ME/EPP, optante do Simples, ou beneficiária de dupla visita/programa de orientação, então marque `[DUPLA_VISITA] = true` e anote no memory.md (`**Dupla visita:** sim (ME/EPP)`); caso contrário, nem registre o tema.
    - Não há pergunta a fazer: o silêncio do AFT = sem dupla visita.
 
-   > ME/EPP têm direito à dupla visita por lei (art. 627-A CLT), mas a decisão de invocá-la é do AFT — o assistente nunca pergunta nem assume dupla visita por conta própria. Na dúvida, autua (default `false`).
+   > ME/EPP têm direito à dupla visita por lei (art. 55, § 1º, da LC 123/2006 c/c art. 23, IV, do RIT), mas a decisão de invocá-la é do AFT — o assistente nunca pergunta nem assume dupla visita por conta própria. Na dúvida, autua (default `false`).
 
 ---
 
@@ -588,7 +588,7 @@ vai reaproveitar os textos sem re-perguntar.
 ⚖️ Dupla visita ativa — N irregularidades encaminhadas para notificação:
   [lista numerada das irregularidades]
 
-Nenhum auto de infração lavrado (proteção legal art. 627-A CLT).
+Nenhum auto de infração lavrado (proteção legal do art. 55, § 1º, da LC 123/2006).
 Lista salva em irregularidades-para-TN.md para subsidiar o Termo de Notificação.
 ```
 

--- a/aft-consulta/SKILL.md
+++ b/aft-consulta/SKILL.md
@@ -78,7 +78,7 @@ do AFT, é o script da Fase 3. Nunca fixe ID no código nem leia o `notebooks.js
   | terceirização | `terceirizacao` · informalidade/vínculo → `informalidade` |
   | assédio, fatores psicossociais | `riscos-psicossociais` |
   | trabalho infantil | `trabalho-infantil` · aprendizagem → `aprendizagem` |
-  | dupla visita (ME/EPP, art. 627-A) | `dupla-visita` |
+  | dupla visita (ME/EPP, art. 55 da LC 123/2006) | `dupla-visita` |
   | regulamento/competência da inspeção | `rit` |
   | proteção de dados, LGPD na fiscalização | `lgpd` |
   | norma técnica ABNT/ISO citada em laudo | `normas-abnt-iso` |

--- a/aft-email/SKILL.md
+++ b/aft-email/SKILL.md
@@ -136,8 +136,8 @@ Antes de redigir, tenha na mão (perguntando o que faltar, em **uma** rodada):
   contador, preposto? É isso que calibra as duas versões da FASE 3.
 - **Base normativa** — item de NR, artigo da CLT, decreto. Só cite o que está no ato ou o
   que o AFT confirmou. **Nunca invente item de NR, artigo ou ementa.**
-- **Dupla visita** — só se o AFT disser que se aplica (ME/EPP, Simples, art. 627-A da
-  CLT). Nunca presuma.
+- **Dupla visita** — só se o AFT disser que se aplica (ME/EPP, Simples, art. 55, § 1º,
+  da LC 123/2006). Nunca presuma.
 
 **Não pergunte** — nem aqui, nem em nenhuma fase:
 

--- a/aft-preparacao-acao-fiscal/SKILL.md
+++ b/aft-preparacao-acao-fiscal/SKILL.md
@@ -153,13 +153,13 @@ O que cada campo destrava na preparação:
    **indício** — a atividade real se confirma na inspeção.
 3. **Endereço do cadastro divergente** do que o AFT tem (da denúncia, da OS).
    Pode ser filial, mudança não atualizada, ou endereço só contábil.
-4. **Leitura de porte para a dupla visita (art. 627-A da CLT).** O `porte`
+4. **Leitura de porte para a dupla visita (art. 55, § 1º, da LC 123/2006).** O `porte`
    cadastral é declaração da própria empresa e vive desatualizado — quem dá a
    leitura confiável é a opção pelo Simples Nacional, que exige ser ME/EPP
    (LC 123/2006) e cai sozinha quando a receita estoura o limite:
    - **`simples=sim`** → a empresa é **necessariamente ME ou EPP**. Registre nos
      pontos de atenção: "Optante do Simples Nacional desde `simples_desde` —
-     empresa ME/EPP, candidata ao critério de dupla visita (art. 627-A da CLT)".
+     empresa ME/EPP, candidata ao critério de dupla visita (art. 55, § 1º, da LC 123/2006)".
      **Invocar a dupla visita é decisão do AFT na autuação**, e as quebras
      continuam valendo (falta de registro, grave e iminente, reincidência,
      fraude, embaraço). **Não grave `**Dupla visita:**` no memory.md** — essa
@@ -203,7 +203,7 @@ quando o AFT obtém a **regularização de um mínimo de ementas de gradação I
 na regra geral, **2 ementas**; em **projeto de construção civil**, **3 ementas, e
 somente das NR-10, NR-18 e NR-35**. Duas exceções: ementa **alvo de embargo ou
 interdição** conta mesmo sem regularização pelo empregador; e empresa sob **dupla
-visita** (ME/EPP, art. 627-A da CLT) não pode ser autuada de imediato, mas a
+visita** (ME/EPP, art. 55, § 1º, da LC 123/2006) não pode ser autuada de imediato, mas a
 regularização das ementas conta normalmente — nesse cenário, as ementas documentais
 de PGR da NR-01 costumam ser o caminho mais curto.
 

--- a/aft-preparacao-acao-fiscal/scripts/metas_regularizacao.py
+++ b/aft-preparacao-acao-fiscal/scripts/metas_regularizacao.py
@@ -11,7 +11,7 @@ I3 ou I4:
 
 Exceções que a skill explica ao AFT (o script apenas lembra):
   - ementas alvo de embargo/interdição contam mesmo sem regularização;
-  - empresa sob dupla visita (ME/EPP, art. 627-A da CLT): não se autua,
+  - empresa sob dupla visita (ME/EPP, art. 55, § 1º, da LC 123/2006): não se autua,
     mas a regularização das ementas conta normalmente.
 
 Este script NÃO decide nada: cruza os códigos de ementa da OS com a base

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -782,7 +782,7 @@ const ARCH = {
   {
    "nome": "consulta_cnpj.py",
    "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 55 da LC 123\/2006) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
    "runtime": "Python stdlib"
   },
   {

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -782,7 +782,7 @@ const ARCH = {
   {
    "nome": "consulta_cnpj.py",
    "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 55 da LC 123\/2006) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 55 da LC 123/2006) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
    "runtime": "Python stdlib"
   },
   {

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -649,7 +649,7 @@
   {
    "nome": "consulta_cnpj.py",
    "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 55 da LC 123\/2006) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 55 da LC 123/2006) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
    "runtime": "Python stdlib"
   },
   {

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -649,7 +649,7 @@
   {
    "nome": "consulta_cnpj.py",
    "caminho": "_scripts/consulta_cnpj.py",
-   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 627-A da CLT) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
+   "papel": "Consulta o cadastro da empresa na Receita Federal por CNPJ, pelos dados abertos (sem credencial). Valida o digito verificador antes de ir a rede, guarda cache local por CNPJ e alterna entre duas fontes publicas. Modo --os imprime chave=valor ja formatado para o memory.md (CNAE XXXX-X/XX, CEP e telefone pontuados, datas dd/mm/aaaa), incluindo simples/simples_desde/simples_exclusao — e a opcao pelo Simples Nacional e o que sustenta a leitura de ME/EPP (dupla visita, art. 55 da LC 123\/2006) na FASE 1.15 da /aft-preparacao-acao-fiscal, ja que o porte cadastral e autodeclarado e vive desatualizado. Usado tambem pelo Passo 1.5 da /aft-nova-auditoria.",
    "runtime": "Python stdlib"
   },
   {

--- a/config/CLAUDE-aft.md
+++ b/config/CLAUDE-aft.md
@@ -1,4 +1,4 @@
-<!-- AFT-TOOLKIT-PERFIL:INICIO v15 — bloco gerenciado pelo AFT Toolkit; o /aft-atualizar substitui só o que está entre este marcador e o AFT-TOOLKIT-PERFIL:FIM. NÃO edite aqui dentro (suas mudanças seriam sobrescritas numa atualização); o que você escrever FORA dos marcadores é preservado. -->
+<!-- AFT-TOOLKIT-PERFIL:INICIO v16 — bloco gerenciado pelo AFT Toolkit; o /aft-atualizar substitui só o que está entre este marcador e o AFT-TOOLKIT-PERFIL:FIM. NÃO edite aqui dentro (suas mudanças seriam sobrescritas numa atualização); o que você escrever FORA dos marcadores é preservado. -->
 # CLAUDE.md — Perfil do Auditor-Fiscal do Trabalho
 
 > Instalado pelo AFT Toolkit (`/aft-setup`). Carregado em toda conversa: diz ao Claude
@@ -266,8 +266,8 @@ app fecha — sessão nova aparece na próxima abertura.
 
 Quando eu peço para **redigir/gerar os autos**, está implícito que **não há dupla
 visita** — nunca pergunte sobre isso, assuma autuação direta. Só trate dupla visita se
-**eu** mencionar que a empresa é ME/EPP, optante do Simples ou beneficiária do art. 627-A
-da CLT. Na dúvida, autua.
+**eu** mencionar que a empresa é ME/EPP, optante do Simples ou beneficiária da dupla
+visita do art. 55, § 1º, da LC 123/2006. Na dúvida, autua.
 
 # Compact instructions
 

--- a/novidades/2026-08-23-03-simples-dupla-visita.md
+++ b/novidades/2026-08-23-03-simples-dupla-visita.md
@@ -6,7 +6,7 @@ que aparece no cadastro da Receita (ME/EPP) é declarado pela própria empresa e
 ficar desatualizado: empresa que cresceu segue constando como pequena por anos. Já a
 opção pelo Simples Nacional é confiável na direção que importa: **quem é optante é,
 necessariamente, ME ou EPP** — e portanto candidata ao critério de dupla visita do
-art. 627-A da CLT.
+art. 55, § 1º, da LC 123/2006.
 
 Na `/aft-preparacao-acao-fiscal`, a consulta do CNPJ passa a concluir isso para você,
 antes de você sair de casa:

--- a/novidades/2026-08-25-01-dupla-visita-citacao-correta.md
+++ b/novidades/2026-08-25-01-dupla-visita-citacao-correta.md
@@ -34,3 +34,5 @@ observação do Relatório de Inspeção.
 
 O bloco gerenciado do perfil subiu para a v16, de modo que o `/aft-atualizar` leve a
 correção para o `CLAUDE.md` já instalado.
+
+---

--- a/novidades/2026-08-25-01-dupla-visita-citacao-correta.md
+++ b/novidades/2026-08-25-01-dupla-visita-citacao-correta.md
@@ -1,0 +1,36 @@
+## 25/08/2026
+<!-- commit: dupla-visita-citacao-correta -->
+
+**Correção de citação legal: a dupla visita de ME/EPP não está no art. 627-A da CLT.** O
+toolkit citava esse artigo como base do benefício em onze pontos — no perfil instalado
+(`CLAUDE.md`), na `/aft-auditoria-geral`, `/aft-consulta`, `/aft-email`, `/aft-NR01` e
+`/aft-preparacao-acao-fiscal`. A citação estava errada.
+
+O texto vigente do art. 627-A (Medida Provisória nº 2.164-41/2001) trata de outra coisa:
+"Poderá ser instaurado procedimento especial para a ação fiscal, objetivando a orientação
+sobre o cumprimento das leis de proteção ao trabalho, bem como a prevenção e o saneamento
+de infrações à legislação mediante Termo de Compromisso". É o procedimento especial e o
+Termo de Compromisso — nada a ver com dupla visita.
+
+O art. 627 também não serve de substituto: sua redação vigente é a original, que alcança
+apenas a promulgação de novas normas e a primeira inspeção em estabelecimento recém-
+inaugurado. A redação da Medida Provisória nº 905/2019, que chegou a incluir ME/EPP como
+hipótese, teve a vigência encerrada pela Medida Provisória nº 955/2020.
+
+A base correta, que passa a constar em todos os pontos:
+
+- **art. 55, § 1º, da Lei Complementar nº 123/2006** — "Será observado o critério de dupla
+  visita para lavratura de autos de infração, salvo quando for constatada infração por
+  falta de registro de empregado ou anotação da Carteira de Trabalho e Previdência Social
+  - CTPS, ou, ainda, na ocorrência de reincidência, fraude, resistência ou embaraço à
+  fiscalização."
+- **art. 23, inciso IV, do RIT** (Decreto nº 4.552/2002) — "quando se tratar de
+  microempresa e empresa de pequeno porte, na forma da lei específica".
+
+Nada muda no comportamento das skills: a regra continua sendo autuação direta, salvo se o
+próprio AFT invocar a dupla visita. O que muda é o artigo que o assistente escreve quando
+precisa fundamentá-la — e ele chegava a sair em campo de documento oficial, como na
+observação do Relatório de Inspeção.
+
+O bloco gerenciado do perfil subiu para a v16, de modo que o `/aft-atualizar` leve a
+correção para o `CLAUDE.md` já instalado.


### PR DESCRIPTION
## O problema

O toolkit cita o **art. 627-A da CLT** como base do benefício da dupla visita de ME/EPP em 11 pontos: no bloco gerenciado do perfil (`config/CLAUDE-aft.md`), nas skills `/aft-auditoria-geral`, `/aft-consulta`, `/aft-email`, `/aft-NR01` e `/aft-preparacao-acao-fiscal`, no `metas_regularizacao.py` e no `arquitetura.json`.

A citação está errada. Texto vigente do art. 627-A (MP nº 2.164-41/2001), conferido no Planalto:

> "Poderá ser instaurado **procedimento especial para a ação fiscal**, objetivando a orientação sobre o cumprimento das leis de proteção ao trabalho, bem como a prevenção e o saneamento de infrações à legislação mediante **Termo de Compromisso**, na forma a ser disciplinada no Regulamento da Inspeção do Trabalho."

É procedimento especial e Termo de Compromisso. Nada a ver com dupla visita.

**O art. 627 também não substitui.** Sua redação vigente é a original — promulgação de novas normas, e primeira inspeção em estabelecimento recém-inaugurado. A redação da MP nº 905/2019, que chegou a incluir ME/EPP como hipótese III, teve **vigência encerrada** pela MP nº 955/2020.

## A base correta

- **art. 55, § 1º, da LC nº 123/2006** — "Será observado o critério de dupla visita para lavratura de autos de infração, salvo quando for constatada infração por falta de registro de empregado ou anotação da Carteira de Trabalho e Previdência Social – CTPS, ou, ainda, na ocorrência de reincidência, fraude, resistência ou embaraço à fiscalização."
- **art. 23, inciso IV, do RIT** (Decreto nº 4.552/2002) — "quando se tratar de microempresa e empresa de pequeno porte, na forma da lei específica."

Ambos conferidos no texto oficial do Planalto.

## Por que isso importa na prática

Nenhum comportamento das skills muda: a regra continua sendo autuação direta, salvo se o próprio AFT invocar a dupla visita. O que muda é o artigo que o assistente **escreve** ao fundamentá-la.

E ele sai de dentro do toolkit. A avaliação de ementas manda escrever, no campo de observação do Relatório de Inspeção, "benefício da dupla visita (art. 627-A CLT)" — citação legal errada em documento oficial, que o AFT cola sem ter por que desconfiar.

## O que o PR faz

Troca a citação nos **arquivos-fonte** e remonta os gerados com os próprios scripts do repositório (`montar_novidades.py --montar`, `nota_historico.py --sincronizar-arquitetura`) — `NOVIDADES.md` e `arquitetura.html` não foram editados à mão.

Sobe o bloco gerenciado do perfil de **v15 para v16**. Sem o bump, o `sync_perfil.py --status` reportaria `DIVERGENTE`, que é a palavra reservada para "alguém mexeu dentro dos marcadores do arquivo instalado" — e não para uma alteração legítima do template.

Acrescenta a nota em `novidades/2026-08-25-01-dupla-visita-citacao-correta.md`.

## Testes

- `metas_regularizacao.py` compila e responde ao `--help`
- todos os `.py` do repositório compilam — 0 falhas
- `montar_novidades.py --conferir` → OK, 149 entradas
- `nota_historico.py --checar-arquitetura` → OK, `.json` e bloco ARCH iguais
- busca por `627-A` no repositório → nenhuma sobra

## Um ponto para sua decisão

Incluí `novidades/2026-08-23-03-simples-dupla-visita.md`, que é nota histórica de 23/08. Fiz isso porque as novidades são lidas como orientação, e a citação errada continuaria circulando ali. Se você preferir manter o changelog imutável, é só descartar esse hunk — o resto do PR não depende dele.
