### PR TITLE
fix(checar_acentos): ignora caminho de arquivo e front-matter

### DIFF
--- a/_scripts/checar_acentos.py
+++ b/_scripts/checar_acentos.py
@@ -155,9 +155,19 @@ CAMELCASE = re.compile(r"^.[a-zà-ÿ]*[A-ZÀ-Ü]")
 # "... REFRIGERACAO ..." ou "... SEGURANCA ..." — todas na lista acima, e todas
 # comuns em razão social brasileira. Foi assim que o defeito apareceu: numa
 # fiscalização real, a razão social da autuada terminava em "DECORACOES".
+# O "E" e o "&" entram como CONECTOR de uma letra so. Sem isso, uma razao social
+# que comece imediatamente antes do conector -- "MOVEIS E DECORACOES LTDA" -- tinha
+# a primeira palavra deixada de fora da mascara, e "MOVEIS" caia na lista de
+# palavras sem acento. Achado em 27/08/2026, no teste que consolidou esta guarda
+# com a do metodo: o nome COMPLETO da autuada passava (a corrida comeca antes e
+# cobre tudo), e so o nome comecado no conector falhava -- falso positivo raro e
+# por isso mais dificil de achar. Continua exigindo ao menos uma palavra de 2+
+# letras na corrida: letra solta no meio de prosa nao vira mascara.
 CAIXA_ALTA = re.compile(
     r"(?<![0-9A-Za-zÀ-ÿ])[A-ZÀ-ÜÇ][A-ZÀ-ÜÇ0-9&./\-]*"
-    r"(?:\s+[A-ZÀ-ÜÇ0-9&./\-]{2,}){1,}(?![0-9A-Za-zÀ-ÿ])")
+    r"(?:\s+(?:[A-ZÀ-ÜÇ0-9&./\-]{2,}|E|&))*"
+    r"\s+[A-ZÀ-ÜÇ0-9&./\-]{2,}"
+    r"(?:\s+(?:[A-ZÀ-ÜÇ0-9&./\-]{2,}|E|&))*(?![0-9A-Za-zÀ-ÿ])")
 
 
 # Trecho entre crases e LITERAL, nao prosa: caminho de arquivo, nome de pasta,

