### PR TITLE
Prefactor da remontagem + empacotador do toolkit

### DIFF
--- a/_scripts/empacotar.py
+++ b/_scripts/empacotar.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""
+empacotar.py - Produz o pacote versionado do toolkit a partir do main.
+
+Parte da migracao da distribuicao (issue #138): em vez de `git pull` num
+repositorio publico, o AFT passa a atualizar por um pacote .zip carimbado com
+versao, publicado no portal `notebooks-aft`. Este script cuida so do lado
+"produzir o pacote" - subir para o portal e a rota autenticada sao trabalho
+de outro repositorio.
+
+Como ele funciona, em ordem:
+
+  1. confere que a copia em --repo esta no main e sem trabalho em aberto -
+     nunca empacota estado de worktree nem mudanca nao commitada;
+  2. carimba a versao a partir do PROPRIO COMMIT de HEAD (data do commit +
+     hash curto) - nao do relogio. E o que garante que rodar duas vezes no
+     mesmo commit sempre produz a mesma versao;
+  3. cria um worktree git DESCARTAVEL no mesmo commit (o padrao que o resto
+     do toolkit ja usa para isolar sessoes - ver AGENTS.md) e roda a
+     remontagem (remontar.py, issue #139) dentro dele: NOVIDADES.md,
+     arquitetura.html e o manifesto skills_oficiais.txt saem em dia, sem
+     tocar na copia original em --repo;
+  4. escreve o carimbo de versao (_scripts/versao.txt) dentro do worktree;
+  5. zipa o worktree - sem o .git do worktree, sem os arquivos que so fazem
+     sentido no repositorio - e calcula o sha256 do pacote;
+  6. remove o worktree descartavel.
+
+Uso:
+    python empacotar.py --repo <copia limpa do main> --saida <pasta>
+"""
+
+try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
+    import sys as _sys
+    from pathlib import Path as _Path
+    _aqui = _Path(__file__).resolve()
+    for _p in (_aqui.parent, *(_a / "_scripts" for _a in _aqui.parents)):
+        if (_p / "erro_ticket.py").is_file():
+            _sys.path.insert(0, str(_p))
+            from erro_ticket import ativar as _ativar_ticket
+            _ativar_ticket(__file__)
+            break
+except Exception:
+    pass
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from remontar import git, remontar, EXCLUIR  # noqa: E402  (path acima e proposital)
+
+try:  # console do Windows e cp1252
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+ARQUIVO_VERSAO = "versao.txt"
+
+
+def _copia_limpa_do_main(raiz):
+    ramo = git(["branch", "--show-current"], raiz)
+    if ramo != "main":
+        raise SystemExit(
+            f"ERRO: {raiz} está no ramo '{ramo}', não em 'main'.\n"
+            "  O pacote só pode ser montado a partir do main.")
+    sujo = git(["status", "--porcelain"], raiz)
+    if sujo:
+        raise SystemExit(
+            f"ERRO: {raiz} tem mudança não commitada:\n  " +
+            "\n  ".join(sujo.splitlines()[:5]) +
+            "\n  Empacotar exige uma cópia limpa do main - "
+            "commite ou descarte antes de tentar de novo.")
+
+
+def carimbo_versao(raiz):
+    """(versao, commit, data) do HEAD de `raiz`. So olha metadados do proprio
+    commit - nunca o relogio - para que empacotar duas vezes o mesmo commit
+    sempre devolva a mesma versao."""
+    commit = git(["rev-parse", "HEAD"], raiz)
+    data = git(["show", "-s", "--format=%cs", "HEAD"], raiz)  # AAAA-MM-DD
+    versao = f"{data.replace('-', '.')}-{commit[:7]}"
+    return versao, commit, data
+
+
+def _worktree_descartavel(raiz, commit):
+    """Cria um worktree git desligado (--detach) de `raiz` no `commit`, numa
+    pasta temporaria propria. Devolve o Path do worktree; quem chamar precisa
+    remove-lo com `_remover_worktree` no final (inclusive em erro)."""
+    base = Path(tempfile.mkdtemp(prefix="aft-empacotar-"))
+    wt = base / "toolkit"
+    git(["worktree", "add", "--detach", str(wt), commit], raiz)
+    return wt, base
+
+
+def _remover_worktree(raiz, wt, base):
+    git(["worktree", "remove", "--force", str(wt)], raiz, checar=False)
+    shutil.rmtree(base, ignore_errors=True)
+
+
+def escrever_carimbo(worktree, versao, commit, data):
+    texto = f"versao: {versao}\ncommit: {commit}\ndata: {data}\n"
+    (worktree / "_scripts" / ARQUIVO_VERSAO).write_text(texto, encoding="utf-8")
+
+
+def _arquivos_do_pacote(worktree):
+    """Todo arquivo do worktree, exceto o que esta em EXCLUIR (por nome de
+    qualquer componente do caminho)."""
+    for caminho in sorted(worktree.rglob("*")):
+        if caminho.is_dir():
+            continue
+        partes = caminho.relative_to(worktree).parts
+        if any(p in EXCLUIR for p in partes):
+            continue
+        yield caminho
+
+
+def montar_zip(worktree, destino_zip):
+    with zipfile.ZipFile(destino_zip, "w", zipfile.ZIP_DEFLATED) as z:
+        for caminho in _arquivos_do_pacote(worktree):
+            z.write(caminho, caminho.relative_to(worktree))
+
+
+def sha256_de(caminho):
+    h = hashlib.sha256()
+    with open(caminho, "rb") as f:
+        for bloco in iter(lambda: f.read(1 << 20), b""):
+            h.update(bloco)
+    return h.hexdigest()
+
+
+def empacotar(raiz, pasta_saida):
+    _copia_limpa_do_main(raiz)
+    versao, commit, data = carimbo_versao(raiz)
+
+    wt, base = _worktree_descartavel(raiz, commit)
+    try:
+        linhas, _ = remontar(wt, conferir=False)
+        for l in linhas:
+            print("  " + l)
+        escrever_carimbo(wt, versao, commit, data)
+
+        pasta_saida = Path(pasta_saida).expanduser()
+        pasta_saida.mkdir(parents=True, exist_ok=True)
+        zip_path = pasta_saida / f"aft-toolkit-{versao}.zip"
+        montar_zip(wt, zip_path)
+    finally:
+        _remover_worktree(raiz, wt, base)
+
+    soma = sha256_de(zip_path)
+    (pasta_saida / f"{zip_path.name}.sha256").write_text(
+        f"{soma}  {zip_path.name}\n", encoding="utf-8")
+    return {"versao": versao, "commit": commit, "zip": str(zip_path),
+            "sha256": soma}
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Produz o pacote versionado do toolkit a partir do main")
+    ap.add_argument("--repo", required=True, help="cópia limpa do main")
+    ap.add_argument("--saida", required=True, help="pasta onde gravar o pacote")
+    args = ap.parse_args()
+
+    raiz = Path(args.repo).expanduser().resolve()
+    if not (raiz / "AGENTS.md").is_file():
+        raise SystemExit(f"ERRO: {raiz} não parece a raiz do AFT Toolkit "
+                         "(falta o AGENTS.md).")
+
+    info = empacotar(raiz, args.saida)
+    print(json.dumps(info, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/_scripts/publicar.py
+++ b/_scripts/publicar.py
@@ -49,7 +49,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from remontar import git, rodar_script, remontar, MONTADOS
+from remontar import git, rodar_script, remontar, MONTADOS, EXCLUIR
 
 try:  # console do Windows e cp1252
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -58,11 +58,6 @@ except Exception:
     pass
 
 DESTINO = Path.home() / ".claude" / "skills"
-
-# O que nao vai para a pasta instalada: controle de versao, lixo do sistema e o
-# roteiro de instalacao (que so faz sentido no repositorio).
-EXCLUIR = [".git", ".gitignore", ".DS_Store", ".backups", ".claude",
-           "COMO-INSTALAR.md", "__pycache__"]
 
 
 def _repo_a_partir_de(pasta):

--- a/_scripts/publicar.py
+++ b/_scripts/publicar.py
@@ -45,10 +45,11 @@ except Exception:
     pass
 
 import argparse
-import json
 import subprocess
 import sys
 from pathlib import Path
+
+from remontar import git, rodar_script, remontar, MONTADOS
 
 try:  # console do Windows e cp1252
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -62,14 +63,6 @@ DESTINO = Path.home() / ".claude" / "skills"
 # roteiro de instalacao (que so faz sentido no repositorio).
 EXCLUIR = [".git", ".gitignore", ".DS_Store", ".backups", ".claude",
            "COMO-INSTALAR.md", "__pycache__"]
-
-
-def git(args, cwd, checar=True):
-    r = subprocess.run(["git"] + args, cwd=str(cwd), capture_output=True,
-                       text=True, encoding="utf-8", errors="replace")
-    if checar and r.returncode != 0:
-        raise SystemExit(f"ERRO: git {' '.join(args)}\n{r.stderr.strip()}")
-    return r.stdout.strip()
 
 
 def _repo_a_partir_de(pasta):
@@ -106,40 +99,6 @@ def copia_principal(inicio=None):
         "ERRO: não encontrei o repositório do AFT Toolkit a partir daqui.\n"
         "  Rode o publicar de dentro do repositório (ou de um worktree dele):\n"
         "    cd ~/Documents/aft-toolkit && python _scripts/publicar.py")
-
-
-def python_atual():
-    return sys.executable or "python3"
-
-
-def rodar_script(raiz, nome, args, conferir):
-    script = raiz / "_scripts" / nome
-    if not script.is_file():
-        return f"{nome}: não encontrado (pulado)"
-    if conferir:
-        return f"{nome}: rodaria agora"
-    r = subprocess.run([python_atual(), str(script)] + args,
-                       capture_output=True, text=True, encoding="utf-8",
-                       errors="replace")
-    bruto = (r.stdout or r.stderr).strip()
-    saida = bruto.splitlines()
-    ultima = saida[-1] if saida else f"terminou ({r.returncode})"
-    # Scripts que respondem em JSON: uns numa linha so (instalar_agentes), outros
-    # indentado em varias (instalar_servidor_painel) - neste, a ultima linha e um
-    # "}" solto, que nao diz nada ao AFT. Tenta a saida INTEIRA antes da ultima.
-    for candidato in (bruto, ultima):
-        if not candidato.startswith("{"):
-            continue
-        try:
-            d = json.loads(candidato)
-        except ValueError:
-            continue
-        partes = [f"{len(d[k])} {k}" for k in
-                  ("instalados", "atualizados", "em_dia", "erros")
-                  if isinstance(d.get(k), list) and d[k]]
-        ultima = ", ".join(partes) or d.get("detalhe") or "nada a fazer"
-        break
-    return f"{nome}: {ultima}"
 
 
 def main():
@@ -193,41 +152,24 @@ def main():
         print("  main já estava em dia com o GitHub")
 
     # 3. Regerar os dois arquivos montados, num lugar so ---------------------
-    gerados = []
-    print(rodar_script(raiz, "montar_novidades.py",
-                       ["--conferir" if conferir else "--montar"], False)
-          .replace("montar_novidades.py: ", "  NOVIDADES.md: "))
-    print(rodar_script(raiz, "nota_historico.py",
-                       ["--checar-arquitetura" if conferir
-                        else "--sincronizar-arquitetura"], False)
-          .replace("nota_historico.py: ", "  arquitetura: "))
-    MONTADOS = ["NOVIDADES.md", "arquitetura/arquitetura.html",
-                "_scripts/skills_oficiais.txt"]
-    if not conferir:
-        # A lista do que o toolkit instala e MONTADA como os outros dois: sai de
-        # `git ls-files`, e por isso muda sozinha sempre que nasce uma skill ou
-        # uma pasta nova. Ela era regravada mais adiante e NUNCA commitada — o
-        # publicar sujava a copia principal e, na vez seguinte, o proprio
-        # guarda-corpo do passo 1 recusava publicar por causa da sujeira que ele
-        # mesmo tinha feito (constatado em 24/08/2026, duas vezes no mesmo dia).
-        # E ela que diz o que NAO e nosso e, portanto, nao pode ser apagado da
-        # pasta do AFT; deduzir por prefixo falha, porque 'aft-grant' e skill
-        # pessoal de um AFT e parece oficial.
-        oficiais = sorted({l.split("/")[0] for l in
-                           git(["ls-files"], raiz).splitlines() if "/" in l})
-        (raiz / "_scripts" / "skills_oficiais.txt").write_text(
-            "\n".join(oficiais) + "\n", encoding="utf-8")
-        mudou = git(["status", "--porcelain", "--"] + MONTADOS, raiz)
-        if mudou:
-            gerados = [l.strip() for l in mudou.splitlines()]
-            git(["add"] + MONTADOS, raiz)
-            git(["commit", "-m",
-                 "chore: remonta NOVIDADES.md, a arquitetura e o manifesto\n\n"
-                 "Gerado por _scripts/publicar.py na copia principal - um lugar\n"
-                 "so, para duas sessoes nunca colidirem nestes arquivos."],
-                raiz)
-            git(["push", "origin", "main"], raiz)
-            print(f"  regerados e publicados: {', '.join(gerados)}")
+    # (extraido para remontar.py na issue #139: e o mesmo passo que o
+    # empacotador do toolkit vai reusar, sem duplicar esta logica)
+    linhas, gerados = remontar(raiz, conferir=conferir)
+    for l in linhas:
+        print("  " + l)
+    if not conferir and gerados:
+        # Isto era regravado mais adiante e NUNCA commitado — o publicar
+        # sujava a copia principal e, na vez seguinte, o proprio guarda-corpo
+        # do passo 1 recusava publicar por causa da sujeira que ele mesmo
+        # tinha feito (constatado em 24/08/2026, duas vezes no mesmo dia).
+        git(["add"] + MONTADOS, raiz)
+        git(["commit", "-m",
+             "chore: remonta NOVIDADES.md, a arquitetura e o manifesto\n\n"
+             "Gerado por _scripts/publicar.py na copia principal - um lugar\n"
+             "so, para duas sessoes nunca colidirem nestes arquivos."],
+            raiz)
+        git(["push", "origin", "main"], raiz)
+        print(f"  regerados e publicados: {', '.join(gerados)}")
 
     # 4. Copiar para a pasta instalada ---------------------------------------
     if not destino.is_dir():

--- a/_scripts/remontar.py
+++ b/_scripts/remontar.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""
+remontar.py - O passo de remontagem do publicar.py, isolado para ter um
+segundo chamador.
+
+O publicar.py sempre fez tres coisas num lugar so, antes de copiar para a
+pasta instalada: remontar o NOVIDADES.md a partir de novidades/, sincronizar
+o bloco ARCH do arquitetura.html com o arquitetura.json, e regerar o
+manifesto _scripts/skills_oficiais.txt a partir de `git ls-files`. O
+empacotador do toolkit (que vai gerar o pacote versionado a partir do main)
+precisa exatamente dos mesmos tres arquivos em dia antes de zipar - por isso
+este passo agora mora aqui, importavel por quem precisar, em vez de dentro
+do publicar.py.
+
+Este modulo NAO commita, NAO empurra para o GitHub e NAO toca em nenhuma
+pasta instalada: so escreve os tres arquivos MONTADOS dentro da `raiz` que
+foi passada, e devolve um relatorio do que mudou para quem chamou decidir o
+proximo passo (o publicar.py commita e empurra; o empacotador nao precisa).
+
+Uso isolado, sem tocar em nada:
+    python remontar.py --conferir --repo <pasta>
+Uso isolado, regravando os arquivos (sem commit):
+    python remontar.py --repo <pasta>
+"""
+
+try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
+    import sys as _sys
+    from pathlib import Path as _Path
+    _aqui = _Path(__file__).resolve()
+    for _p in (_aqui.parent, *(_a / "_scripts" for _a in _aqui.parents)):
+        if (_p / "erro_ticket.py").is_file():
+            _sys.path.insert(0, str(_p))
+            from erro_ticket import ativar as _ativar_ticket
+            _ativar_ticket(__file__)
+            break
+except Exception:
+    pass
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:  # console do Windows e cp1252
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+# Os tres arquivos que este passo mantem em dia - usado tanto para regerar o
+# manifesto quanto para quem chamou decidir se ha algo para commitar.
+MONTADOS = ["NOVIDADES.md", "arquitetura/arquitetura.html",
+            "_scripts/skills_oficiais.txt"]
+
+
+def git(args, cwd, checar=True):
+    r = subprocess.run(["git"] + args, cwd=str(cwd), capture_output=True,
+                       text=True, encoding="utf-8", errors="replace")
+    if checar and r.returncode != 0:
+        raise SystemExit(f"ERRO: git {' '.join(args)}\n{r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def python_atual():
+    return sys.executable or "python3"
+
+
+def rodar_script(raiz, nome, args, conferir):
+    script = raiz / "_scripts" / nome
+    if not script.is_file():
+        return f"{nome}: não encontrado (pulado)"
+    if conferir:
+        return f"{nome}: rodaria agora"
+    r = subprocess.run([python_atual(), str(script)] + args,
+                       capture_output=True, text=True, encoding="utf-8",
+                       errors="replace")
+    bruto = (r.stdout or r.stderr).strip()
+    saida = bruto.splitlines()
+    ultima = saida[-1] if saida else f"terminou ({r.returncode})"
+    # Scripts que respondem em JSON: uns numa linha so (instalar_agentes), outros
+    # indentado em varias (instalar_servidor_painel) - neste, a ultima linha e um
+    # "}" solto, que nao diz nada ao AFT. Tenta a saida INTEIRA antes da ultima.
+    for candidato in (bruto, ultima):
+        if not candidato.startswith("{"):
+            continue
+        try:
+            d = json.loads(candidato)
+        except ValueError:
+            continue
+        partes = [f"{len(d[k])} {k}" for k in
+                  ("instalados", "atualizados", "em_dia", "erros")
+                  if isinstance(d.get(k), list) and d[k]]
+        ultima = ", ".join(partes) or d.get("detalhe") or "nada a fazer"
+        break
+    return f"{nome}: {ultima}"
+
+
+def regenerar_manifesto(raiz):
+    """Regrava _scripts/skills_oficiais.txt a partir de `git ls-files` em
+    `raiz`. E ela que diz o que NAO e nosso e, portanto, nao pode ser apagado
+    da pasta do AFT numa atualizacao; deduzir por prefixo falha, porque
+    'aft-grant' e skill pessoal de um AFT e parece oficial."""
+    oficiais = sorted({l.split("/")[0] for l in
+                       git(["ls-files"], raiz).splitlines() if "/" in l})
+    (raiz / "_scripts" / "skills_oficiais.txt").write_text(
+        "\n".join(oficiais) + "\n", encoding="utf-8")
+    return oficiais
+
+
+def remontar(raiz, conferir=False):
+    """Remonta o NOVIDADES.md, sincroniza a arquitetura e - se `conferir` for
+    False - regenera o manifesto skills_oficiais.txt dentro de `raiz`.
+
+    Devolve (linhas, mudou): `linhas` e a lista de textos prontos para
+    imprimir (sem indentacao - quem chamou decide o layout); `mudou` e a
+    lista de linhas do `git status --porcelain` para os MONTADOS (vazia se
+    nada mudou, ou sempre vazia em modo `conferir`, que nunca escreve nada).
+    """
+    linhas = [
+        rodar_script(raiz, "montar_novidades.py",
+                     ["--conferir" if conferir else "--montar"], False)
+        .replace("montar_novidades.py: ", "NOVIDADES.md: "),
+        rodar_script(raiz, "nota_historico.py",
+                     ["--checar-arquitetura" if conferir
+                      else "--sincronizar-arquitetura"], False)
+        .replace("nota_historico.py: ", "arquitetura: "),
+    ]
+    if conferir:
+        return linhas, []
+    regenerar_manifesto(raiz)
+    bruto = git(["status", "--porcelain", "--"] + MONTADOS, raiz)
+    mudou = [l.strip() for l in bruto.splitlines()] if bruto else []
+    return linhas, mudou
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Remonta NOVIDADES.md, arquitetura e o manifesto - isolado, sem "
+                    "commitar nem tocar em pasta instalada")
+    ap.add_argument("--conferir", action="store_true",
+                    help="so mostra o que seria feito, sem alterar nada")
+    ap.add_argument("--repo", required=True, help="raiz do repositorio")
+    args = ap.parse_args()
+
+    raiz = Path(args.repo).expanduser().resolve()
+    if not (raiz / "AGENTS.md").is_file():
+        raise SystemExit(f"ERRO: {raiz} não parece a raiz do AFT Toolkit "
+                         "(falta o AGENTS.md).")
+
+    linhas, mudou = remontar(raiz, conferir=args.conferir)
+    for l in linhas:
+        print(l)
+    if mudou:
+        print("mudou: " + ", ".join(mudou))
+    elif not args.conferir:
+        print("nada mudou")
+
+
+if __name__ == "__main__":
+    main()

--- a/_scripts/remontar.py
+++ b/_scripts/remontar.py
@@ -53,6 +53,13 @@ except Exception:
 MONTADOS = ["NOVIDADES.md", "arquitetura/arquitetura.html",
             "_scripts/skills_oficiais.txt"]
 
+# O que nao vai para fora do repositorio: controle de versao, lixo do sistema
+# e o roteiro de instalacao (que so faz sentido aqui dentro). Usado tanto
+# pelo publicar.py (copia para a pasta instalada) quanto pelo empacotar.py
+# (zip do pacote) - um lugar so, para os dois nunca divergirem no que excluem.
+EXCLUIR = {".git", ".gitignore", ".DS_Store", ".backups", ".claude",
+           "COMO-INSTALAR.md", "__pycache__"}
+
 
 def git(args, cwd, checar=True):
     r = subprocess.run(["git"] + args, cwd=str(cwd), capture_output=True,


### PR DESCRIPTION
## Summary
- Extrai o passo que remonta o `NOVIDADES.md`, sincroniza a arquitetura e regenera o `skills_oficiais.txt` do `publicar.py` para `_scripts/remontar.py`, importável e executável isoladamente (`python remontar.py --repo <pasta>`), sem tocar na pasta instalada nem commitar - `publicar.py` continua fazendo exatamente o que fazia antes.
- Novo `_scripts/empacotar.py`: produz o pacote versionado do toolkit a partir de uma cópia limpa do main - carimba a versão a partir do próprio commit de HEAD (determinística), remonta num worktree git descartável, zipa sem metadados de controle de versão e calcula o sha256.
- Move o `EXCLUIR` (lista do que não sai do repositório) para `remontar.py`, fonte única compartilhada entre `publicar.py` e `empacotar.py`.

Closes #139
Closes #140

## Test plan
- [x] `publicar.py --conferir` produz saída byte-a-byte idêntica à de antes da mudança
- [x] `remontar.py --conferir --repo <pasta>` roda isolado, sem alterar nada
- [x] `remontar.py --repo <pasta>` regenera os três arquivos e não commita/empurra
- [x] `empacotar.py` testado em clones descartáveis: pacote sem `.git`/`.gitignore`/`COMO-INSTALAR.md`, sha256 confere, manifesto bate com o conteúdo do próprio pacote
- [x] `empacotar.py` falha com mensagem clara em cópia suja e em ramo diferente de `main`
- [x] rodar `empacotar.py` duas vezes no mesmo commit produz a mesma versão

🤖 Generated with [Claude Code](https://claude.com/claude-code)