### PR TITLE
feat(det): abrangência da notificação vira parâmetro, com o enum do DET

### DIFF
--- a/_scripts/det_criar.py
+++ b/_scripts/det_criar.py
@@ -17,7 +17,20 @@ ouro do perfil: o assistente redige a minuta, o AFT decide e transmite.
 
 Estrutura confirmada no molde real (RMNHLB58LINBKP, 21/08/2026):
   - casca:  POST /notificacoes  {cpfAuditor, status:0 (EM_ELABORACAO),
-            tipoGeracao:0, auditores:[{cpf,nome,cif}], rascunho:"<json>"}
+            tipoGeracao:0, tipoAbrangencia, auditores:[{cpf,nome,cif}],
+            rascunho:"<json>"}
+            tipoAbrangencia vai na casca por precaução. O que se APUROU em
+            26/08/2026, lendo o DET de volta: enquanto a notificação está EM
+            ELABORAÇÃO, o registro principal fica vazio de qualquer forma
+            (titulo=None, itens=0, observacoes=0, tipoAbrangencia=None) e tudo
+            vive no blob `rascunho`; é a LAVRATURA que transfere blob ->
+            registro principal. Mandar tipoAbrangencia no POST não mudou o
+            registro principal (continuou nulo), mas é inofensivo e deixa a
+            casca coerente com o blob. NÃO está comprovado que isto conserte
+            a falha de lavratura relatada — se ela voltar, investigue por
+            outro caminho, e não presuma que o campo nulo no registro
+            principal seja a causa (titulo e itens ficam nulos do mesmo jeito
+            numa notificação que lavra sem problema).
   - item:   {ordem, descricao, tipo, tipoRetornoSolicitado, dataPrazoEntrega,
             status:0, preAssinalado:false, versao:1}
             tipo:   0 SOLICITACAO_DOCUMENTO · 1 CUMPRIMENTO_OBRIGACAO · 2 ORIENTACAO
@@ -56,6 +69,15 @@ RETORNO_IMPRESSO = 2
 RETORNO_VISTORIA = 3
 STATUS_EM_ELABORACAO = 0
 PRAZO_PADRAO_DIAS = 16
+# Abrangência da notificação (enum bt do bundle do DET, chunk 251): campo do
+# REGISTRO PRINCIPAL, não do item. 0 EMPRESA (matriz e filiais) · 1
+# ESTABELECIMENTO (só o CNPJ notificado) · 2 ESTABELECIMENTO_E_INDICADOS.
+ABRANGENCIA_EMPRESA = 0
+ABRANGENCIA_ESTABELECIMENTO = 1
+ABRANGENCIA_ESTABELECIMENTO_E_INDICADOS = 2
+# Padrão do toolkit: a notificação sai contra o estabelecimento inspecionado.
+# Ampliar para matriz e filiais é decisão do AFT, dita expressamente.
+ABRANGENCIA_PADRAO = ABRANGENCIA_ESTABELECIMENTO
 
 # "Todos os tipos de arquivo" marcados — a string vem de config/det-opcoes.json
 # (o site concatena os grupos e repete o .txt; reproduzir igual é o que faz a
@@ -378,6 +400,8 @@ def parametros_do_md(texto: str) -> dict:
           prazo: 07/09/2026          # ou prazo_dias: 16
           tipo: obrigacao            # solicitacao | obrigacao | orientacao
           retorno: digital           # sem | digital | impresso | vistoria
+          abrangencia: estabelecimento   # empresa | estabelecimento |
+                                         # estabelecimento_e_indicados
           preassinalado: sim
           excecoes:
             - item: 7
@@ -440,6 +464,9 @@ def parametros_do_md(texto: str) -> dict:
     r = _palavra(_palavras("retorno_solicitado"), simples.get("retorno"))
     if r is not None:
         p["retorno"] = r
