### PR TITLE
fix(skills_pessoais): retrato batizado à mão quebrava a conferência

### DIFF
--- a/_scripts/skills_pessoais.py
+++ b/_scripts/skills_pessoais.py
@@ -24,7 +24,7 @@ atualizar_toolkit.py aponta para outra pasta com --skills/--manifesto, que e o
 que permite exercitar a atualizacao inteira contra uma pasta de mentira.
 """
 from __future__ import annotations
-import argparse, shutil, sys, time
+import argparse, re, shutil, sys, time
 from pathlib import Path
 
 SKILLS = Path.home() / ".claude" / "skills"
@@ -35,6 +35,9 @@ GUARDA = Path.home() / ".claude" / "skills-pessoais-backup"
 # de um AFT e tem cara de oficial. Palpite pelo nome deixaria ela desprotegida.
 MANIFESTO = Path(__file__).with_name("skills_oficiais.txt")
 INFRA = {"_scripts", "Template", "agents", "arquitetura", "config", "novidades"}
+# Nome de retrato feito por este script: AAAAMMDD-HHMMSS, com sufixo -2, -3...
+# quando dois caem no mesmo segundo.
+NOSSO_RETRATO = re.compile(r"^\d{8}-\d{6}(-\d+)?$")
 
 
 def oficiais() -> set[str]:
@@ -77,18 +80,29 @@ def fazer_backup() -> Path:
         return alvo
     for d in achadas:
         shutil.copytree(d, alvo / d.name, dirs_exist_ok=True)
-    # so os 5 retratos mais recentes
-    retratos = sorted(GUARDA.iterdir(), reverse=True)
-    for velho in retratos[5:]:
+    # So os 5 retratos mais recentes - e so os NOSSOS. Retrato batizado a mao
+    # pelo AFT ("manual-20260821-aposentada", "pre-rename-...") fica onde esta:
+    # apagar pasta que nao fomos nos que criamos e estrago, nao faxina. A
+    # ordem tambem e pela data do arquivo, nao pelo nome (ver ultimo_retrato).
+    nossos = sorted((d for d in GUARDA.iterdir()
+                     if d.is_dir() and NOSSO_RETRATO.match(d.name)),
+                    key=lambda d: d.stat().st_mtime_ns, reverse=True)
+    for velho in nossos[5:]:
         shutil.rmtree(velho, ignore_errors=True)
     print(f"skills_pessoais: {len(achadas)} skill(s) guardada(s) em {alvo}")
     return alvo
 
 
 def ultimo_retrato() -> Path | None:
+    """O retrato mais recente - pela DATA do arquivo, nao pelo nome. Ordenar
+    por nome parece dar no mesmo (os nomes sao AAAAMMDD-HHMMSS), mas retrato
+    batizado a mao ganha sempre: 'pre-rename-20260819-...' vem depois de
+    '20260829-...' no alfabeto. Era o que acontecia de verdade nesta maquina -
+    a conferencia comparava com um retrato de 19/08 e acusava sumico todo dia."""
     if not GUARDA.is_dir():
         return None
-    r = sorted((d for d in GUARDA.iterdir() if d.is_dir()), reverse=True)
+    r = sorted((d for d in GUARDA.iterdir() if d.is_dir()),
+               key=lambda d: d.stat().st_mtime_ns, reverse=True)
     return r[0] if r else None
 
 

--- a/_scripts/testar_aplicador.py
+++ b/_scripts/testar_aplicador.py
@@ -180,6 +180,12 @@ def rodar(base):
     # As duas pessoais: uma com o prefixo e outra SEM (o caso de 19/08/2026).
     escrever(destino / "minha-coisa" / "SKILL.md", "skill pessoal com prefixo\n")
     escrever(destino / "cowork-ingest" / "SKILL.md", "skill pessoal sem prefixo\n")
+    # Retrato batizado a mao pelo AFT, com estrutura que nao e a nossa: nao pode
+    # vencer a ordenacao dos retratos (era o que acontecia de verdade em
+    # ~/.claude, onde um "pre-rename-...-aft-grant" de 19/08 ganhava de todos os
+    # datados e fazia a conferencia acusar sumico todo dia) nem entrar na faxina.
+    escrever(destino.parent / f"{destino.name}-pessoais-backup"
+             / "pre-rename-20260819-a-mao" / "logs" / "x.log", "antigo\n")
     antes = retrato(destino)
 
     print("\n2. Simulacao do pacote 2")
@@ -243,10 +249,16 @@ def rodar(base):
     guarda = destino.parent / f"{destino.name}-pessoais-backup"
     checar(guarda.is_dir(), "o retrato das pessoais foi para a pasta de mentira "
                             "(nunca para a instalacao real)")
-    retratos = sorted(guarda.iterdir()) if guarda.is_dir() else []
+    retratos = sorted((d for d in guarda.iterdir() if d.name[0].isdigit()),
+                      key=lambda d: d.stat().st_mtime_ns) if guarda.is_dir() else []
     checar(bool(retratos) and {d.name for d in retratos[-1].iterdir()}
            == {"minha-coisa", "cowork-ingest"},
            "o retrato guardou as duas skills pessoais")
+    checar(res["erro"] is None,
+           "retrato batizado a mao nao vira falso alarme de skill sumida",
+           str(res.get("erro")) + " / " + str(res.get("conferencia_pessoais")))
+    checar((guarda / "pre-rename-20260819-a-mao" / "logs" / "x.log").is_file(),
+           "retrato batizado a mao nao entrou na faxina")
 
     print("\n7. Retencao: so as duas ultimas")
     # Backup antigo, feito a mao pelo AFT: nao tem a nossa marca dentro e nao


### PR DESCRIPTION
Continuação de #149 (issue #141). **Publicar na máquina de verdade** fez o `publicar.py` acusar `skill pessoal sumiu: logs`. Não era perda nenhuma — eram dois defeitos antigos do `skills_pessoais.py`, e os dois derrubariam o `atualizar_toolkit.py` em uso real, porque ele trata o código 3 da conferência como falha da transação.

**1. `ultimo_retrato()` ordenava por nome.** Os retratos se chamam `AAAAMMDD-HHMMSS`, e por isso ordenar por nome *parece* dar no mesmo — só que retrato batizado à mão ganha sempre: `pre-rename-20260819-…` vem depois de `20260829-…` no alfabeto. A conferência comparava, todo dia, com um retrato de **19/08**; e aquela pasta nem era retrato da pasta de skills, e sim o conteúdo de *dentro* da skill `aft-grant` (daí o `logs`). Passa a ordenar pela data do arquivo.

**2. A faxina dos 5 retratos tinha o mesmo defeito — e ali ele destruía.** Ordenando por nome, os batizados à mão (`manual-20260821-aposentada`, `pre-rename-…`) sobreviviam por acidente. Corrigir só a ordem os teria apagado na publicação seguinte. A faxina passa a valer **só para retrato com o nosso formato de nome** — mesma regra da marca `.aft-backup` dos backups: apagar pasta que não fomos nós que criamos é estrago, não faxina.

Os dois estavam de pé há semanas sem ninguém ver, porque `--conferir` só é chamado no fim do `publicar.py` e a saída dele é a última linha, num relatório que termina com `PUBLICADO`.

`testar_aplicador.py` ganhou o cenário: retrato batizado à mão presente **desde antes da primeira aplicação**, conferindo que ele não vira falso alarme nem entra na faxina. **39 verificações**, todas passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)