### PR TITLE
feat(tn-nco, PGR): variante orientativa da notificação e NCO do PGR

### DIFF
--- a/aft-PGR-analise/SKILL.md
+++ b/aft-PGR-analise/SKILL.md
@@ -528,8 +528,8 @@ Ao final, salve a análise completa em
 Ao terminar as sete ementas, faça uma pergunta única ao AFT:
 
 > "Deseja que eu (1) redija os autos de infração das ementas presentes (formato pronto
-> para o `/aft-gera-ai`, com o PGR como anexo), (2) escreva um relatório de recomendação
-> geral para envio à empresa, ou (3) ambos?"
+> para o `/aft-gera-ai`, com o PGR como anexo), (2) monte a notificação para correção do
+> PGR (NCO do DET, itens de orientação), ou (3) ambos?"
 
 ### 1) Redação dos autos de infração (formato /aft-gera-ai)
 
@@ -648,20 +648,61 @@ remove o hífen no cod_3):
      /aft-gera-ai comprime com o script do toolkit.
 ```
 
-### 2) Relatório de recomendação geral para a empresa
+### 2) NCO do PGR — notificação para correção, no DET
 
-Quando solicitado, redija um relatório técnico **resumido e de fácil entendimento**
-dirigido à empresa, com:
+Notificar a empresa a revisar o PGR é o desfecho normal desta análise, e o canal é o
+DET. **Esta skill fornece o CONTEÚDO; quem monta a notificação é a `/aft-tn-nco`** —
+front-matter, parâmetros do DET, textos fixos, `.md`, `.docx` e a revisão da FASE 3.7
+vivem lá, e não devem ser reescritos aqui. Duas fontes para o mesmo boilerplate é
+exatamente o que o toolkit evita.
 
-- Identificação dos principais problemas encontrados no PGR auditado, agrupados por
-  tema (identificação de perigos, avaliação, Inventário, Plano de Ação, ergonomia,
-  aft-consulta/comunicação).
-- Orientação clara de que a empresa deve **revisar integralmente o PGR**, com foco nos
-  pontos críticos apontados.
-- Tom técnico, direto, sem linguagem jurídica de auto de infração. O destinatário aqui
-  é o empregador, não o processo.
+**Parâmetros a propor ao AFT** (ele decide; não assuma em silêncio):
 
-Salve o relatório como `recomendacao-geral-PGR.md` na pasta da OS.
+| Parâmetro | Proposta | Por quê |
+|---|---|---|
+| `tipo` | `orientacao` | as irregularidades do PGR costumam já ter virado auto, e o auto é, por si, meio de coerção indireto. A notificação orienta a revisão do documento |
+| `retorno` | `sem` | é o único que o DET aceita em item de orientação, e por isso a notificação não tem prazo |
+| `abrangencia` | `estabelecimento` | padrão do toolkit |
+
+> Se o AFT preferir **exigir** a revisão em vez de orientar (não houve auto, ou ele quer
+> prazo e comprovação), passe `tipo: obrigacao` / `retorno: digital` e peça, no fecho de
+> cada item, o PGR revisado. Aí valem a introdução e as observações **principais** da
+> `/aft-tn-nco`, não a variante orientativa.
+
+**Um item por ementa irregular**, na ordem da análise, no formato da `/aft-tn-nco`
+(`*Título* - norma: texto [ementa]`). Cada item manda **rever o que está errado**, com
+a referência concreta do documento auditado (página, tabela, seção) que a análise
+levantou — é isso que permite ao empregador achar o defeito. Títulos sugeridos:
+
+| Ementa | Título do item | O item manda |
+|---|---|---|
+| 101059-0 | Evitar os Riscos na Origem | incorporar a etapa de evitar, anterior à avaliação, com levantamento preliminar de perigos; reescrever a hierarquia de medidas para alcançar o perigo mecânico, e não só o agente ambiental |
+| 101060-3 | Identificação de Perigos e Análise de Risco de Máquinas | elaborar análise de risco das máquinas, individualizada, com limites do equipamento, perigos e estimativa de risco; alcançar atividades não rotineiras e de contratadas |
+| 101062-0 | Classificação dos Riscos Ocupacionais | explicitar os critérios e a regra que liga severidade e probabilidade ao nível; assegurar que risco de nível elevado gere medida no plano de ação |
+| 101064-6 | Condições Previstas na NR-17 | realizar AEP e, onde couber, AET, com resultados no inventário; identificação específica por função; gradação da probabilidade por norma de produção, ritmo e modo operatório; limite de peso; fatores de organização do trabalho |
+| 101074-3 | Plano de Ação | novo plano datado e assinado, vinculado ao inventário, com cronograma, formas de acompanhamento e aferição de resultados |
+| 101079-4 | Inventário de Riscos Ocupacionais | caracterização de processos e ambientes; atividades não rotineiras e de contratadas; resultados da NR-17; critérios adotados; inventariar os perigos reais ainda ausentes; manter atualizado |
+| 101115-4 | Consulta e Comunicação aos Trabalhadores | estabelecer e documentar consulta sobre percepção de riscos e comunicação do inventário e do plano de ação, com registro de recebimento e resposta |
+
+Inclua **apenas** as ementas que a análise concluiu presentes.
+
+**Bloco de observação adicional (SEMPRE, nas NCOs de PGR)** — acrescente depois dos
+blocos fixos da `/aft-tn-nco`, sem reescrevê-los:
+
+```
+Elaboração por terceiro:
+> Recomendamos o fornecimento de uma cópia dessa notificação caso haja uma terceira empresa responsável pela elaboração do PGR.
+```
+
+> O PGR é, com frequência, elaborado por consultoria externa, e quem precisa conhecer as
+> falhas apontadas é quem o redige. A recomendação não transfere responsabilidade: o
+> sujeito passivo continua sendo o empregador.
+
+**O contexto do documento auditado NÃO entra na introdução** (que é texto fixo). Data de
+elaboração, quadro de pessoal declarado, norma revogada que o documento adota: isso é
+matéria de item, ou vai num bloco de observação próprio.
+
+Entregue os itens à `/aft-tn-nco` e deixe-a concluir o fluxo dela.
 
 ---
 

--- a/aft-tn-nco/SKILL.md
+++ b/aft-tn-nco/SKILL.md
@@ -185,6 +185,16 @@ Em conformidade com a legislação em vigor, especialmente o previsto na alínea
 
 > ⚠️ **O "X" em "alínea X" está CORRETO e é intencional** — designa a décima alínea (alínea 10) do art. 18. **Nunca** substitua o "X" por uma letra, número arábico ou qualquer outro valor, e nunca "corrija" essa frase. Copie a introdução exatamente como está acima.
 
+#### Variante orientativa (quando TODOS os itens forem `tipo: orientacao` / `retorno: sem`)
+
+A introdução acima fala em cumprir obrigações e corrigir irregularidades — linguagem de exigência, que contradiz uma notificação inteiramente orientativa. Nesse caso, e **somente nesse caso**, use esta variante, também literal:
+
+```
+Em conformidade com a legislação em vigor, especialmente o previsto na alínea X do art. 18 do Decreto 4552/2002 (Regulamento da Inspeção do Trabalho), fica a empresa ORIENTADA quanto às irregularidades relacionadas nessa notificação, para que adote as medidas de correção nela indicadas:
+```
+
+> Vale a mesma regra do "X": copie literal. E vale a mesma fronteira: a variante troca **só** o verbo e o comando; nada de contexto da fiscalização entra na introdução. Contexto (data de elaboração do documento auditado, quadro de pessoal, norma revogada que ele adota) é matéria de **item**, não de texto fixo. Se a notificação tiver itens orientativos E itens de obrigação, use a introdução principal — a variante é para a notificação inteiramente orientativa.
+
 ### Itens (um por irregularidade)
 
 **ORDEM DOS ITENS: crescente por Norma Regulamentadora, da NR-01 à NR-38.** Agrupe os itens
@@ -262,6 +272,20 @@ Dúvidas:
 ```
 
 > Esse texto de observações é o boilerplate canônico do AFT — reproduza-o verbatim, sem reescrever ou "consertar" a redação.
