### PR TITLE
Aviso: autos empacotados e não lavrados podem dar erro na reorganização

### DIFF
--- a/aft-organiza-os/SKILL.md
+++ b/aft-organiza-os/SKILL.md
@@ -195,6 +195,31 @@ Pastas vazias (nada a fazer): PASTA-A, PASTA-B
 Nada será apagado. Confirma a organização completa?
 ```
 
+### Aviso obrigatório — autos empacotados e ainda não lavrados
+
+Antes de apresentar o plano, verifique em cada OS que terá arquivo movido ou pasta
+renomeada se há **autos já empacotados pelo `/aft-gera-ai` mas ainda não lavrados**.
+Sinais: linhas com "aguarda importação" ou "pendente" em `## Autos de Infração` do
+`memory.md`; seção "Pendentes de transmissão" do `autos-lavrados.md`; lote
+`AUTOS/Autos <DD-MM>/` com TXT cujos autos não aparecem como transmitidos.
+
+Se houver, o plano DEVE trazer este aviso em destaque, antes da pergunta de
+confirmação (adapte os nomes):
+
+> ⚠️ **Autos importados no Sistema Auditor e ainda não lavrados podem dar ERRO
+> depois desta reorganização.** O Sistema Auditor guarda o caminho dos anexos no
+> momento da importação; mover ou renomear arquivos e pastas faz esse caminho
+> deixar de bater. Antes de aprovar o plano, escolha:
+> 1. **Lavrar primeiro os autos já importados** (recomendado) e só depois aplicar
+>    a reorganização; ou
+> 2. Aplicar agora e, depois, **gerar o pacote de novo com o `/aft-gera-ai`** e
+>    reimportar no Sistema Auditor.
+
+A reorganização em si nunca toca nas pastas `AUTOS/Autos <DD-MM>/` — mas o
+caminho registrado na importação inclui a pasta da OS inteira, então renomear a
+pasta da empresa, ou mover um arquivo que tenha sido apontado como anexo, já
+basta para o erro. Na dúvida, o aviso entra.
+
 ### Layout padrão da pasta de uma OS
 
 Duas caixas (`NOTIFICACOES/` e `AUTOS/`) concentram o material volumoso; as **pastas

--- a/novidades/2026-08-28-06-pastas-tematicas-auditoria.md
+++ b/novidades/2026-08-28-06-pastas-tematicas-auditoria.md
@@ -30,4 +30,13 @@ serve para você lembrar do que foi auditado; o inteiro teor fica no arquivo do 
 Constatação avulsa (SESMT, CIPA, ASO faltando) e tema sem relatório salvo ficam como
 estão.
 
+**Um cuidado importante antes de reorganizar uma pasta antiga:** se você tem autos de
+infração já importados no Sistema Auditor mas **ainda não lavrados**, eles podem dar
+ERRO depois da reorganização — o Sistema Auditor guarda o caminho dos anexos no
+momento da importação, e mover ou renomear arquivos e pastas faz esse caminho deixar
+de bater. Recomenda-se **lavrar esses autos antes** de aplicar a reorganização; a
+alternativa é gerar o pacote de novo com o `/aft-gera-ai` depois dela e reimportar. A
+própria `/aft-organiza-os` avisa em destaque, no plano, quando encontra autos nessa
+situação.
+
 ---


### PR DESCRIPTION
Armadilha apontada pelo AFT após a publicação das pastas temáticas (#122): o Sistema Auditor guarda o caminho dos anexos no momento da importação — auto **importado e ainda não lavrado** dá ERRO se a reorganização mover ou renomear arquivos/pastas no caminho registrado.

- `/aft-organiza-os`: nova seção **"Aviso obrigatório — autos empacotados e ainda não lavrados"** — detecta lotes pendentes ("aguarda importação" no memory.md, "Pendentes de transmissão" no autos-lavrados.md, TXT sem auto transmitido) e põe o aviso em destaque no plano, antes da aprovação: **(1) lavrar primeiro (recomendado)** ou (2) regerar o pacote com o `/aft-gera-ai` depois e reimportar.
- Changelog (entrada 2026-08-28-06) ganhou o mesmo recado em linguagem de usuário.
- Notas do cofre atualizadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)