### PR TITLE
fix(vigia): tenta instalar o plyvel uma vez só, e não copia a leveldb sem ele

### DIFF
--- a/_scripts/sessoes_os.py
+++ b/_scripts/sessoes_os.py
@@ -233,21 +233,34 @@ def carregar_config():
     return cfg
 
 
+# A instalação sob demanda do plyvel-ci é tentada UMA vez por processo. O vigia
+# roda em laço permanente, e há máquinas onde a instalação nunca pode dar certo
+# (Python gerenciado pelo uv recusa com "externally-managed-environment"):
+# repetir o pip a cada volta do laço custaria um subprocesso por minuto, para
+# sempre, e enchia o log com o mesmo AVISO. Falhou uma vez, segue no fallback.
+_PLYVEL_FALHOU = False
+
+
 def _ensure_plyvel():
     """Importa a lib de leveldb; instala plyvel-ci sob demanda (é problema técnico
-    nosso, não do AFT — resolvemos sozinhos)."""
+    nosso, não do AFT — resolvemos sozinhos). Instala só na primeira tentativa."""
+    global _PLYVEL_FALHOU
     try:
         import plyvel  # noqa: F401
         return plyvel
     except ImportError:
         pass
+    if _PLYVEL_FALHOU:
+        return None
     try:
         subprocess.run([sys.executable, "-m", "pip", "install", "--quiet",
                         "plyvel-ci"], check=True, **SEM_JANELA)
         import plyvel  # noqa: F401
         return plyvel
     except (OSError, subprocess.CalledProcessError, ImportError) as e:
-        log(f"AVISO: não consegui preparar a leveldb (plyvel-ci): {e}")
+        _PLYVEL_FALHOU = True
+        log(f"AVISO: não consegui preparar a leveldb (plyvel-ci): {e} — sigo pelo "
+            "config JSON e não tento instalar de novo nesta execução.")
         return None
 
 
@@ -287,8 +300,10 @@ def ler_scopes_leveldb():
     """Lê o mapa dframe-group-scopes do Local Storage (fonte de verdade dos grupos).
     Retorna o dict de scopes, {} se a chave não existe, ou None se não deu para ler."""
     plyvel = _ensure_plyvel()
+    if not plyvel:       # sem a lib, copiar a leveldb inteira do app seria desperdício
+        return None
     cop = _copia_leveldb()
-    if not plyvel or not cop:
+    if not cop:
         return None
     tmp, dst = cop
     try:

--- a/novidades/2026-08-27-03-vigia-aviso-repetido.md
+++ b/novidades/2026-08-27-03-vigia-aviso-repetido.md
@@ -1,0 +1,22 @@
+## 27/08/2026
+<!-- commit: vigia-aviso-repetido -->
+
+**O vigia das sessões parou de repetir o mesmo aviso e de fazer trabalho à toa.** Quem
+cria sozinho a sessão de cada auditoria no grupo "OS ATIVAS" é um vigia que fica em
+segundo plano. Para ler os grupos do app, ele usa um componente extra que, quando falta,
+ele tenta instalar sozinho.
+
+Em algumas máquinas essa instalação nunca pode dar certo (o Python instalado ali recusa,
+por segurança, instalar coisas por fora). O vigia não guardava essa informação: tentava
+de novo a cada volta, mais ou menos a cada minuto, para sempre — e cada tentativa deixava
+uma linha de AVISO no registro `.sessoes-os.log`. No caso real, o registro acumulou
+avisos idênticos de um dia inteiro. Pior: mesmo sem o componente, ele ainda copiava 15 MB
+de dados do app antes de descobrir que não ia conseguir ler nada.
+
+Agora ele tenta **uma vez só** por execução. Não deu, avisa uma vez e segue pelo caminho
+alternativo, em silêncio, sem copiar nada. O registro volta a mostrar só o que interessa,
+e a máquina para de trabalhar de graça enquanto você usa o computador.
+
+Nada muda no que você vê: as sessões continuam sendo criadas do mesmo jeito.
+
+---


### PR DESCRIPTION
Dois desperdícios encadeados no caminho do `plyvel` em `_scripts/sessoes_os.py`, confirmados no `.sessoes-os.log` da máquina do AFT (avisos de 26/08 até 27/08 04:55).

**1. `pip install` a cada volta do laço.** `_ensure_plyvel()` tentava instalar o `plyvel-ci` em toda chamada. Onde a instalação nunca pode dar certo (Python gerenciado pelo uv, que recusa com `externally-managed-environment` / PEP 668), o laço permanente do vigia repetia o subprocesso ~1x por minuto, para sempre, com um AVISO idêntico no log a cada vez. A tentativa passa a ser memorizada em variável de módulo — uma por processo. O `import plyvel` continua sendo tentado sempre, então a lib instalada por outro caminho é aproveitada sem reiniciar o vigia; e reiniciar o vigia refaz a tentativa uma vez, que é o desejável.

**2. Cópia da leveldb feita antes de saber se serviria.** `ler_scopes_leveldb()` chamava `_copia_leveldb()` antes de testar `_ensure_plyvel()`. Sem a lib, o `copytree` da pasta leveldb inteira do app (15 MB, 0,34 s) era feito só para ser descartado. Agora sai cedo quando `plyvel` é `None`.

Medido com `plyvel` ausente e `pip` que sempre recusa, em 10 chamadas: antes 10 tentativas de pip, 5 cópias e 10 avisos; depois **1 tentativa, 0 cópias, 1 aviso**. `--status` roda normalmente na máquina.

Casa da regra: changelog em `novidades/2026-08-27-03-vigia-aviso-repetido.md`; nota técnica `sessoes-os-vigia.md` com seção `## Atualização (27/08/2026)` acrescentada (não reescrita); `arquitetura/arquitetura.json` não muda — o `plyvel` não aparece lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)