+    a = _palavra(_palavras("abrangencia_da_notificacao"), simples.get("abrangencia"))
+    if a is not None:
+        p["abrangencia"] = a
     if "preassinalado" in simples:
         p["preassinalado"] = _verdadeiro(simples["preassinalado"])
     if simples.get("arquivos"):
@@ -757,7 +784,7 @@ def _prazo_para_iso(prazo) -> str | None:
 def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo=None,
                    prazo_dias=None, token: str = "", id_modelo=None, cif=None,
                    prazo=None, tipo=None, retorno=None, preassinalado=None,
-                   ri=None, ni=None,
+                   abrangencia=None, ri=None, ni=None,
                    overrides=None) -> tuple[dict, list[dict]]:
     """Lê a TN-NCO e o memory.md da OS e devolve (payload, itens) prontos —
     sem escrever nada.
@@ -828,6 +855,7 @@ def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo=None,
     tipo = escolher(tipo, "tipo", TIPO_CUMPRIMENTO_OBRIGACAO)
     retorno = escolher(retorno, "retorno", RETORNO_DIGITAL)
     preassinalado = escolher(preassinalado, "preassinalado", True)
+    abrangencia = escolher(abrangencia, "abrangencia", ABRANGENCIA_PADRAO)
     prazo_iso = (_prazo_para_iso(prazo)
                  or _prazo_para_iso(do_md.get("prazo"))
                  or _prazo_iso(prazo_dias or do_md.get("prazo_dias")
@@ -839,7 +867,8 @@ def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo=None,
 
     payload = montar_payload(token, ri, cnpj, titulo, itens, prazo_iso,
                              tipo=tipo, retorno=retorno,
-                             preassinalado=preassinalado, overrides=combinadas)
+                             preassinalado=preassinalado,
+                             abrangencia=abrangencia, overrides=combinadas)
     # Introdução e observações saem do PRÓPRIO .md — é o texto que o AFT
     # revisou. O modelo do DET só entra se o arquivo não trouxer nada
     # (ver `enriquecer`, que não sobrescreve o que já veio daqui).
@@ -863,6 +892,9 @@ def preparar_de_os(pasta_os: Path, arquivo_tn: str, titulo=None,
     payload["_enriquecimento"]["parametros_do_md"] = do_md or None
     payload["_parametros"] = {"titulo": titulo, "prazo": prazo_iso,
                               "tipo": tipo, "retorno": retorno,
+                              "abrangencia": abrangencia,
+                              "abrangencia_rotulo": rotulo(
+                                  "abrangencia_da_notificacao", abrangencia),
                               "preassinalado": preassinalado,
                               "excecoes": combinadas or None}
     return payload, itens
@@ -874,6 +906,7 @@ def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
                    retorno: int = RETORNO_DIGITAL,
                    preassinalado: bool = True,
                    tipos_arquivo: str | None = None,
+                   abrangencia: int | None = None,
                    overrides: dict | None = None) -> dict:
     """Corpo do rascunho, PRONTO para conferência — NÃO envia nada.
     Espelha o molde real: casca (auditor/status) + itens com o texto integral.
