### PR TITLE
Painel: dados cadastrais caem para o corpo da ficha; skill de CNAE grava o front-matter

### DIFF
--- a/_scripts/gerar_painel.py
+++ b/_scripts/gerar_painel.py
@@ -95,6 +95,14 @@ RE_TITULO = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
 # rural, empregador doméstico) tem CPF/CAEPF no lugar do CNPJ — a linha vem
 # rotulada "**CPF:**", e sem isso o card ficava "CNPJ não informado".
 RE_CNPJ_BODY = re.compile(r"\*\*(?:CNPJ|CPF|CAEPF|CNPJ/CPF)\s*:\*\*\s*([\d./-]+)")
+# Fallback dos campos cadastrais no corpo (o espelho humano do front-matter):
+# ficha em que uma skill apurou o dado e gravou só a linha em negrito, deixando
+# o front-matter vazio. Pega só o número/código inicial — o resto da linha é
+# texto para gente ("3 (Anexo I da NR-04)", "1.306 empregados (1.151 homens...)").
+RE_GRAU_BODY = re.compile(r"\*\*Grau de risco\s*:\*\*\s*([1-4])\b")
+RE_CNAE_BODY = re.compile(r"\*\*CNAE\s*:\*\*\s*([0-9][0-9./-]*[0-9])")
+RE_TRAB_BODY = re.compile(
+    r"\*\*(?:N[ºo°]?\.?\s*de\s*trabalhadores|Quadro de pessoal)\s*:\*\*\s*([\d.]+)")
 RE_PRAZO = re.compile(
     r"(?:prazo|entrega\s+at[eé])[:\s]+(\d{2}/\d{2}/\d{4}|\d{4}-\d{2}-\d{2})",
     re.IGNORECASE)
@@ -254,7 +262,9 @@ def saida_artifact() -> Path | None:
 
 
 def parse_fm(fm: str, chave: str) -> str | None:
-    m = re.search(rf"^{chave}\s*:\s*(.+?)\s*$", fm, re.MULTILINE)
+    # [ \t] em vez de \s: com o campo vazio ("grau_risco:"), \s engolia a quebra
+    # de linha e o valor devolvido era a LINHA SEGUINTE do front-matter.
+    m = re.search(rf"^{chave}[ \t]*:[ \t]*(.*?)[ \t]*$", fm, re.MULTILINE)
     if not m:
         return None
     v = m.group(1).strip().strip('"').strip("'")
@@ -347,6 +357,18 @@ def parse_memory(path: Path) -> dict:
     num_trab = parse_fm(fm, "trabalhadores") or parse_fm(fm, "num_trabalhadores")
     cnae = parse_fm(fm, "cnae")
     grau_risco = parse_fm(fm, "grau_risco")
+    # Front-matter vazio, corpo preenchido: cai para o espelho humano, como já
+    # acontece com empregador e CNPJ.
+    if not num_trab:
+        m = RE_TRAB_BODY.search(corpo)
+        if m:
+            num_trab = m.group(1).replace(".", "")
+    if not cnae:
+        m = RE_CNAE_BODY.search(corpo)
+        cnae = m.group(1) if m else None
+    if not grau_risco:
+        m = RE_GRAU_BODY.search(corpo)
+        grau_risco = m.group(1) if m else None
     ri = parse_fm(fm, "ri") or parse_fm(fm, "os") or ""
 
     # DETs — uma entrada por linha checkbox da seção.

--- a/aft-cnae-grau-risco-nr04/SKILL.md
+++ b/aft-cnae-grau-risco-nr04/SKILL.md
@@ -64,6 +64,23 @@ integralmente contra o PDF oficial (zero divergências). O Anexo I opera em nív
 5. Para dúvidas conceituais ou navegação por seção/divisão da CNAE, consulte
    `references/anexo_i_cnae_gr.md` (tabela integral estruturada, com seções A–U).
 
