### PR TITLE
fix(inserir_foto_docx): limita altura da foto e prende foto+legenda

### DIFF
--- a/_scripts/inserir_foto_docx.py
+++ b/_scripts/inserir_foto_docx.py
@@ -6,7 +6,8 @@ Uso:
 
 Embute a imagem em word/media/, cria a relação em document.xml.rels e monta o
 parágrafo <w:drawing> com a foto centralizada, seguido de um parágrafo de legenda.
-A largura é ajustada para caber na mancha do texto (máx. ~15,5 cm).
+O tamanho é ajustado para caber na mancha do texto (máx. 15,5 cm de largura,
+9,0 cm de altura), para reduzir saltos de página com vão em branco.
 """
 import re, sys, shutil, subprocess, struct, random
 from pathlib import Path
@@ -14,6 +15,7 @@ from pathlib import Path
 SCRIPTS = Path.home() / '.claude/skills/_scripts'
 EMU_POR_CM = 360000
 LARGURA_MAX_CM = 15.5
+ALTURA_MAX_CM = 9.0
 
 
 def dimensoes(caminho):
@@ -72,16 +74,27 @@ def inserir(docx, foto, ancora, legenda):
     rels_path.write_text(rels, encoding='utf-8')
 
     # 3. calcula o tamanho preservando a proporção
+    # (achado em 28/08/2026: só a largura era limitada; uma foto quadrada saía
+    # com 15,5 x 15,5 cm, quase meia página, e quando não cabia no que sobrava
+    # da página corrente o Word empurrava o bloco inteiro para a próxima,
+    # deixando um vão grande em branco no fim da página anterior. Limitando
+    # também a altura, a imagem fica pequena o bastante para caber com mais
+    # previsibilidade no espaço restante)
     px_w, px_h = dimensoes(foto)
     larg_cm = min(LARGURA_MAX_CM, px_w / 96 * 2.54)
     alt_cm = larg_cm * px_h / px_w
+    if alt_cm > ALTURA_MAX_CM:
+        alt_cm = ALTURA_MAX_CM
+        larg_cm = alt_cm * px_w / px_h
     cx, cy = int(larg_cm * EMU_POR_CM), int(alt_cm * EMU_POR_CM)
 
     # 4. monta os parágrafos (imagem centralizada + legenda)
+    # w:keepNext prende a imagem ao parágrafo seguinte (a legenda), para que o
+    # Word nunca quebre página entre a foto e o texto que a identifica.
     did = random.randint(100, 9999)
     p_img = (
         f'<w:p w14:paraId="{novo_paraid()}" w14:textId="77777777" w:rsidR="00B0080B" '
-        f'w:rsidRDefault="00B0080B"><w:pPr><w:spacing w:before="120" w:after="60"/>'
+        f'w:rsidRDefault="00B0080B"><w:pPr><w:keepNext/><w:spacing w:before="120" w:after="60"/>'
         f'<w:jc w:val="center"/></w:pPr><w:r><w:drawing>'
         f'<wp:inline distT="0" distB="0" distL="0" distR="0">'
         f'<wp:extent cx="{cx}" cy="{cy}"/><wp:effectExtent l="0" t="0" r="0" b="0"/>'

--- a/novidades/2026-08-28-12-foto-docx-altura.md
+++ b/novidades/2026-08-28-12-foto-docx-altura.md
@@ -1,0 +1,12 @@
+## 28/08/2026
+<!-- commit: fix-foto-altura-quebra-pagina -->
+
+**Foto quadrada nao ocupa mais meia pagina, e a legenda nao se separa mais da imagem.**
+O programa que insere fotografia nos documentos so limitava a largura da imagem. Uma foto
+quadrada, como as de celular, saia com quase meia pagina de altura: quando nao cabia no
+que restava da folha, o Word empurrava a foto inteira para a pagina seguinte e deixava um
+vao branco enorme no fim da anterior. Agora a altura tambem tem limite (9 cm), e a imagem
+ficou presa a sua legenda, que nunca mais cai sozinha na pagina de baixo. Notado pelo AFT
+ao revisar um Relatorio Tecnico de Interdicao com cinco fotos.
+
+---


### PR DESCRIPTION
## Problema

`inserir_foto_docx.py` só limitava a **largura** da imagem inserida no `.docx` (15,5 cm). Uma foto quadrada (comum em celulares) saía com 15,5 x 15,5 cm — quase meia página. Quando esse bloco não cabia no espaço restante da página corrente, o Word empurrava a foto inteira para a página seguinte, deixando um vão grande em branco no fim da página anterior. Como a legenda também não tinha nenhum vínculo formal com a foto, havia ainda o risco de a legenda ficar separada da imagem numa quebra de página.

Reportado pelo usuário do toolkit ao revisar um Relatório Técnico de Interdição com 5 fotos.

## Correção

- Acrescentado `ALTURA_MAX_CM = 9.0`: o cálculo de tamanho agora limita largura **e** altura, escalando pela dimensão mais restritiva.
- Acrescentado `w:keepNext` no parágrafo da imagem, para o Word nunca separar a foto da legenda por quebra de página.

## Teste

Testado nos três casos de proporção:
- Imagem quadrada (1280x1280) → 9,0 x 9,0 cm (limitada pela altura)
- Imagem larga e baixa (2000x600) → 15,5 x 4,65 cm (limitada pela largura, como antes)
- Imagem alta e estreita (600x2000) → 2,7 x 9,0 cm (limitada pela altura)

Testado também via inserção real num `.docx`: o `wp:extent` gravado no XML confere 3240000 x 3240000 EMU (9,0 x 9,0 cm) para uma foto quadrada, e o marcador `w:keepNext` aparece no parágrafo da imagem.

Nenhum dado de fiscalização no PR — o teste usa um `.docx` e uma âncora fictícios.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)