### PR TITLE
fix(inserir_foto_docx): declara Content-Type da imagem nova no docx

### DIFF
--- a/_scripts/inserir_foto_docx.py
+++ b/_scripts/inserir_foto_docx.py
@@ -61,6 +61,22 @@ def inserir(docx, foto, ancora, legenda):
     nome_media = f'foto{n}{ext}'
     shutil.copy(foto, media / nome_media)
 
+    # 1b. garante que [Content_Types].xml declara o tipo da extensão da imagem
+    # (achado em 28/08/2026: o script copiava a mídia e criava a relação, mas
+    # nunca registrava o Content-Type — o Word/python-docx recusam o .docx com
+    # "no content type for partname '/word/media/fotoN.ext'", porque o OOXML
+    # exige essa declaração para toda parte nova, e um template sem nenhuma
+    # imagem antes não tem o Default da extensão usada aqui).
+    ct_path = raiz / '[Content_Types].xml'
+    ct = ct_path.read_text(encoding='utf-8')
+    ext_sem_ponto = ext.lstrip('.')
+    mime = {'jpg': 'image/jpeg', 'jpeg': 'image/jpeg', 'png': 'image/png'}.get(
+        ext_sem_ponto, f'image/{ext_sem_ponto}')
+    if f'Extension="{ext_sem_ponto}"' not in ct:
+        novo_default = f'<Default Extension="{ext_sem_ponto}" ContentType="{mime}"/>'
+        ct = ct.replace('</Types>', novo_default + '</Types>')
+        ct_path.write_text(ct, encoding='utf-8')
+
     # 2. cria a relação em document.xml.rels
     rels_path = raiz / 'word/_rels/document.xml.rels'
     rels = rels_path.read_text(encoding='utf-8')

--- a/novidades/2026-08-28-11-foto-docx-content-type.md
+++ b/novidades/2026-08-28-11-foto-docx-content-type.md
@@ -1,0 +1,11 @@
+## 28/08/2026
+<!-- commit: fix-content-types-foto -->
+
+**Foto em .jpg deixou de corromper o documento.** Ao inserir uma fotografia num
+documento do toolkit, o programa embutia a imagem mas esquecia de registrar, na ficha
+interna do arquivo, que aquele tipo de imagem estava ali dentro. O Word recusava o
+documento inteiro, dizendo que o arquivo estava corrompido. Aparecia justamente com foto
+de celular em .jpg, que e o caso mais comum. Corrigido: o registro passa a ser feito
+sozinho, para qualquer tipo de imagem.
+
+---


### PR DESCRIPTION
## Problema

Ao inserir a primeira foto num `.docx` cujo template ainda não tinha nenhuma imagem embutida, o `[Content_Types].xml` não ganhava o `Default Extension` da extensão usada (jpg/jpeg/png). O Word e o `python-docx` recusam o pacote OOXML nesse caso, com:

```
KeyError: "no content type for partname '/word/media/foto1.jpg' in [Content_Types].xml"
```

O OOXML exige a declaração de Content-Type para toda extensão nova usada no pacote; o script copiava a mídia e criava a relação em `document.xml.rels`, mas nunca tocava no `[Content_Types].xml`.

## Correção

Antes de criar a relação, garante que `[Content_Types].xml` declara a extensão da imagem (mapeando jpg/jpeg/png para o Content-Type correto), só adicionando o `Default` quando ainda não existir.

## Teste

Testado nos dois sentidos com um `.docx` fictício sem nenhuma imagem prévia:
- **Sem o fix:** falha ao reabrir com o erro acima.
- **Com o fix:** abre normalmente, com a foto embutida.

Regressão verificada contra um template que já trazia uma imagem própria (comportamento não muda quando a extensão já está declarada).

Nenhum dado de fiscalização no PR — o teste usa um `.docx` e uma âncora fictícios.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)