### PR TITLE
fix: scan da analise preliminar enxerga caminho longo no Windows (MAX_PATH)

### DIFF
--- a/_scripts/analise_preliminar_scan.py
+++ b/_scripts/analise_preliminar_scan.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -46,6 +47,42 @@ if hasattr(sys.stdout, "reconfigure"):
 
 ITEM_RE = re.compile(r"^item(\d+)[_ ]?(.*)$", re.IGNORECASE)
 DIA_RE = re.compile(r"^baixada em (\d{2}-\d{2}-\d{4})$", re.IGNORECASE)
+
+# Avisos de leitura acumulados durante a varredura (vão no JSON de saída):
+# arquivo/pasta que não pôde ser lido NUNCA some em silêncio do inventário.
+AVISOS: list[str] = []
+
+
+def _lp(p: Path) -> Path:
+    """Windows: caminho estendido (prefixo \\\\?\\), que escapa do limite de
+    260 caracteres do MAX_PATH. Pasta de OS dentro do OneDrive + pacote de
+    notificação + subpasta do dia + item com descrição longa passam fácil dos
+    260, e sem o prefixo o Python nem ENXERGA o arquivo: itens do pacote
+    sumiam do inventário sem erro nenhum (ticket de 28/08/2026; mesma causa
+    da issue #104 no det_baixar.py). Como os filhos de um caminho prefixado
+    herdam o prefixo, basta aplicar na raiz do pacote. Fora do Windows
+    devolve o caminho como veio."""
+    if os.name != "nt":
+        return p
+    s = os.path.abspath(str(p))
+    if s.startswith("\\\\?\\"):
+        return Path(s)
+    if s.startswith("\\\\"):  # caminho de rede (UNC)
+        return Path("\\\\?\\UNC\\" + s[2:])
+    return Path("\\\\?\\" + s)
+
+
+def _visivel(p: Path | str | None) -> str | None:
+    """Caminho SEM o prefixo \\\\?\\, para o JSON de saída e mensagens: o
+    prefixo é detalhe de I/O, não deve vazar para o relatório da skill."""
+    if p is None:
+        return None
+    s = str(p)
+    if s.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + s[8:]
+    if s.startswith("\\\\?\\"):
+        return s[4:]
+    return s
 
 # Limiar de "item volumoso" num dia: a partir daqui a skill não lê arquivo por
 # arquivo — amostra e devolve PRECISA AUDITORIA AFT. Uma fonte só, aqui.
@@ -89,12 +126,26 @@ def inventariar_arquivos(pasta: Path, invalidado: bool) -> list[dict]:
             continue
         try:
             size = entry.stat().st_size
-        except OSError:
+        except OSError as e:
+            # Nunca pular calado: subcontar arquivo vira falso "não entregue".
+            aviso = (f"arquivo ilegível (fica FORA da contagem): "
+                     f"{_visivel(entry)} - {e}")
+            AVISOS.append(aviso)
+            print(f"AVISO: {aviso}", file=sys.stderr)
             continue
+        try:
+            sha = sha256_of(entry)
+        except OSError as e:
+            # Arquivo visível mas ilegível (ex.: OneDrive só na nuvem, sem
+            # rede): entra na contagem, sem hash, e o aviso vai no relatório.
+            sha = None
+            aviso = f"conteúdo ilegível (sem hash): {_visivel(entry)} - {e}"
+            AVISOS.append(aviso)
+            print(f"AVISO: {aviso}", file=sys.stderr)
         out.append({
             "nome": entry.name,
             "tipo": classify(entry.name),
-            "sha256": sha256_of(entry),
+            "sha256": sha,
             "tamanho_kb": round(size / 1024, 1),
             "invalidado": invalidado,
         })