+## Gravação na ficha da OS (memory.md)
+
+Se a consulta é de uma empresa com pasta em `OS ATIVAS/` (sessão da OS, ou empresa
+identificada pelo AFT), grave o resultado no `memory.md` dela — **nos dois lugares,
+sempre juntos**:
+
+1. **Front-matter:** `grau_risco: <GR>` e, se o campo estiver vazio, também
+   `cnae: "<XXXX-X/XX>"`. É daqui que o `/aft-painel` e os scripts leem — a linha em
+   negrito do corpo é o espelho humano, não a fonte deles.
+2. **Corpo** (cabeçalho em negrito, esquema da `/aft-nova-auditoria`):
+   `**CNAE:** <código> — <denominação>` e `**Grau de risco:** <GR> (Anexo I da NR-04)`.
+
+Nunca preencha só um dos dois: front-matter vazio deixa o card do painel sem o dado, e
+corpo vazio esconde o dado do AFT. Se a atividade preponderante divergir da principal
+(item 4.5.1), grave o **maior** GR e anote a divergência em `## Auditoria de documentos`.
+Consulta avulsa, sem OS, não grava nada.
+
 ## Formato padrão de resposta (consulta por código)
 
 ```

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -591,7 +591,7 @@ const ARCH = {
     {
       "nome": "gerar_painel.py",
       "caminho": "_scripts/gerar_painel.py",
-      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante; desde 27/08/2026, campo cadastral vazio no front-matter — trabalhadores, cnae, grau_risco — cai para a linha em negrito do corpo da ficha, como já acontecia com empregador e CNPJ, e campo vazio nunca mais devolve a linha seguinte do front-matter como valor), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
       "runtime": "Python stdlib (+pdfplumber opcional)"
     },
     {

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -458,7 +458,7 @@
     {
       "nome": "gerar_painel.py",
       "caminho": "_scripts/gerar_painel.py",
-      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
+      "papel": "Varre OS ATIVAS/*/memory.md (parser tolerante; desde 27/08/2026, campo cadastral vazio no front-matter — trabalhadores, cnae, grau_risco — cai para a linha em negrito do corpo da ficha, como já acontecia com empregador e CNPJ, e campo vazio nunca mais devolve a linha seguinte do front-matter como valor), calcula dias-para-o-prazo com date.today(), detecta PDFs de notificação DET não cadastrados (código por regex + 1ª página via pdfplumber, comparado ao memory.md) e gera o painel.html autocontido; 3º argumento opcional grava a versão para a tool Artifact (sem wrapper HTML e sem a coluna Pasta). Imprime resumo JSON no stdout.",
       "runtime": "Python stdlib (+pdfplumber opcional)"
     },
     {

--- a/novidades/2026-08-27-06-painel-dados-cadastrais.md
+++ b/novidades/2026-08-27-06-painel-dados-cadastrais.md
@@ -1,0 +1,16 @@
+## 27/08/2026
+<!-- commit: painel-frontmatter-fallback -->
+
+**O cartão do painel não perde mais o grau de risco, o CNAE e o nº de trabalhadores.**
+A ficha de cada empresa (o memory.md) guarda esses dados em dois lugares: o cabeçalho
+técnico que os programas leem e as linhas em negrito que você lê. Quando um deles era
+preenchido sem o outro, o painel mostrava o cartão sem o dado — e, num caso pior, com
+um texto sem sentido no lugar do grau de risco (defeito real, encontrado numa OS ativa:
+o campo vazio fazia o painel ler a linha errada da ficha). Três consertos: o painel
+agora encontra o dado onde ele estiver na ficha (se o cabeçalho técnico está vazio, ele
+lê as linhas em negrito); campo vazio nunca mais vira texto sem sentido; e a habilidade
+de grau de risco (/aft-cnae-grau-risco-nr04) passou a preencher os dois lugares da ficha
+ao apurar o enquadramento de uma empresa com OS aberta. Nenhuma ficha sua precisa ser
+corrigida à mão.
+
+---


### PR DESCRIPTION
## O que muda para o AFT

O cartao do painel nao perde mais o grau de risco, o CNAE e o numero de trabalhadores quando a ficha (memory.md) tem o dado so nas linhas em negrito do corpo, com o front-matter vazio. Caso real: uma OS ativa tinha **Grau de risco:** 3 no corpo e grau_risco: vazio no cabecalho tecnico - o card saia sem o dado.

## Consertos

1. **parse_fm devolvia a linha seguinte quando o campo estava vazio** (o \s* do regex engolia a quebra de linha): grau_risco: vazio virava "status: em_andamento" no card. Trocado por [ \t].
2. **Fallback para o corpo** em trabalhadores/cnae/grau_risco no parse_memory, como ja existia para empregador e CNPJ. Pega so o numero/codigo inicial da linha em negrito; front-matter preenchido continua mandando. Aceita os rotulos "No de trabalhadores" e "Quadro de pessoal".
3. **/aft-cnae-grau-risco-nr04 passou a gravar na ficha** (secao nova "Gravacao na ficha da OS"): front-matter E corpo, sempre juntos, quando a consulta e de empresa com OS aberta. A /aft-preparacao-acao-fiscal ja mandava gravar e nao foi tocada.

## Testes

Pasta de mentira (fora de OS ATIVAS): 4 casos do parser (FM vazio + corpo cheio; FM preenchido vence; rotulo alternativo; nada em lugar nenhum) + geracao completa do painel + node --check no JS embutido. Tudo passou.

## Documentacao

- Changelog: novidades/2026-08-27-06-painel-dados-cadastrais.md
- Nota tecnica: atualizacao em ficha-memory-md-e-painel.md (cofre)
- Arquitetura: json + html sincronizados (--checar-arquitetura OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)