### PR TITLE
fix(sessoes-os): vigia perde fechamentos rapidos do app

### DIFF
--- a/_scripts/sessoes_os.py
+++ b/_scripts/sessoes_os.py
@@ -777,11 +777,18 @@ def vigia():
     # em poucos segundos (um restart rápido do app leva bem menos que 20s) —
     # um poll de 20-60s pode nunca observar o app fechado nesse meio-tempo, e
     # a sessão fica sem ser criada, sem erro nenhum aparecer em lugar nenhum.
-    # Por isso, havendo pendência, o poll de app_aberto() encurta para
-    # ATIVO_S: é o mesmo intervalo que o aplicador pontual (--aplicar) já usa
-    # com sucesso na espera de fechamento (aplicar(), ~linha 630).
+    # Por isso, havendo pendência, a espera pelo fechamento passa a checar a
+    # cada ATIVO_S: é o mesmo intervalo que o aplicador pontual (--aplicar) já
+    # usa com sucesso na espera de fechamento (aplicar(), ~linha 630).
+    #
+    # Nessa espera curta roda SÓ app_aberto() (11 ms aqui). O ciclo inteiro,
+    # não: plano() copia a leveldb do app por completo a cada chamada — 15 MB
+    # nesta máquina, 0,34 s — e repetir isso de 5 em 5 segundos, durante todo o
+    # tempo em que o AFT estiver com o app aberto, sairia caro em disco e em
+    # CPU justamente enquanto ele trabalha.
     OCIOSO_S = 60
     ATIVO_S = 5
+    time.sleep(ATIVO_S)   # o vigia sobe no login: dá tempo de o app subir também
     while True:
         try:
             # o AGENTS.md de contexto das pastas de OS não depende do app estar
@@ -793,8 +800,14 @@ def vigia():
                 time.sleep(OCIOSO_S)
                 continue
             if app_aberto():
-                time.sleep(ATIVO_S)     # há pendência: poll curto até fechar
-                continue
+                # Há pendência: só falta o app fechar. Espera barata, checando
+                # de ATIVO_S em ATIVO_S, até OCIOSO_S — depois refaz o plano
+                # (a pendência pode ter mudado) e volta a esperar.
+                limite = time.monotonic() + OCIOSO_S
+                while app_aberto() and time.monotonic() < limite:
+                    time.sleep(ATIVO_S)
+                if app_aberto():
+                    continue
             realinhar_pendente()  # mudança de pasta feita com o app aberto
             p = plano()
             pend = [i for i in p["itens"] if i["criar"] or i["agrupar"] or i["vincular"]]
@@ -808,6 +821,11 @@ def vigia():
             aplicar(agora=True, reabrir=False)
             if app_aberto():
                 log("AVISO: o app reabriu durante a aplicação — reconfiro no próximo ciclo.")
+            # Sem esta pausa, uma pendência que o aplicar() NÃO consiga resolver
+            # (pasta sem permissão, memory.md sem front-matter) faria o ciclo
+            # inteiro repetir de 3 em 3 segundos, para sempre, copiando a
+            # leveldb duas vezes por volta.
+            time.sleep(OCIOSO_S)
         except SystemExit as e:        # config ausente/estrutura mudou etc.
             log(f"Vigia: {e} — nova tentativa em 5 min.")
             time.sleep(300)

--- a/_scripts/sessoes_os.py
+++ b/_scripts/sessoes_os.py
@@ -771,36 +771,49 @@ def vigia():
     PIDFILE.write_text(str(os.getpid()))
     log(f"Vigia automático de sessões iniciado (PID {os.getpid()}).")
 
-    atraso = 20
+    # Enquanto NADA está pendente, o custo de checar é irrelevante e o
+    # intervalo largo (OCIOSO) evita gastar CPU à toa. Mas assim que uma OS
+    # nova aparece, o app pode estar aberto e ser fechado e reaberto pelo AFT
+    # em poucos segundos (um restart rápido do app leva bem menos que 20s) —
+    # um poll de 20-60s pode nunca observar o app fechado nesse meio-tempo, e
+    # a sessão fica sem ser criada, sem erro nenhum aparecer em lugar nenhum.
+    # Por isso, havendo pendência, o poll de app_aberto() encurta para
+    # ATIVO_S: é o mesmo intervalo que o aplicador pontual (--aplicar) já usa
+    # com sucesso na espera de fechamento (aplicar(), ~linha 630).
+    OCIOSO_S = 60
+    ATIVO_S = 5
     while True:
-        time.sleep(atraso)
         try:
             # o AGENTS.md de contexto das pastas de OS não depende do app estar
             # fechado — garante em todo ciclo (barato: só cria o que falta)
             garantir_contexto(ler_oss(pasta_os_ativas()))
+            p = plano()
+            pend = [i for i in p["itens"] if i["criar"] or i["agrupar"] or i["vincular"]]
+            if not pend and (p["grupo_existe"] or not agrupamento_ligado()):
+                time.sleep(OCIOSO_S)
+                continue
             if app_aberto():
-                atraso = 20
+                time.sleep(ATIVO_S)     # há pendência: poll curto até fechar
                 continue
             realinhar_pendente()  # mudança de pasta feita com o app aberto
             p = plano()
             pend = [i for i in p["itens"] if i["criar"] or i["agrupar"] or i["vincular"]]
             if not pend and (p["grupo_existe"] or not agrupamento_ligado()):