@@ -138,9 +189,9 @@ def inventariar_dia(dia_dir: Path, rotulo: str) -> dict:
     historico = dia_dir / "historico-itens.md"
     return {
         "dia": rotulo,
-        "pasta": str(dia_dir),
-        "relatorio_atendimento": str(relatorio[0]) if relatorio else None,
-        "historico_itens": str(historico) if historico.is_file() else None,
+        "pasta": _visivel(dia_dir),
+        "relatorio_atendimento": _visivel(relatorio[0]) if relatorio else None,
+        "historico_itens": _visivel(historico) if historico.is_file() else None,
         "itens": itens,
     }
 
@@ -152,7 +203,7 @@ def detectar_duplicatas(dias: list[dict]) -> list[dict]:
     for d in dias:
         for it in d["itens"]:
             for a in it["arquivos"]:
-                if a["invalidado"]:
+                if a["invalidado"] or a["sha256"] is None:
                     continue
                 bucket.setdefault(a["sha256"], []).append({
                     "dia": d["dia"],
@@ -189,9 +240,12 @@ def main(argv: list[str]) -> int:
               file=sys.stderr)
         return 9
 
-    pacote = Path(args[0]).expanduser().resolve()
+    # Prefixo de caminho estendido ANTES de qualquer acesso a disco: todos os
+    # filhos (dias, itens, arquivos) herdam o prefixo e escapam do MAX_PATH.
+    pacote = _lp(Path(args[0]).expanduser().resolve())
     if not pacote.is_dir():
-        print(f"ERRO: pasta não encontrada: {pacote}", file=sys.stderr)
+        print(f"ERRO: pasta não encontrada: {_visivel(pacote)}",
+              file=sys.stderr)
         return 1
 
     # Código da notificação: token alfanumérico maiúsculo no nome do pacote
@@ -226,18 +280,20 @@ def main(argv: list[str]) -> int:
     notificacao_pdf = sorted(pacote.glob("notificacao-*.pdf"))
     out = {
         "notificacao": codigo,
-        "pacote": str(pacote),
-        "empresa_dir": str(empresa_dir),
-        "notificacao_pdf": str(notificacao_pdf[0]) if notificacao_pdf else None,
+        "pacote": _visivel(pacote),
+        "empresa_dir": _visivel(empresa_dir),
+        "notificacao_pdf": (_visivel(notificacao_pdf[0])
+                            if notificacao_pdf else None),
         "dias": dias,
         "duplicatas": detectar_duplicatas(dias),
+        "avisos": AVISOS,
     }
 
     texto = json.dumps(out, ensure_ascii=False, indent=2)
     if saida:
         try:
-            saida.parent.mkdir(parents=True, exist_ok=True)
-            saida.write_text(texto, encoding="utf-8")
+            _lp(saida).parent.mkdir(parents=True, exist_ok=True)
+            _lp(saida).write_text(texto, encoding="utf-8")
         except OSError as e:
             print(f"ERRO de I/O ao gravar {saida}: {e}", file=sys.stderr)
             return 9
@@ -246,6 +302,10 @@ def main(argv: list[str]) -> int:
         print(f"Notificação {codigo}: {len(dias)} dia(s) de entrega, "
               f"{n_itens} item(ns) com pasta, "
               f"{len(out['duplicatas'])} duplicata(s).")
+        if AVISOS:
+            print(f"ATENÇÃO: {len(AVISOS)} aviso(s) de leitura - veja o "
+                  f"campo 'avisos' do inventário antes de confiar nas "
+                  f"contagens.")
     else:
         print(texto)
     return 0

--- a/agents/aft-analista-preliminar.md
+++ b/agents/aft-analista-preliminar.md
@@ -76,8 +76,15 @@ Se faltar algum (fora o opcional), pare e diga o que falta; não adivinhe caminh
 
    Use a pasta temporária do sistema para o JSON, nunca a pasta da OS. O JSON traz, por
    dia de entrega: itens, arquivos com tipo/SHA-256/tamanho, o que está em
-   `invalidados/`, a marca `volumoso` e as `duplicatas` (mesmo SHA-256 em 2+ lugares,
-   entre itens ou entre dias).
+   `invalidados/`, a marca `volumoso`, as `duplicatas` (mesmo SHA-256 em 2+ lugares,
+   entre itens ou entre dias) e o campo `avisos` (arquivos que o script viu mas não
+   conseguiu ler por inteiro). Se `avisos` não estiver vazio, as contagens daquele item
+   podem estar incompletas: transcreva cada aviso no relatório, na seção "Decisões
+   pendentes do AFT", e não conclua "não entregue" para item citado ali.
+   Sanidade: compare os itens do inventário com os da notificação e com o
+   `historico-itens.md` — item que a notificação lista mas o inventário não traz merece
+   conferência manual da pasta antes de qualquer conclusão, nunca um "não entregue"
+   automático.
 
 2. **Metadados antes de PDF.** Leia primeiro o que já é texto barato:
    - `historico-itens.md` de cada dia — status oficial de cada item (enviado, não

--- a/arquitetura/arquitetura.html
+++ b/arquitetura/arquitetura.html
@@ -821,7 +821,7 @@ const ARCH = {
     {
       "nome": "analise_preliminar_scan.py",
       "caminho": "_scripts/analise_preliminar_scan.py",
-      "papel": "Inventário SOMENTE LEITURA do pacote de uma notificação DET, por dia de entrega (baixada em <data>/): tipo lógico, SHA-256 e tamanho de cada arquivo, invalidados/ à parte, marca de item volumoso e duplicatas entre itens e dias. Sem flatten: a estrutura por dia é prova. JSON no stdout ou em arquivo (--saida).",
+      "papel": "Inventário SOMENTE LEITURA do pacote de uma notificação DET, por dia de entrega (baixada em <data>/): tipo lógico, SHA-256 e tamanho de cada arquivo, invalidados/ à parte, marca de item volumoso e duplicatas entre itens e dias. Sem flatten: a estrutura por dia é prova. JSON no stdout ou em arquivo (--saida). Windows: varre por caminho estendido (\\\\?\\, mesmo remédio da issue #104 no det_baixar.py) — sem ele, pacote dentro do OneDrive passava dos 260 caracteres do MAX_PATH e itens sumiam do inventário sem erro (ticket de 28/08/2026). Arquivo ilegível nunca é pulado calado: entra no campo 'avisos' do JSON, que o agente transcreve nas decisões pendentes.",
       "runtime": "Python stdlib"
     }
   ],

--- a/arquitetura/arquitetura.json
+++ b/arquitetura/arquitetura.json
@@ -688,7 +688,7 @@
     {
       "nome": "analise_preliminar_scan.py",
       "caminho": "_scripts/analise_preliminar_scan.py",
-      "papel": "Inventário SOMENTE LEITURA do pacote de uma notificação DET, por dia de entrega (baixada em <data>/): tipo lógico, SHA-256 e tamanho de cada arquivo, invalidados/ à parte, marca de item volumoso e duplicatas entre itens e dias. Sem flatten: a estrutura por dia é prova. JSON no stdout ou em arquivo (--saida).",
+      "papel": "Inventário SOMENTE LEITURA do pacote de uma notificação DET, por dia de entrega (baixada em <data>/): tipo lógico, SHA-256 e tamanho de cada arquivo, invalidados/ à parte, marca de item volumoso e duplicatas entre itens e dias. Sem flatten: a estrutura por dia é prova. JSON no stdout ou em arquivo (--saida). Windows: varre por caminho estendido (\\\\?\\, mesmo remédio da issue #104 no det_baixar.py) — sem ele, pacote dentro do OneDrive passava dos 260 caracteres do MAX_PATH e itens sumiam do inventário sem erro (ticket de 28/08/2026). Arquivo ilegível nunca é pulado calado: entra no campo 'avisos' do JSON, que o agente transcreve nas decisões pendentes.",
       "runtime": "Python stdlib"
     }
   ],

--- a/novidades/2026-08-28-04-analise-preliminar-caminho-longo.md
+++ b/novidades/2026-08-28-04-analise-preliminar-caminho-longo.md
@@ -1,0 +1,28 @@
+## 28/08/2026 (4)
+<!-- commit: analise-preliminar-caminho-longo -->
+
+**A triagem preliminar não perde mais itens por caminho longo no Windows.** Um AFT
+relatou (ticket de 28/08/2026) que a `/aft-analise-preliminar` de uma notificação com 8
+itens listou só 6 e ainda subcontou os arquivos de um terceiro: a pasta dele fica dentro
+do OneDrive, os nomes de item do DET são longos, e o caminho completo passava dos 260
+caracteres que o Windows aceita por padrão. Acima desse limite o inventário simplesmente
+não enxergava as pastas, sem nenhum erro na tela — e item entregue podia aparecer como
+"não entregue".
+
+- **Corrigido na raiz.** O script de inventário agora usa o modo de caminho estendido do
+  Windows (o mesmo remédio já aplicado no download do DET, que tinha o defeito irmão) e
+  enxerga qualquer profundidade de pasta. Quem usa Mac não era afetado e não muda nada.
+- **Fim das falhas silenciosas.** Se algum arquivo não puder ser lido por qualquer outro
+  motivo (por exemplo, arquivo do OneDrive "somente na nuvem" sem internet no momento), a
+  varredura não pula mais calada: o arquivo entra na contagem quando possível e o
+  problema sai listado no relatório, na seção de decisões pendentes, avisando que a
+  contagem daquele item merece conferência.
+- **Conferência cruzada.** A triagem passou a comparar os itens do inventário com a lista
+  da própria notificação: item que existe na notificação mas não aparece na pasta agora
+  gera conferência manual, nunca um "não entregue" automático.
+
+**O que você precisa fazer: nada.** Basta atualizar o toolkit (`/aft-atualizar`). Se uma
+triagem recente sua bateu com contagem estranha em pasta do OneDrive, vale rodar a
+`/aft-analise-preliminar` de novo naquela notificação.
+
+---


### PR DESCRIPTION
## Resumo

Corrige o ticket de campo `ticket-2026-08-28-0812`: em maquina Windows com a pasta de trabalho dentro do OneDrive, o `analise_preliminar_scan.py` omitiu 2 de 8 itens de uma notificacao e subcontou os arquivos de um terceiro, sem nenhum erro - caminho completo acima dos 260 caracteres do MAX_PATH. E o defeito irmao da issue #104 (det_baixar.py): o remedio foi aplicado no download e na mudanca de pasta, mas o scan da triagem nasceu depois e ficou sem.

## O que muda

- **`_lp()`**: prefixo de caminho estendido `\\?\` (e `\\?\UNC\` para rede) aplicado uma vez na raiz do pacote; todos os filhos herdam. `_visivel()` remove o prefixo do JSON de saida e das mensagens.
- **Fim das falhas silenciosas**: `stat` ou leitura de conteudo que falhe (ex.: OneDrive "somente na nuvem" sem rede) nao pula mais calado - aviso no stderr e no campo novo `avisos` do JSON; arquivo com conteudo ilegivel entra na contagem com `sha256: null` (excluido das duplicatas). O resumo final alerta quando ha avisos.
- **Agente** (`aft-analista-preliminar`): transcreve os `avisos` na secao "Decisoes pendentes do AFT" e cruza o inventario com a lista da notificacao e o `historico-itens.md` - item da notificacao sem pasta no inventario vira conferencia manual, nunca "nao entregue" automatico.
- Changelog em `novidades/`, arquitetura (.json + .html sincronizados) e nota tecnica no cofre atualizados.

## Teste

Smoke-test em pasta de mentira (fora de OS ATIVAS): inventario, invalidados e deteccao de duplicata intactos, campo `avisos` presente e vazio no caminho feliz; `py_compile` ok. A parte Windows segue o mesmo padrao ja provado em producao no `det_baixar.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)