--- a/_scripts/checar_acentos.py
+++ b/_scripts/checar_acentos.py
@@ -168,6 +168,18 @@ CAIXA_ALTA = re.compile(
 # verificador (a mesma licao dos alarmes falsos ja corrigidos no metodo).
 CODIGO = re.compile(r"`[^`]*`")
 
+# Trecho que e CAMINHO ou NOME DE ARQUIVO: tem barra entre palavras, ou termina em
+# extensao conhecida. Deliberadamente estreito -- nao basta ser palavra sem acento,
+# tem de parecer caminho de verdade.
+#
+# PORTADO do checar_texto_oficial.py (27/08/2026), que ja resolvia isto e por isso
+# ACEITAVA um texto que este script REPROVAVA: duas guardas de acentuacao dando
+# vereditos opostos sobre a mesma frase. Guarda que reprova o documento correto e
+# desligada por quem a usa, e ai deixa de proteger de tudo.
+CAMINHO = re.compile(
+    r"(?:[A-Za-zÀ-ÿ0-9_.\-]+[\\/])+[A-Za-zÀ-ÿ0-9_.\-]*"
+    r"|\b[A-Za-zÀ-ÿ0-9_\-]+\.(?:md|py|docx|pdf|json|txt|csv|xlsx|html|zip)\b")
+
 
 def mascarar_nomes_proprios(linha):
     """Troca por espaços o que não é prosa, preservando as colunas.
@@ -180,6 +192,7 @@ def mascarar_nomes_proprios(linha):
     trecho de contexto que o relatório imprime.
     """
     linha = CODIGO.sub(lambda m: " " * len(m.group(0)), linha)
+    linha = CAMINHO.sub(lambda m: " " * len(m.group(0)), linha)
     return CAIXA_ALTA.sub(lambda m: " " * len(m.group(0)), linha)
 
 
@@ -200,8 +213,23 @@ def main():
     except UnicodeDecodeError:
         texto = open(caminho, encoding="latin-1").read()
 
+    # FRONT-MATTER (--- ... ---) e CONFIGURACAO, nao prosa: os valores sao enums
+    # da API de destino, escritos sem acento de proposito ("tipo: obrigacao", que o
+    # det_criar.py documenta como "solicitacao | obrigacao | orientacao"), e os
+    # comentarios ali sao anotacao de trabalho do AFT. Acusa-los reprovava TODA
+    # notificacao real -- a do acervo dava 9 ocorrencias, nenhuma delas erro de
+    # grafia. Guarda que reprova o documento correto ensina a ignorar a guarda.
+    # As linhas continuam contando: o numero de linha do relatorio segue valendo.
+    linhas = texto.splitlines()
+    if linhas and linhas[0].strip() == "---":
+        for k in range(1, len(linhas)):
+            if linhas[k].strip() == "---":
+                for j in range(0, k + 1):
+                    linhas[j] = " " * len(linhas[j])
+                break
+
     achados = []
-    for i, linha in enumerate(texto.splitlines(), 1):
+    for i, linha in enumerate(linhas, 1):
         # A razão social vai no auto sem acento, como consta do cadastro da RFB:
         # ela sai da conferência, e só ela. O resto da linha continua valendo.
         conferivel = mascarar_nomes_proprios(linha)

--- a/novidades/2026-08-28-10-checar-acentos-falso-positivo.md
+++ b/novidades/2026-08-28-10-checar-acentos-falso-positivo.md
@@ -1,0 +1,15 @@
+## 28/08/2026
+<!-- commit: checar-acentos-caminho-frontmatter -->
+
+**O conferidor de acentuacao parou de reprovar documento correto.** A ferramenta que
+confere se o texto foi escrito com acentuacao completa vinha acusando "erro" em duas
+coisas que nao sao prosa: o caminho de um arquivo (`_scripts/montar_rt.py`, `memory.md`)
+e o cabecalho de configuracao no topo das notificacoes, cujos valores sao escritos sem
+acento de proposito porque o DET os exige assim. Numa notificacao real do acervo isso
+dava nove reclamacoes, nenhuma delas erro de grafia de verdade. Guarda que reprova o
+documento certo ensina a ignorar a guarda, e ai ela deixa de proteger de tudo. Corrigido:
+os dois casos passam a ser ignorados, e o erro de acentuacao de verdade continua sendo
+apontado. De quebra, razao social com "E" no meio ("MOVEIS E DECORACOES LTDA") tambem
+deixou de ser confundida com prosa sem acento.
+
+---


### PR DESCRIPTION
## Resumo

`checar_acentos.py` acusava falso positivo em dois casos:

1. **Caminho/nome de arquivo** (barra entre palavras, ou extensão conhecida) sendo lido como prosa sem acento.
2. **Front-matter** (`--- ... ---`) sendo conferido como prosa — os valores são enums da API de destino, escritos sem acento de propósito (ex.: `tipo: obrigacao`), e os comentários ali são anotação de trabalho do AFT.

Isso já tinha sido resolvido no `checar_texto_oficial.py`; duas guardas de acentuação davam veredito oposto sobre a mesma frase, e a que reprovava (esta) chegava a reprovar **toda notificação real do acervo** (9 ocorrências, nenhuma erro de grafia de fato) — guarda que reprova o documento correto ensina a ignorar a guarda.

## Correção

Portado o mesmo tratamento do `checar_texto_oficial.py`: regex `CAMINHO` mascara trecho que parece caminho/nome de arquivo antes da conferência; bloco de front-matter é mascarado por inteiro (linhas continuam contando para o número de linha do relatório).

🤖 Gerado com [Claude Code](https://claude.com/claude-code)