@@ -885,6 +918,8 @@ def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
     o penúltimo pedir Vistoria in loco."""
     aud = auditor_do_token(token)
     ni = re.sub(r"\D", "", cnpj or "")
+    if abrangencia is None:
+        abrangencia = ABRANGENCIA_PADRAO
     overrides = overrides or {}
     itens_payload = []
     for i, it in enumerate(itens, 1):
@@ -931,7 +966,7 @@ def montar_payload(token: str, ri: str, cnpj: str, titulo: str,
         "cpfAuditor": aud["cpf"],
         "status": STATUS_EM_ELABORACAO,
         "tipoGeracao": 0,
-        "tipoAbrangencia": 1,
+        "tipoAbrangencia": abrangencia,
         "tipoNi": 0 if len(ni) == 14 else 1,   # 0 = CNPJ, 1 = CPF (14 vs 11)
         "auditores": [aud],
         "ri": re.sub(r"\D", "", ri or ""),
@@ -1029,6 +1064,22 @@ def revisar_payload(payload: dict) -> list[dict]:
               f"CNPJ/CPF do empregador inválido ({len(ni)} dígitos; esperado 14 ou 11)")
     if not (payload.get("titulo") or "").strip():
         anota("impede", "notificação", "sem título")
+    # Abrangência é obrigatória na tela do DET e validada na LAVRATURA, no
+    # registro principal. Nula, a tela mostra "Não informada" e o Lavrar falha
+    # — com a notificação inteira já montada. Melhor barrar aqui.
+    abr = payload.get("tipoAbrangencia")
+    if abr not in (ABRANGENCIA_EMPRESA, ABRANGENCIA_ESTABELECIMENTO,
+                   ABRANGENCIA_ESTABELECIMENTO_E_INDICADOS):
+        anota("impede", "notificação",
+              f"abrangência ausente ou inválida ({abr!r}) — esperado 0 (toda a "
+              "empresa), 1 (somente o estabelecimento notificado) ou 2 "
+              "(estabelecimento e os demais indicados)")
+    elif abr == ABRANGENCIA_ESTABELECIMENTO_E_INDICADOS \
+            and not (payload.get("estabelecimentos") or []):
+        anota("aviso", "notificação",
+              "abrangência 'estabelecimento e os demais indicados' sem nenhum "
+              "estabelecimento na aba Demais Estabelecimentos — inclua-os no "
+              "DET antes de lavrar")
 
     itens = payload.get("itens") or []
     if not itens:
@@ -1208,8 +1259,16 @@ def criar_rascunho(token: str, corpo: dict) -> dict:
         raise RuntimeError("rascunho incompleto, nada foi enviado ao DET — " + detalhe)
     corpo = {k: v for k, v in corpo.items()
              if k not in ("_enriquecimento", "_parametros")}
+    # tipoAbrangencia também na casca, para o POST ficar coerente com o blob.
+    # Ver a nota do topo do módulo: em elaboração o registro principal fica
+    # vazio de todo modo, e mandar o campo aqui não o preencheu no teste de
+    # 26/08/2026. Mantido por ser inofensivo e por deixar explícito, em quem
+    # ler o POST, qual abrangência a notificação carrega.
     casca = {"cpfAuditor": corpo["cpfAuditor"], "status": STATUS_EM_ELABORACAO,
-             "tipoGeracao": 0, "auditores": corpo["auditores"]}
+             "tipoGeracao": 0,
+             "tipoAbrangencia": corpo.get("tipoAbrangencia",
+                                          ABRANGENCIA_PADRAO),
+             "auditores": corpo["auditores"]}
     casca["rascunho"] = json.dumps(casca, ensure_ascii=False)
     criada = json.loads(det_baixar._requisicao(
         token, "/notificacoes", corpo=casca, metodo="POST").decode("utf-8"))
@@ -1268,6 +1327,41 @@ def _autoteste() -> int:
                 "observacoes": observacoes}
         return [a for a in revisar_payload(base)
                 if a["onde"] == "introdução/observações"]
+
+    # 3b. abrangência: padrão, palavras do front-matter e barreira do revisor
+    confere("abrangência: padrão do toolkit é 'somente o estabelecimento'",
+            ABRANGENCIA_PADRAO == 1)
+    confere("abrangência: rótulo do enum 1 bate com o do DET",
+            rotulo("abrangencia_da_notificacao", 1)
+            == "Somente o Estabelecimento Notificado")
+    _pal = _palavras("abrangencia_da_notificacao")
+    confere("abrangência: 'empresa' no front-matter vira 0",
+            _palavra(_pal, "empresa") == 0)
+    confere("abrangência: 'estabelecimento' vira 1",
+            _palavra(_pal, "estabelecimento") == 1)
+    confere("abrangência: 'estabelecimento_e_indicados' vira 2",
+            _palavra(_pal, "estabelecimento_e_indicados") == 2)
+    confere("abrangência: acento e espaço não atrapalham",
+            _palavra(_pal, "Somente o Estabelecimento Notificado") == 1)
+    confere("abrangência: valor desconhecido não é aceito",
+            _palavra(_pal, "toda a galáxia") is None)
+    _fm = parametros_do_md(
+        "---\ndet:\n  tipo: orientacao\n  abrangencia: empresa\n---\n")
+    confere("abrangência: lida do front-matter", _fm.get("abrangencia") == 0)
+    _fm2 = parametros_do_md("---\ndet:\n  tipo: orientacao\n---\n")
+    confere("abrangência: ausente do front-matter não inventa valor",
+            "abrangencia" not in _fm2)
+
+    def _abr(valor):
+        base = {"ri": "1", "ni": "1" * 14, "titulo": "t", "itens": [],
+                "observacoes": norm, "tipoAbrangencia": valor}
+        return [a for a in revisar_payload(base)
+                if "abrangência" in a["problema"] and a["gravidade"] == "impede"]
+
+    confere("revisão: barra abrangência nula", bool(_abr(None)))
+    confere("revisão: barra abrangência fora do enum", bool(_abr(7)))
+    confere("revisão: aceita abrangência 0, 1 e 2",
+            not (_abr(0) or _abr(1) or _abr(2)))
 
     confere("revisão: barra texto sem ordem", bool(desordem(do_modelo)))
     confere("revisão: barra ordem repetida",

--- a/_scripts/servir_painel.py
+++ b/_scripts/servir_painel.py
@@ -889,7 +889,11 @@ class Handler(BaseHTTPRequestHandler):
 
     def _det_criar(self):
         """POST /api/det-criar — ESCREVE um rascunho de notificação no DET.
