### PR TITLE
fix: token no autos.md nao e defeito; nome truncado no de-para, sim

### DIFF
--- a/_scripts/checar_arquivos_internos.py
+++ b/_scripts/checar_arquivos_internos.py
@@ -62,6 +62,9 @@ PADROES = [
      "token de pseudonimizacao nao re-hidratado"),
 ]
 
+# So estes padroes valem no autos.md; o token, nao. Ver SO_NO_TXT abaixo.
+SO_NO_TXT = {"token de pseudonimizacao nao re-hidratado"}
+
 
 def trechos_do_arquivo(caminho):
     """Devolve [(rotulo, texto)] das regioes que de fato vao para o auto."""
@@ -102,6 +105,18 @@ def main():
     achados = []
     for rotulo, texto in trechos_do_arquivo(sys.argv[1]):
         for padrao, motivo in PADROES:
+            # TOKEN DE PSEUDONIMIZACAO no autos.md e CORRETO, nao defeito
+            # (26/08/2026). Duas skills oficiais mandam escreve-lo ali: a
+            # /aft-auditoria-geral ("ao redigi-los nos autos, use os tokens
+            # [[TRAB_NN]]") e a /aft-gera-ai ("a partir dai refira-se a ele so
+            # pelo token"). Como esta guarda rodava a mesma regra nos dois
+            # arquivos, TODO auto redigido conforme a skill manda era reprovado
+            # pelo gate da /aft-revisa-auto -- achado rodando o fluxo de ponta a
+            # ponta numa fiscalizacao real. No TXT final a regra continua
+            # valendo integralmente: token ali significa que o rehydrate.py nao
+            # rodou, e e o nome do trabalhador que deixa de chegar ao autuado.
+            if motivo in SO_NO_TXT and rotulo == "autos.md":
+                continue
             for m in padrao.finditer(texto):
                 ini = max(0, m.start() - 45)
                 fim = min(len(texto), m.end() + 45)

--- a/_scripts/tokenizar.py
+++ b/_scripts/tokenizar.py
@@ -122,6 +122,33 @@ def add(mapa, nome, funcao, admissao, fonte):
     for t in mapa.setdefault("trabalhadores", []):
         if normaliza(t.get("nome", "")) == alvo:
             return t["token_nome"], True
+
+    # NOME QUE E PREFIXO (OU CONTINUACAO) DE OUTRO JA MAPEADO -- provavelmente a
+    # MESMA pessoa (26/08/2026, achado rodando o fluxo de ponta a ponta). O
+    # assistente passou "CARLOS HENRIQUE DE ALBUQUERQUE", cortado por uma
+    # exibicao de 30 caracteres, quando o de-para ja tinha "Carlos Henrique de
+    # Albuquerque Pereira": nasceu um segundo token para o mesmo trabalhador, sem
+    # aviso nenhum. Dois tokens da mesma pessoa num auto sugerem dois prejudicados
+    # onde ha um -- erro que so aparece depois de o auto estar lavrado.
+    # A guarda RECUSA e manda decidir; nao escolhe sozinha, porque homonimo
+    # parcial existe de verdade (pai e filho, irmaos com nome composto igual).
+    partes_alvo = alvo.split()
+    for t in mapa["trabalhadores"]:
+        outro = normaliza(t.get("nome", ""))
+        p_outro = outro.split()
+        menor, maior = sorted((partes_alvo, p_outro), key=len)
+        if len(menor) >= 2 and maior[:len(menor)] == menor:
+            print("ERRO: o nome informado e prefixo de um ja mapeado (ou vice-versa), "
+                  "e quase sempre e a MESMA pessoa:", file=sys.stderr)
+            print("  ja no de-para: %s -> %s" % (t["token_nome"], mascara(t.get("nome", ""))),
+                  file=sys.stderr)
+            print("  informado agora: %s" % mascara(nome), file=sys.stderr)
+            print("Se for a mesma pessoa, use o token que ja existe -- nao acrescente. "
+                  "Se forem pessoas diferentes, informe o nome COMPLETO de cada uma "
+                  "(nome truncado nunca entra no de-para: o auto sai com o nome errado).",
+                  file=sys.stderr)
+            sys.exit(3)
+
     token = proximo_token(mapa)
     entrada = {"token_nome": token, "nome": nome.strip()}
     if funcao:

--- a/_scripts/tokenizar.py
+++ b/_scripts/tokenizar.py
@@ -25,7 +25,10 @@ Uso:
   tokenizar.py <pasta-OS> --conferir <arquivo>        (token orfao? nome real vazado?)
   tokenizar.py <pasta-OS> --listar [--mostrar]        (mascarado por padrao)
 
-Exit 0 = ok; 1 = achado que exige acao; 2 = erro de uso.
+Exit 0 = ok; 1 = achado que exige acao; 2 = erro de uso; 3 = nome informado e
+prefixo de outro ja mapeado (provavel duplicata do mesmo trabalhador) -- quem
+decide e o AFT. Com --add-lista o 3 interrompe a lista e NADA e gravado: o
+arquivo so e salvo ao fim; corrija a lista e rode de novo.
 """
 
 try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)

--- a/novidades/2026-08-27-02-token-no-autos-e-nome-truncado.md
+++ b/novidades/2026-08-27-02-token-no-autos-e-nome-truncado.md
@@ -1,0 +1,32 @@
+## 27/08/2026
+<!-- commit: token-autos-md-e-nome-truncado -->
+
+**A revisão do auto reprovava exatamente o que as skills mandam escrever.** Antes de
+empacotar o auto para o Sistema Auditor, o toolkit passa uma guarda que impede o nosso
+ambiente de trabalho de vazar para dentro do documento legal — nome de arquivo interno,
+pasta de trabalho, caminho do computador. Essa guarda também reprovava os apelidos de
+trabalhador (`[[TRAB_01]]`) no rascunho do auto.
+
+Só que o apelido ali é o certo, e é o que a `/aft-auditoria-geral` e a `/aft-gera-ai`
+mandam usar: o nome real do trabalhador só entra no arquivo final, por substituição
+automática, para não ficar circulando na conversa. Resultado: todo auto que citava um
+trabalhador — praticamente todos — era reprovado, e não havia como consertar sem
+desobedecer às outras skills.
+
+Agora a guarda distingue os dois arquivos. No rascunho, o apelido é aceito. No arquivo
+final que vai ao Sistema Auditor, continua reprovando — ali o apelido significaria que o
+nome do trabalhador não chegou ao autuado, que é falha grave. Todo o resto da guarda segue
+igual nos dois.
+
+**Nome de trabalhador cortado não vira mais um segundo trabalhador.** Quando um nome é
+informado pela metade — cortado por uma lista que só mostrava os primeiros caracteres, por
+exemplo — o toolkit criava um apelido novo, em silêncio, para quem já tinha um. Dois
+apelidos da mesma pessoa num auto sugerem dois prejudicados onde há um, e o erro só
+apareceria depois da lavratura. Agora o toolkit recusa e avisa, mostrando os dois nomes
+abreviados: se for a mesma pessoa, usa-se o apelido que já existe; se forem pessoas
+diferentes, informa-se o nome completo de cada uma. Ele não escolhe sozinho de propósito —
+pai e filho com o mesmo nome composto existem de verdade.
+
+Achado e corrigido pelo colega Diego, rodando uma fiscalização de ponta a ponta.
+
+---


### PR DESCRIPTION
Dois defeitos achados rodando o fluxo de análise de resposta a NAD de ponta a ponta, numa fiscalização real. São independentes entre si; se preferir, dá para pegar um e descartar o outro — os hunks não se tocam.

## 1. O gate de revisão reprova todo auto redigido como a skill manda

O `checar_arquivos_internos.py` trata `[[TOKEN]]` como **"token de pseudonimizacao nao re-hidratado"** e aplicava a regra tanto ao `autos.md` quanto ao TXT do Sistema Auditor.

Mas o token no `autos.md` é correto e obrigatório — duas skills oficiais mandam escrevê-lo ali:

- **`/aft-auditoria-geral`**, em "Política de anonimização": *"Ao redigi-los nos autos, use os tokens `[[TRAB_NN]]` / `[[CPF_NN]]` no lugar do nome/CPF real"*.
- **`/aft-gera-ai`**, na 1.6: *"registre o nome no mapa de-para (FASE 2.5) e a partir daí refira-se a ele só pelo token `[[TRAB_NN]]`"*.

Resultado: o gate que a `/aft-revisa-auto` roda reprova exatamente o que as duas skills de redação instruem a escrever. Aconteceu comigo com o auto na mão, e o revisor não tinha como resolver — ele obedece à skill e é reprovado pela guarda.

**A correção usa uma distinção que o próprio conferidor já fazia.** O `trechos_do_arquivo()` já rotula as regiões: `"autos.md"` de um lado, `"auto N / texto"` do TXT de outro. Faltava só usar o rótulo. A regra do token passa a valer **apenas no TXT**, onde ela é exatamente certa: token ali significa que o `rehydrate.py` não rodou, e é o nome do trabalhador que deixa de chegar ao autuado.

Nenhum outro padrão foi afetado — `inspecao-fisica.md`, `memory.md`, `.depara_*.json`, pasta "OS ATIVAS", nome de skill e caminho de máquina continuam reprovando nos dois arquivos.

## 2. `tokenizar.py` cria token novo para a mesma pessoa, em silêncio

O casamento é por igualdade exata do nome normalizado. Um nome **truncado** não casa, e o script abre um token novo — sem aviso.

Aconteceu assim: o de-para já tinha `Carlos Henrique de Albuquerque Pereira` como `[[TRAB_02]]`; foi passado `CARLOS HENRIQUE DE ALBUQUERQUE`, cortado por uma exibição de 30 caracteres numa etapa anterior. Nasceu `[[TRAB_03]]`. Dois tokens da mesma pessoa num auto sugerem dois trabalhadores prejudicados onde há um — e o erro só aparece depois de o auto estar lavrado.

**A correção recusa e manda decidir.** Quando o nome informado é prefixo de um já mapeado (ou o contrário), com ao menos duas partes em comum, o script sai com erro mostrando os dois lados **mascarados** e explicando as duas saídas: se for a mesma pessoa, usar o token existente; se forem pessoas diferentes, informar o nome completo de cada uma.

Ele **não escolhe sozinho** de propósito: homônimo parcial existe de verdade — pai e filho, irmãos com nome composto igual. Escolher por conta própria trocaria um erro silencioso por outro.

## Testes

Do primeiro:

- `autos.md` real com tokens → **OK** (antes: REPROVADO)
- TXT com token no campo 18 da linha tipo 1 → **REPROVADO** (regra preservada)
- `autos.md` citando `inspecao-fisica.md` → **REPROVADO** (regra preservada)

Do segundo:

- nome completo → aceita
- mesmo nome truncado → **recusa**, com os dois lados mascarados
- pessoa genuinamente diferente → aceita
- nome exato repetido → reaproveita o token, sem duplicar

## Uma coisa que não fiz

Não acrescentei `--remover` ao `tokenizar.py`, embora a falta dela tenha me obrigado a editar o JSON à mão para desfazer o token duplicado. Achei que remover entrada de de-para merece decisão sua sobre o comportamento — se apaga, se marca como inativa, se renumera —, e não quis embutir a minha preferência num PR de correção.

Nenhum dado de fiscalização entra neste PR: os nomes acima são os do exemplo, e o código só imprime nome mascarado.