+
+#### Variante orientativa (quando TODOS os itens forem `tipo: orientacao` / `retorno: sem`)
+
+O bloco "Comprovação de cumprimento" fala em prazos previstos nos itens e em comprovação pelo empregador — e item de orientação não tem prazo nem pede documento. Numa notificação inteiramente orientativa, **substitua aquele primeiro bloco** por este, mantendo o bloco "Dúvidas" verbatim:
+
+```
+Natureza desta notificação:
+> Os itens acima têm caráter de orientação e não exigem retorno nem apresentação de documentos por esta notificação. O cumprimento será verificado em fiscalização futura.
+
+Dúvidas:
+>  Perguntas/esclarecimentos adicionais podem ser feitos no  "Canal de Comunicação" dentro dessa própria notificação, ou pelos e-mails disponíveis na notificação.
+```
+
+> **Blocos de observação adicionais** são permitidos depois destes, quando a skill chamadora os fornecer (é o caso da `/aft-PGR-analise`, que acrescenta a recomendação sobre a empresa terceira elaboradora do PGR). Escreva-os no mesmo formato `Título:` seguido de `> texto`. O que **não** se faz é reescrever os blocos fixos acima para acomodar um assunto novo: acrescenta-se um bloco.
 
 ---
 


### PR DESCRIPTION
Duas lacunas que apareceram ao notificar a revisão de um PGR real. Segue a [#97](https://github.com/ryckardo42/aft-toolkit/pull/97).

## 1. A `/aft-tn-nco` não previa notificação inteiramente orientativa

Os textos fixos da skill falam em *"prazos previstos nos itens"* e em *"comprovação pelo empregador"* — que contradizem itens `tipo: orientacao` / `retorno: sem`, os quais, por definição, **não têm prazo nem pedem documento**.

Sem uma variante sancionada, quem monta a notificação acaba improvisando o boilerplate — que é justamente o que a skill manda não fazer. Foi o que aconteceu na fiscalização que originou este PR.

Entram agora, condicionadas a que **todos** os itens sejam orientativos:

- **introdução alternativa** — *"fica a empresa ORIENTADA quanto às irregularidades relacionadas nessa notificação, para que adote as medidas de correção nela indicadas"*, preservando a alínea X e a regra de cópia literal;
- **bloco "Natureza desta notificação"**, que substitui o de comprovação, mantendo `Dúvidas` verbatim.

Dois limites ficam explícitos:

- contexto da fiscalização **não entra na introdução** — data de elaboração do documento auditado, quadro de pessoal, norma revogada que ele adota são matéria de item ou de bloco de observação;
- blocos de observação **adicionais são permitidos** depois dos fixos. Acrescenta-se um bloco; não se reescreve os fixos.

## 2. A `/aft-PGR-analise` oferecia um relatório solto onde cabia uma notificação

A pós-análise oferecia *"relatório de recomendação geral"* num `.md` avulso. O canal real para mandar a empresa revisar o PGR é o DET.

A opção 2 passa a ser a **NCO do PGR**, com divisão clara de papéis:

- **esta skill fornece o conteúdo** — um item por ementa presente, com a referência concreta do documento auditado (página, tabela, seção) que a análise levantou, mais uma tabela de títulos sugeridos por ementa;
- **a `/aft-tn-nco` monta a notificação** — front-matter, parâmetros do DET, textos fixos, `.md`, `.docx` e a revisão da FASE 3.7 continuam vivendo lá. Sem duplicação de boilerplate.

Propõe ao AFT `tipo: orientacao` / `retorno: sem` / `abrangencia: estabelecimento`, com a alternativa registrada para quando ele preferir **exigir** a revisão com prazo e comprovação.

### Bloco próprio das NCOs de PGR

Sempre, depois dos blocos fixos:

> Recomendamos o fornecimento de uma cópia dessa notificação caso haja uma terceira empresa responsável pela elaboração do PGR.

O PGR é com frequência elaborado por consultoria externa, e quem precisa conhecer as falhas apontadas é quem o redige. Não transfere responsabilidade: o sujeito passivo continua sendo o empregador.

## Teste

Aplicado a uma NCO real de 7 itens (as sete ementas de PGR), com o `.docx` gerado pela `aft-modelo-docx` e a prévia do `det_criar` conferindo introdução + 4 blocos de observação. A criação do rascunho no DET ficou pendente de uma indisponibilidade do endpoint `/fiscalizacoes/detalhe/{ri}`, sem relação com estas mudanças.

🤖 Generated with [Claude Code](https://claude.com/claude-code)