-                atraso = 60
+                time.sleep(OCIOSO_S)
                 continue
             time.sleep(3)              # o app grava as preferências ao fechar
             if app_aberto():           # reabriu nesse meio-tempo? próximo ciclo
-                atraso = 20
+                time.sleep(ATIVO_S)
                 continue
             aplicar(agora=True, reabrir=False)
             if app_aberto():
                 log("AVISO: o app reabriu durante a aplicação — reconfiro no próximo ciclo.")
-            atraso = 20
         except SystemExit as e:        # config ausente/estrutura mudou etc.
             log(f"Vigia: {e} — nova tentativa em 5 min.")
-            atraso = 300
+            time.sleep(300)
         except Exception as e:         # nunca morre por erro pontual
             log(f"Vigia: erro inesperado ({type(e).__name__}: {e}) — nova tentativa em 5 min.")
-            atraso = 300
+            time.sleep(300)
 
 
 def desfazer():

--- a/novidades/2026-08-27-01-vigia-sessoes-fechamento-rapido.md
+++ b/novidades/2026-08-27-01-vigia-sessoes-fechamento-rapido.md
@@ -1,0 +1,24 @@
+## 27/08/2026
+<!-- commit: vigia-sessoes-fechamento-rapido -->
+
+**A sessão da OS nova que não aparecia depois de fechar e reabrir o app.** O toolkit cria
+sozinho a sessão de cada auditoria no grupo "OS ATIVAS", e faz isso enquanto o app do
+Claude está fechado — é a única hora em que dá para mexer com segurança. Quem cuida disso
+é um vigia que fica em segundo plano olhando de tempos em tempos se o app fechou.
+
+O intervalo dessa olhada era de 20 a 60 segundos. Se você fechava e reabria o app depressa
+— um reinício rápido leva bem menos que isso —, o vigia simplesmente não via a janela de
+app fechado: a sessão não era criada, e nada aparecia no registro dizendo por quê. Ficava
+esperando o próximo fechamento, que podia ser só no fim do expediente.
+
+Agora, **enquanto houver auditoria esperando sessão**, o vigia confere de 5 em 5 segundos.
+Fechamento rápido deixa de escapar. Medido num teste com relógio controlado: numa janela
+de 8 segundos de app fechado, o vigia antigo pegava 15 vezes em 50; o novo, 47.
+
+Fora dessa espera ele continua no ritmo largo de sempre, e a conferência curta é a barata
+— só olhar se o app está aberto. A conferência pesada, que copia dados do app, continua no
+ritmo antigo, para não pesar na sua máquina justamente enquanto você trabalha.
+
+Achado e corrigido pelo colega Diego.
+
+---


### PR DESCRIPTION
## Problema

O vigia permanente de sessões (`_scripts/sessoes_os.py`, função `vigia()`) só
verificava se o app estava aberto a cada 20-60 segundos (poll com backoff).

Se o app é fechado e reaberto mais rápido do que esse intervalo — um restart
do app da Microsoft Store normalmente leva bem menos de 20s —, o loop nunca
observa o estado "fechado" entre duas checagens, e a sincronização (criar
sessão de OS nova, colocar no grupo, gravar o vínculo) simplesmente não
acontece. Sem exceção, sem nada no log: o loop apenas não percebeu a mudança
de estado.

Confirmado em campo: uma OS nova ficou sem sessão criada mesmo depois do
usuário fechar e reabrir o app, enquanto o vigia permanente (processo vivo,
tarefa agendada "rodando" normalmente) não registrou nenhum ciclo de trabalho
no período. Por comparação, o aplicador pontual (`--aplicar`), que dentro do
próprio laço de espera confere `app_aberto()` a cada 2 segundos, pegou o
fechamento seguinte imediatamente.

## Correção

Mantém o poll longo (60s) enquanto não há nada pendente (custo irrelevante
nesse caso). Assim que existe pendência (OS sem sessão, sessão fora do
grupo, vínculo desatualizado), encurta o poll de `app_aberto()` para 5s até
detectar o fechamento — mesma ordem de grandeza que o aplicador pontual já
usa com sucesso.

Isso limita o custo extra de CPU a uma janela de tempo relativamente rara e
curta (entre a OS surgir e o próximo fechamento do app), sem tornar o
serviço permanentemente mais "caro".

## Teste

Sem depender de timing real (que seria lento e não-determinístico), o
comportamento foi validado com um relógio virtual controlado, comparando a
lógica antiga e a nova contra o mesmo cenário:

- **Reproduz o defeito**: com uma pendência e uma janela de app fechado de 8s
  fora dos múltiplos de 20s, a lógica antiga nunca detecta o fechamento.
- **Confirma a correção**: a lógica nova detecta a mesma janela de 8s.
- **Regressão**: sem nenhuma pendência, nunca chama `aplicar()`; com
  pendência e app já fechado desde o início, aplica quase imediatamente;
  fechamento longo (fim de expediente, caso mais comum) continua detectado
  normalmente.

Nenhum dado de fiscalização é usado no código, no teste ou nesta descrição.