-        Corpo {pasta, arquivo, titulo?, prazo_dias?, confirmar}. Sem
+        Corpo {pasta, arquivo, titulo?, prazo_dias?, abrangencia?, confirmar}.
+        `abrangencia` (0 toda a empresa · 1 só o estabelecimento notificado ·
+        2 estabelecimento e os demais indicados) só precisa ser passada para
+        contrariar o front-matter do .md; omitida, vale o .md e, na falta
+        dele, o padrão do toolkit (1). Sem
         confirmar=true, devolve só a PRÉVIA (payload montado), sem tocar o DET.
         Com confirmar=true, cria a casca + salva o rascunho — NUNCA lavra."""
         try:
@@ -920,6 +924,8 @@ class Handler(BaseHTTPRequestHandler):
                 tipo=int(p["tipo"]) if p.get("tipo") is not None else None,
                 retorno=int(p["retorno"]) if p.get("retorno") is not None else None,
                 preassinalado=p.get("preassinalado"),
+                abrangencia=(int(p["abrangencia"])
+                             if p.get("abrangencia") is not None else None),
                 ri=p.get("ri"),
                 ni=p.get("ni"),
                 overrides=ov)

--- a/aft-NAD/SKILL.md
+++ b/aft-NAD/SKILL.md
@@ -226,11 +226,15 @@ det:
   prazo_dias: 16          # ou prazo: dd/mm/aaaa
   tipo: solicitacao       # a NAD é Solicitação de Documento
   retorno: digital        # a empresa anexa pelo DET
+  abrangencia: estabelecimento   # empresa | estabelecimento |
+                                 # estabelecimento_e_indicados
   preassinalado: sim
   arquivos: todos
   modelo: 11301           # só se veio de modelo (FASE 0.5)
   cif: 358070             # a CIF do DONO do modelo
 ---
+
+> **Abrangência** é campo da notificação (aba "Informações Básicas" do DET), não do item, e o DET a valida na lavratura: nula, o Lavrar falha. O padrão do toolkit é `estabelecimento`, ou seja, apenas o CNPJ notificado. Use `empresa` (matriz e filiais) ou `estabelecimento_e_indicados` somente quando o AFT pedir; neste último caso, lembre-o de preencher a aba Demais Estabelecimentos no DET antes de lavrar. O campo continua editável no site.
 
 # Notificação para Apresentação de Documentos
 

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -278,6 +278,9 @@ Texto sozinho não vira notificação. O DET exige, de **cada item**, o que a em
 | `prazo_dias` | `16` | dias corridos, contados da criação da notificação |
 | `preassinalado` | `sim` | o item já nasce marcado |
 | `arquivos` | `todos` | aceita qualquer extensão que o DET permite |
+| `abrangencia` | `estabelecimento` | Abrangência da notificação: só o CNPJ notificado. `empresa` alcança matriz e filiais; `estabelecimento_e_indicados` alcança o notificado mais os CNPJs listados na aba Demais Estabelecimentos do DET |
+
+> **Abrangência é campo da notificação, não do item.** O DET a exige na aba "Informações Básicas" e a valida **na lavratura**: nula, a tela mostra "Não informada" e o Lavrar falha com a notificação inteira já montada. O padrão do toolkit é `estabelecimento` — a notificação sai contra o estabelecimento inspecionado. Ampliar o alcance é decisão do AFT e precisa ser dita: só grave `empresa` ou `estabelecimento_e_indicados` quando ele pedir. Ao usar `estabelecimento_e_indicados`, lembre-o de preencher a aba **Demais Estabelecimentos** no DET antes de lavrar, porque o toolkit não a preenche. De todo modo, o campo é editável no site antes da lavratura.
 
 > **O retorno depende do tipo.** O DET não oferece as quatro opções sempre — a lista muda conforme o tipo do item, e combinação fora dela é impossível na tela do site (e o toolkit recusa):
 >
@@ -382,6 +385,8 @@ det:
   prazo: 07/09/2026          # data fixa; ou prazo_dias: 16
   tipo: obrigacao            # solicitacao | obrigacao | orientacao
   retorno: digital           # sem | digital | impresso | vistoria
+  abrangencia: estabelecimento   # empresa | estabelecimento |
+                                 # estabelecimento_e_indicados
   preassinalado: sim
   arquivos: todos
   excecoes:

--- a/config/det-opcoes.json
+++ b/config/det-opcoes.json
@@ -110,6 +110,34 @@
   }
  },
 
+ "abrangencia_da_notificacao": {
+  "campo_no_payload": "tipoAbrangencia",
+  "obrigatorio": true,
+  "onde_aparece": "Aba 'Informações Básicas' da notificação, campo 'Abrangência (Obrigatório)'. Vai no REGISTRO PRINCIPAL da notificação, não no item.",
+  "padrao_do_toolkit": 1,
+  "_por_que_esse_padrao": "Notificação de fiscalização sai, por regra, contra o estabelecimento inspecionado. Ampliar para matriz e filiais, ou para outros CNPJs, é decisão do AFT e tem de ser dita expressamente.",
+  "opcoes": {
+   "0": {
+    "rotulo": "Toda a Empresa",
+    "enum_no_bundle": "EMPRESA",
+    "palavras_no_frontmatter": ["empresa", "toda_a_empresa", "toda_empresa", "matriz_e_filiais"],
+    "tooltip_do_site": "Toda a Empresa: Os CNPJs de matriz e filiais."
+   },
+   "1": {
+    "rotulo": "Somente o Estabelecimento Notificado",
+    "enum_no_bundle": "ESTABELECIMENTO",
+    "palavras_no_frontmatter": ["estabelecimento", "somente_o_estabelecimento_notificado", "somente_estabelecimento", "so_o_estabelecimento"],
+    "tooltip_do_site": "Somente o Estabelecimento Notificado: Apenas o CNPJ notificado."
+   },
+   "2": {
+    "rotulo": "Estabelecimento Notificado e os demais indicados na notificação",
+    "enum_no_bundle": "ESTABELECIMENTO_E_INDICADOS",
+    "palavras_no_frontmatter": ["estabelecimento_e_indicados", "estabelecimento_e_demais", "notificado_e_demais", "demais_estabelecimentos"],
+    "tooltip_do_site": "Estabelecimento Notificado e os demais indicados na Notificação: O CNPJ notificado e outros citados na notificação (ver Demais Estabelecimentos)."
+   }
+  },
+  "_fonte": "Bundle Angular do proprio DET, chunk 251 (enum bt: EMPRESA=0, ESTABELECIMENTO=1, ESTABELECIMENTO_E_INDICADOS=2, com o Map de rotulos ao lado). Lido em 26/08/2026."
+ },
  "outros_enums": {
   "status_da_notificacao": {"0": "Em Elaboração", "1": "Confirmada", "2": "Cancelada"},
   "status_do_item": {"0": "Inicial", "1": "Recebido", "2": "Rejeitado", "3": "Dispensado"},


### PR DESCRIPTION
## O que muda

A abrangência da notificação ia **cravada como `1`** dentro do `montar_payload`, sem documentação e sem como o AFT mudá-la pelo arquivo da notificação. Agora é parâmetro de primeira classe, com o padrão que o toolkit assume por regra: **"Somente o Estabelecimento Notificado"**.

Ampliar o alcance (matriz e filiais, ou outros CNPJs) passa a exigir decisão expressa do AFT, escrita no front-matter:

```yaml
det:
  abrangencia: estabelecimento   # empresa | estabelecimento | estabelecimento_e_indicados
```

## De onde veio o enum

Do bundle Angular do próprio DET (chunk 251, enum `bt`) — o mesmo método já usado para as demais opções do formulário:

```
EMPRESA = 0 · ESTABELECIMENTO = 1 · ESTABELECIMENTO_E_INDICADOS = 2
```

## Arquivos

| Arquivo | Mudança |
|---|---|
| `config/det-opcoes.json` | seção `abrangencia_da_notificacao` — rótulos, tooltips do site, palavras do front-matter. Continua sendo a fonte única |
| `_scripts/det_criar.py` | constantes `ABRANGENCIA_*`, leitura do front-matter, parâmetro em `montar_payload`/`preparar_de_os`, rótulo por extenso na prévia, campo no POST da casca |
| `_scripts/det_criar.py` | `revisar_payload` **barra** abrangência nula ou fora do enum; **avisa** quando a abrangência 2 vai sem estabelecimento na aba Demais Estabelecimentos |
| `_scripts/servir_painel.py` | `POST /api/det-criar` aceita `abrangencia`, para a chamada contrariar o front-matter |
| `aft-tn-nco/SKILL.md`, `aft-NAD/SKILL.md` | documentam o campo, o padrão e o lembrete da aba Demais Estabelecimentos |

## Sobre o diagnóstico que originou o trabalho

Relatou-se que a lavratura falhava porque o registro principal ficava com `tipoAbrangencia` nulo. **Lendo o DET de volta, isso não se sustenta:** enquanto a notificação está Em Elaboração o registro principal fica vazio de todo modo — `titulo`, `itens` e `observacoes` também vêm nulos — e tudo vive no blob `rascunho`. É a lavratura que transfere blob → registro principal.

Mandar o campo no POST da casca não mudou isso. Portanto **não está comprovado** que este PR conserte aquela falha, e a docstring do módulo registra o achado para que ninguém repita a suposição.

O que este PR resolve, com certeza: a impossibilidade de escolher a abrangência e a ausência de validação dela.

## Teste

- `python _scripts/det_criar.py --autoteste` → **25/25** (9 casos novos).
- Em produção: rascunho criado pelo toolkit com abrangência `1`, e a tela do DET exibiu **"Somente o Estabelecimento Notificado"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)