### PR TITLE
feat(ci): acao de empacotamento disparada a clique

### DIFF
--- a/.github/workflows/empacotar.yml
+++ b/.github/workflows/empacotar.yml
@@ -1,0 +1,56 @@
+name: Empacotar toolkit
+
+# Disparo manual (issue #145): um clique monta o pacote versionado a partir
+# do main e disponibiliza o .zip + sha256 ao final da execução. Nunca roda
+# sozinho (sem "on: push" nem "on: schedule") e não depende de nenhuma
+# organização privada — só do próprio repositório.
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  empacotar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Anexar o HEAD ao ramo main
+        # actions/checkout deixa o HEAD desanexado (detached), mesmo pedindo
+        # "ref: main" - e o empacotar.py exige uma cópia num ramo chamado
+        # main (git branch --show-current), nunca um worktree solto. Sem
+        # isso o script erra achando que está numa cópia errada.
+        run: git checkout -B main
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Empacotar (_scripts/empacotar.py)
+        run: python3 _scripts/empacotar.py --repo "${{ github.workspace }}" --saida "${{ github.workspace }}/dist"
+
+      - name: Resumir o pacote gerado
+        run: |
+          {
+            echo "## Pacote do AFT Toolkit"
+            echo
+            for zip in dist/*.zip; do
+              echo "- \`$(basename "$zip")\`"
+            done
+            echo
+            echo '```'
+            cat dist/*.sha256
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publicar o pacote e a soma
+        uses: actions/upload-artifact@v4
+        with:
+          name: aft-toolkit
+          path: dist/*
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ __pycache__/
 !/novidades/
 # Site publico do GitHub Pages (so a politica de privacidade da extensao).
 !/docs/
+# Actions do proprio repositorio (workflows em .github/workflows/).
+!/.github/
 # Atalho .agents/skills -> .claude/skills. E da maquina, nao do projeto: cada
 # pessoa cria o seu (link simbolico no Mac/Linux, junction no Windows). Versionar
 # um atalho quebraria na maquina dos outros.

--- a/_scripts/remontar.py
+++ b/_scripts/remontar.py
@@ -58,7 +58,7 @@ MONTADOS = ["NOVIDADES.md", "arquitetura/arquitetura.html",
 # pelo publicar.py (copia para a pasta instalada) quanto pelo empacotar.py
 # (zip do pacote) - um lugar so, para os dois nunca divergirem no que excluem.
 EXCLUIR = {".git", ".gitignore", ".DS_Store", ".backups", ".claude",
-           "COMO-INSTALAR.md", "__pycache__"}
+           "COMO-INSTALAR.md", "__pycache__", ".github"}
 
 
 def git(args, cwd, checar=True):


### PR DESCRIPTION
## Summary
- Adiciona `.github/workflows/empacotar.yml` (`workflow_dispatch`): um clique monta o pacote sempre a partir do `main`, chamando `_scripts/empacotar.py` (issue #140) sem reimplementar nada.
- Resolve a armadilha do `actions/checkout` deixar o HEAD desanexado: `empacotar.py` exige uma copia num ramo chamado `main` (`git branch --show-current`), entao o workflow roda `git checkout -B main` logo apos o checkout, em vez de afrouxar a conferencia do script.
- Pacote (.zip) e sha256 ficam disponiveis ao final da execucao: no resumo do job (`GITHUB_STEP_SUMMARY`) e como artifact para download.
- Ajustes de suporte: `.github/` estava fora do allowlist do `.gitignore` (nasceria invisivel ao git, como o comentario do proprio arquivo alerta para pasta oficial nova) e passou a ser excluido do proprio pacote via `EXCLUIR` em `remontar.py`, ja que so faz sentido dentro deste repositorio.

Closes #145

## Test plan
- [x] Simulado localmente o comportamento do `actions/checkout` (clone + `checkout --detach`) e confirmado que `empacotar.py` falha com "nao esta no ramo main" antes do fix.
- [x] Aplicado `git checkout -B main` e confirmado que `empacotar.py` roda ate o fim, gera o `.zip` e o `.sha256`, e o sha256 bate (`shasum -a 256 -c`).
- [x] Confirmado que o `.zip` nao contem `.git/` nem `.github/`.
- [x] `.gitignore` confirmado: `.github/workflows/empacotar.yml` deixou de ser ignorado (`git check-ignore` retorna vazio) e aparece como untracked/staged normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)