### PR TITLE
Cliente do portal: token, consulta de versao e mensagens de erro (issue #142)

### DIFF
--- a/_scripts/atualizar_toolkit.py
+++ b/_scripts/atualizar_toolkit.py
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 """
-atualizar_toolkit.py - Aplica um pacote do toolkit numa pasta de destino.
+atualizar_toolkit.py - Consulta o portal e aplica um pacote do toolkit.
 
 Esta e a costura da atualizacao (issue #138): a logica que hoje mora no texto
-da /aft-atualizar passa a morar aqui, onde da para ler, rodar e corrigir. Este
-arquivo cobre a fatia que se prova sozinha - PACOTE LOCAL, sem rede e sem
-token (issue #141). O caminho do portal (--verificar / baixar) entra depois,
-neste mesmo script.
+da /aft-atualizar passa a morar aqui, onde da para ler, rodar e corrigir. Sao
+dois caminhos ate o mesmo pacote:
+
+  * PACOTE LOCAL (--origem-local), sem rede e sem codigo de acesso - e o que
+    permite provar a transacao inteira contra uma pasta descartavel;
+  * PORTAL (sem --origem-local), que pergunta a versao disponivel, mostra o
+    changelog e baixa o pacote pelo endereco assinado.
+
+Quem fala com o portal e o portal_toolkit.py, ao lado deste: e la que moram o
+codigo de acesso, o registro da ultima consulta e as frases em portugues de
+cada falha. Daqui para baixo, os dois caminhos sao o mesmo programa: o pacote
+chega, e a transacao abaixo decide o que entra na pasta do AFT.
 
 O QUE ESTE PROGRAMA APAGA, E O QUE ELE NUNCA APAGA
 --------------------------------------------------
@@ -48,13 +56,22 @@ Os passos 1 a 3 acontecem ANTES de qualquer escrita: pacote corrompido ou
 suspeito nao chega a tocar na pasta do AFT.
 
 Uso:
+    python atualizar_toolkit.py --verificar
+    python atualizar_toolkit.py --aplicar
     python atualizar_toolkit.py --origem-local <pacote.zip> --destino <pasta> --simular
     python atualizar_toolkit.py --origem-local <pacote.zip> --destino <pasta> --aplicar
+    python atualizar_toolkit.py --gravar-token      (o codigo vem pelo stdin)
+    python atualizar_toolkit.py --estado-token
 
-A soma esperada vem do arquivo <pacote.zip>.sha256 ao lado do pacote (e o que
-o empacotar.py grava) ou de --sha256. Saida: um objeto JSON no stdout - so
-JSON, para quem chama nao precisar interpretar prosa. Codigos de saida:
-0 = feito, 1 = erro de uso, 2 = transacao recusada.
+Sem --destino, a pasta e ~/.claude/skills (a instalacao de verdade). Com
+--origem-local, a soma esperada vem do arquivo <pacote.zip>.sha256 ao lado do
+pacote (e o que o empacotar.py grava) ou de --sha256; pelo portal, ela vem da
+propria resposta autenticada. Saida: um objeto JSON no stdout - so JSON, para
+quem chama nao precisar interpretar prosa. Codigos de saida: 0 = feito (o que
+inclui "nao ha novidade"), 1 = erro de uso, 2 = transacao recusada ou consulta
+que nao pode ser respondida (falta codigo de acesso, portal fora do ar...).
+Toda recusa traz em `detalhe` a frase pronta para o AFT, em portugues e com o
+proximo passo.
 """
 
 try:  # ticket automatico de erro (ver _scripts/erro_ticket.py e a skill /aft-erro)
@@ -84,6 +101,7 @@ from pathlib import Path
 AQUI = Path(__file__).resolve().parent
 sys.path.insert(0, str(AQUI))
 from remontar import EXCLUIR  # noqa: E402  (mesma lista que o empacotar usa)
+import portal_toolkit as portal  # noqa: E402  (o lado cliente do portal)
 
 try:  # console do Windows e cp1252
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -91,6 +109,7 @@ try:  # console do Windows e cp1252
 except Exception:
     pass
 
+SKILLS_PADRAO = Path.home() / ".claude" / "skills"
 MANIFESTO = "_scripts/skills_oficiais.txt"
 # Marca deixada dentro de cada backup feito por este programa - e o que
 # distingue os nossos de qualquer outra pasta "skills-backup-*" do AFT.
@@ -524,30 +543,195 @@ def soma_esperada_de(zip_path, informada):
         "de origem desconhecida não se instala.")
 
 
+# ------------------------------------------------------------------- o portal
+
+def versao_instalada(destino):
+    return ler_versao(destino / VERSAO).get("versao")
+
+
+def _recusa(modo, estado, destino, **dados):
+    """Uma falha da conversa com o portal, no mesmo formato JSON das demais.
+    `detalhe` e sempre a frase pronta para o AFT - quem chama nao redige nada,
+    e assim a mesma explicacao vale para a skill, para o /aft-bom-dia e para
+    quem rodar o script na mao."""
+    res = {"ok": False, "modo": modo, "estado": estado, "erro": estado,
+           "destino": str(destino),
+           "detalhe": portal.mensagem(estado, **dados)}
+    if dados.get("detalhe_tecnico"):
+        res["detalhe_tecnico"] = dados["detalhe_tecnico"]
+    return res, 2
+
+
+def consultar_portal(destino, base, forcar, precisa_da_url, modo):
+    """Pergunta a versao disponivel. Devolve (resposta, res, codigo): com
+    `res` preenchido, e para devolver isso a quem chamou e parar.
+
+    `precisa_da_url` marca a diferenca entre olhar e baixar. O registro do dia
+    nao guarda o endereco assinado do pacote (ele expira em minutos), entao
+    quem vai baixar de fato repete a consulta - mas so DEPOIS de o registro ja
+    ter dito, de graca, que existe versao nova. Sem novidade, nao ha chamada de
+    rede nenhuma.
+    """
+    instalada = versao_instalada(destino)
+    r = portal.verificar(instalada, base=base, forcar=forcar)
+    if (precisa_da_url and r["estado"] == "ok" and r.get("de_registro")
+            and r.get("versao") != instalada):
+        r = portal.verificar(instalada, base=base, forcar=True)
+    if r["estado"] != "ok":
+        res, codigo = _recusa(modo, r["estado"], destino,
+                              gmail=portal.gmail(),
+                              detalhe_tecnico=r.get("detalhe_tecnico"))
+        return r, res, codigo
+    return r, None, 0
+
+
+def cmd_verificar(destino, base, forcar):
+    """--verificar: diz qual e a versao disponivel, se ha novidade e o que
+    mudou. Nao baixa nada e nao escreve nada na pasta de skills."""
+    instalada = versao_instalada(destino)
+    r, res, codigo = consultar_portal(destino, base, forcar,
+                                      precisa_da_url=False, modo="verificar")
+    if res:
+        res["versao_instalada"] = instalada
+        return res, codigo
+
+    ha_novidade = r["versao"] != instalada
+    res = {"ok": True, "modo": "verificar",
+           "estado": "ok" if ha_novidade else "sem_novidade",
+           "erro": None, "destino": str(destino),
+           "versao_instalada": instalada, "versao": r["versao"],
+           "ha_novidade": ha_novidade, "novidades": r.get("novidades", ""),
+           "consulta_de_hoje": bool(r.get("de_registro")),
+           "detalhe": ""}
+    if ha_novidade:
+        res["detalhe"] = (f"Há uma versão nova do toolkit disponível: "
+                          f"{r['versao']} (a sua é "
+                          f"{instalada or 'de antes da numeração de versões'}).")
+    else:
+        res["detalhe"] = portal.mensagem("sem_novidade", versao=r["versao"])
+    return res, 0
+
+
+def baixar_do_portal(destino, base, forcar, tmp, modo):
+    """Consulta, confere se ha novidade e traz o pacote. Devolve
+    (zip, soma, versao, res, codigo) - com `res` preenchido, e para parar."""
+    instalada = versao_instalada(destino)
+    r, res, codigo = consultar_portal(destino, base, forcar,
+                                      precisa_da_url=True, modo=modo)
+    if res:
+        return None, None, None, res, codigo
+
+    if r["versao"] == instalada:
+        # Sai barato: e o caso comum, e ele nao pode custar download nenhum.
+        return None, None, None, {
+            "ok": True, "modo": modo, "estado": "sem_novidade",
+            "erro": None, "destino": str(destino),
+            "versao_instalada": instalada, "versao": r["versao"],
+            "ha_novidade": False,
+            "detalhe": portal.mensagem("sem_novidade", versao=r["versao"]),
+        }, 0
+
+    if not r.get("url"):
+        return (None, None, None,
+                *_recusa(modo, "portal_indisponivel", destino,
+                         detalhe_tecnico="o portal anunciou a versão "
+                                         f"{r['versao']} mas não mandou o "
+                                         "endereço do pacote"))
+
+    # Nome fixo, e nao a versao que o portal anunciou: nome de arquivo vindo
+    # de fora nunca decide onde se escreve (uma "versao" com barra ou com ".."
+    # apontaria para fora da area temporaria).
+    zip_path = tmp / "pacote.zip"
+    try:
+        portal.baixar(r["url"], zip_path)
+    except Exception as e:
+        # O endereco assinado tem validade curta: uma consulta guardada de
+        # horas atras, uma queda no meio do download, ou o portal fora do ar
+        # entre uma chamada e outra caem todos aqui.
+        return (None, None, None,
+                *_recusa(modo, "portal_indisponivel", destino,
+                         detalhe_tecnico=f"o download do pacote falhou ({e})"))
+    return zip_path, r["sha256"], r["versao"], None, 0
+
+
+# ------------------------------------------------------- o codigo de acesso
+
+def cmd_gravar_token():
+    """--gravar-token: o codigo chega pela ENTRADA PADRAO, nunca como
+    argumento (argumento fica no historico do terminal e nos logs). O valor
+    nao e ecoado em lugar nenhum - a saida so diz onde ele ficou."""
+    try:
+        bruto = sys.stdin.read()
+    except Exception as e:
+        return {"ok": False, "erro": "leitura_falhou",
+                "detalhe": f"Não consegui ler o código de acesso ({e})."}, 1
+    try:
+        alvo = portal.gravar_token(bruto)
+    except ValueError as e:
+        return {"ok": False, "erro": "token_invalido",
+                "detalhe": f"O código de acesso não foi guardado: {e}."}, 1
+    except OSError as e:
+        return {"ok": False, "erro": "gravacao_falhou",
+                "detalhe": f"Não consegui gravar o código de acesso ({e})."}, 2
+    return {"ok": True, "erro": None, "arquivo": str(alvo), "detalhe": (
+        "Código de acesso guardado. Ele fica na sua pasta de trabalho, fora da "
+        "pasta de skills - assim a própria atualização não o apaga. Você não "
+        "precisa digitá-lo de novo.")}, 0
+
+
+def cmd_estado_token():
+    """--estado-token: existe codigo de acesso nesta maquina? Responde sim ou
+    nao e o caminho do arquivo - NUNCA o valor."""
+    tem = portal.tem_token()
+    return {"ok": True, "erro": None, "tem_token": tem,
+            "arquivo": str(portal.caminho_token()),
+            "gmail": portal.gmail(),
+            "detalhe": ("Código de acesso ao portal já configurado nesta máquina."
+                        if tem else portal.mensagem("sem_token"))}, 0
+
+
 def main():
     ap = argparse.ArgumentParser(
-        description="Aplica um pacote do toolkit numa pasta de destino")
+        description="Consulta o portal e aplica um pacote do toolkit")
     modo = ap.add_mutually_exclusive_group(required=True)
     modo.add_argument("--aplicar", action="store_true",
                       help="executa a transação completa")
     modo.add_argument("--simular", action="store_true",
                       help="percorre tudo e relata, sem escrever nada")
+    modo.add_argument("--verificar", action="store_true",
+                      help="pergunta ao portal qual é a versão disponível e o "
+                           "que mudou, sem baixar nem instalar nada")
+    modo.add_argument("--gravar-token", action="store_true",
+                      help="guarda o código de acesso ao portal (ele vem pela "
+                           "entrada padrão, nunca como argumento)")
+    modo.add_argument("--estado-token", action="store_true",
+                      help="diz se já há código de acesso nesta máquina - "
+                           "nunca mostra o valor")
     ap.add_argument("--confirmado", action="store_true",
                     help="segue mesmo com sinal suspeito na varredura - só "
                          "depois de o AFT ver o relatório e confirmar que a "
                          "atualização é legítima")
-    ap.add_argument("--origem-local", required=True,
-                    help="pacote .zip já baixado (dispensa rede e token)")
-    ap.add_argument("--destino", required=True,
-                    help="pasta instalada onde aplicar")
+    ap.add_argument("--origem-local",
+                    help="pacote .zip já baixado (dispensa rede e código de "
+                         "acesso); sem ele, o pacote vem do portal")
+    ap.add_argument("--destino", default=str(SKILLS_PADRAO),
+                    help="pasta instalada onde aplicar (padrão: ~/.claude/skills)")
     ap.add_argument("--sha256", help="soma esperada (padrão: o arquivo "
                                      "<pacote>.sha256 ao lado do pacote)")
+    ap.add_argument("--portal", default=portal.PORTAL,
+                    help="endereço do portal (para ensaio contra um portal de "
+                         "mentira)")
+    ap.add_argument("--forcar", action="store_true",
+                    help="consulta o portal mesmo já tendo consultado hoje")
     args = ap.parse_args()
 
-    zip_path = Path(args.origem_local).expanduser().resolve()
+    if args.gravar_token or args.estado_token:
+        res, codigo = (cmd_gravar_token() if args.gravar_token
+                       else cmd_estado_token())
+        print(json.dumps(res, ensure_ascii=False, indent=2))
+        sys.exit(codigo)
+
     destino = Path(args.destino).expanduser().resolve()
-    if not zip_path.is_file():
-        raise SystemExit(f"ERRO: pacote não encontrado: {zip_path}")
     if not destino.is_dir():
         raise SystemExit(
             f"ERRO: a pasta de destino não existe: {destino}\n"
@@ -555,10 +739,45 @@ def main():
             "pasta nova (um caminho digitado errado viraria uma instalação "
             "fantasma).")
 
-    soma = soma_esperada_de(zip_path, args.sha256)
+    if args.verificar:
+        try:
+            res, codigo = cmd_verificar(destino, args.portal, args.forcar)
+        except Exception as e:
+            # Defeito nosso nao se disfarca de portal fora do ar: quem le o
+            # JSON precisa saber a diferenca entre "tente mais tarde" e "isto
+            # aqui esta quebrado".
+            res, codigo = _recusa("verificar", "falha_inesperada", destino,
+                                  detalhe_tecnico=f"{type(e).__name__}: {e}")
+        print(json.dumps(res, ensure_ascii=False, indent=2))
+        sys.exit(codigo)
+
+    # A area temporaria cobre o pacote baixado do portal; com --origem-local
+    # ela nasce vazia e e apagada no fim, sem custo.
+    baixados = Path(tempfile.mkdtemp(prefix="aft-baixar-"))
     try:
-        res, codigo = transacao(zip_path, destino, soma,
-                                simular=args.simular, confirmado=args.confirmado)
+        if args.origem_local:
+            zip_path = Path(args.origem_local).expanduser().resolve()
+            if not zip_path.is_file():
+                raise SystemExit(f"ERRO: pacote não encontrado: {zip_path}")
+            soma = soma_esperada_de(zip_path, args.sha256)
+        else:
+            zip_path, soma, _versao, res, codigo = baixar_do_portal(
+                destino, args.portal, args.forcar, baixados,
+                "simular" if args.simular else "aplicar")
+            if res is not None:
+                print(json.dumps(res, ensure_ascii=False, indent=2))
+                sys.exit(codigo)
+        res, codigo = _rodar_transacao(zip_path, destino, soma, args)
+    finally:
+        shutil.rmtree(baixados, ignore_errors=True)
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+    sys.exit(codigo)
+
+
+def _rodar_transacao(zip_path, destino, soma, args):
+    try:
+        return transacao(zip_path, destino, soma,
+                         simular=args.simular, confirmado=args.confirmado)
     except Exception as e:
         # Quem chama le o stdout como JSON. Um traceback aqui deixaria a skill
         # sem nenhuma resposta para dar ao AFT - pior do que a propria falha.
@@ -568,9 +787,7 @@ def main():
                            f"({type(e).__name__}: {e}). Se a pasta ficou "
                            "incompleta, a versão anterior está na pasta de "
                            f"backup ao lado de {destino}.")}
-        codigo = 2
-    print(json.dumps(res, ensure_ascii=False, indent=2))
-    sys.exit(codigo)
+        return res, 2
 
 
 if __name__ == "__main__":

--- a/_scripts/erro_ticket.py
+++ b/_scripts/erro_ticket.py
@@ -85,12 +85,39 @@ def _caminhos_sensiveis() -> list[tuple[str, str]]:
     return pares
 
 
+_TOKEN_PORTAL: str | None = None
+
+
+def _token_portal() -> str:
+    """O código de acesso ao portal — lido APENAS para servir de agulha na
+    redação. O arquivo dele (`<pasta AFT>/.aft-toolkit-token`) nunca entra no
+    ticket, e o valor nunca é impresso: se ele aparecer num traceback, sai
+    daqui como `<CODIGO DE ACESSO>`. Credencial não viaja em relato de erro."""
+    global _TOKEN_PORTAL
+    if _TOKEN_PORTAL is None:
+        try:
+            sys.path.insert(0, str(AQUI))
+            from portal_toolkit import ler_token
+            _TOKEN_PORTAL = ler_token() or ""
+        except Exception:
+            _TOKEN_PORTAL = ""
+    return _TOKEN_PORTAL
+
+
 def _redigir(texto) -> str:
     """Remove de um texto qualquer tudo que possa identificar empresa,
     trabalhador ou o próprio AFT. Roda em TODO conteúdo antes de gravar."""
     if texto is None:
         return ""
     s = str(texto)
+
+    # 0. Código de acesso ao portal, caso tenha vazado num traceback. Vem
+    #    ANTES de todas as outras: se um pedaço dele casasse com a regra do
+    #    CNPJ ou a do e-mail, o resto do código escaparia inteiro. Código
+    #    curto demais não se troca - seria trocar palavra comum por engano.
+    token = _token_portal()
+    if len(token) >= 8:
+        s = s.replace(token, "<CODIGO DE ACESSO>")
 
     # 1. Nome da empresa fiscalizada: o segmento logo depois de OS ATIVAS/ARQUIVADAS.
     s = re.sub(r"(OS\s+(?:ATIVAS|ARQUIVADAS))([\\/]+)([^\\/\r\n\"']+)",
@@ -124,6 +151,7 @@ def _redigir(texto) -> str:
             s = re.sub(rf"\b{re.escape(usuario)}\b", "<USUARIO>", s, flags=re.IGNORECASE)
     except Exception:
         pass
+
     return s
 
 
@@ -254,6 +282,17 @@ def ambiente() -> list[tuple[str, str]]:
 
     try:
         itens.append(("Skills instaladas", str(len(list(SKILLS_DIR.glob("*/SKILL.md"))))))
+    except Exception:
+        pass
+
+    # Acesso ao portal: só EXISTE ou NÃO EXISTE. O valor do código nunca entra
+    # num ticket — e é justamente por isso que ele mora fora do aft-config.md,
+    # que este retrato poderia acabar copiando inteiro um dia.
+    try:
+        sys.path.insert(0, str(AQUI))
+        from portal_toolkit import tem_token
+        itens.append(("Código de acesso ao portal",
+                      "configurado" if tem_token() else "não configurado"))
     except Exception:
         pass
     return itens

--- a/_scripts/portal_toolkit.py
+++ b/_scripts/portal_toolkit.py
@@ -1,0 +1,371 @@
+# -*- coding: utf-8 -*-
+"""
+portal_toolkit.py - o lado cliente do portal, para o atualizar_toolkit.py.
+
+Aqui mora tudo o que envolve FALAR com o portal `notebooks-aft`: onde fica o
+codigo de acesso nesta maquina, como se pergunta ao portal qual e a versao
+disponivel, e como cada falha vira frase em portugues com o proximo passo.
+Quem aplica o pacote e o atualizar_toolkit.py; este arquivo nao escreve uma
+linha dentro da pasta de skills.
+
+ONDE MORA O CODIGO DE ACESSO - E POR QUE NAO E ONDE PARECE OBVIO
+----------------------------------------------------------------
+Nem na pasta de skills, nem no aft-config.md.
+
+  * FORA DA PASTA DE SKILLS porque e justamente ela que a atualizacao
+    substitui: guardar o token em ~/.claude/skills seria perde-lo na primeira
+    atualizacao que ele mesmo autorizou - e o AFT ficaria preso, sem entender
+    por que o codigo "some" toda vez. Vale igual para o registro da ultima
+    consulta.
+  * FORA DO aft-config.md porque aquele arquivo e lido, editado e IMPRESSO na
+    tela por varias skills e pelo /aft-doctor. Credencial nao mora em arquivo
+    que se manda mostrar.
+
+Os dois arquivos ficam na pasta de trabalho do AFT, descoberta pelo
+pasta_aft.py (que nunca se presume: pode ter sido movida):
+
+    <pasta AFT>/.aft-toolkit-token      o codigo de acesso, e mais nada
+    <pasta AFT>/.aft-toolkit-consulta.json   quando foi a ultima consulta
+
+Tres regras acompanham o token, e as tres sao contrato: o /aft-doctor confere
+que ele existe sem imprimir o valor; o erro_ticket.py nao le esse arquivo ao
+montar um ticket (e ainda esconde o valor, caso ele apareca num traceback); e
+o assistente nunca ecoa o token no chat.
+
+O CONTRATO COM O PORTAL (issue #138)
+------------------------------------
+Uma unica rota autenticada. O cliente manda Gmail, token e a versao instalada;
+o servidor confere o acesso CONTRA A TABELA DELE e responde:
+
+    POST <portal>/api/toolkit/versao
+    {"gmail": "...", "token": "...", "versao_instalada": "2026.08.29-abc1234"}
+
+    200  {"versao": "...", "sha256": "...", "novidades": "<markdown>",
+          "url": "<endereco assinado, de validade curta, do .zip>"}
+    401  {"erro": "token_invalido"}   codigo desconhecido, trocado ou cancelado
+    403  {"erro": "sem_acesso"}       o Gmail nao esta liberado para o toolkit
+
+O token vai no CORPO, nunca na URL: endereco vaza em log de servidor, em
+historico e em captura de tela. A versao instalada vai junto porque e ela que
+permite ao portal montar o changelog DO PERIODO - o AFT quer ler o que mudou
+desde a versao dele, nao o changelog inteiro.
+
+Quem decide se ha novidade e o cliente, comparando a versao anunciada com a
+instalada. O portal so anuncia o que tem.
+
+UMA CONSULTA POR DIA
+--------------------
+O /aft-bom-dia vai chamar isto toda manha, e ninguem quer uma chamada de rede
+a cada conversa. A resposta fica registrada em .aft-toolkit-consulta.json e
+vale ate a data virar. O registro guarda a versao, o changelog e a versao
+instalada na hora - nunca a `url` assinada, que expira em minutos e nao serve
+para reaproveitar, e nunca o token. Se a versao instalada mudar (o AFT
+atualizou), o registro e considerado velho na hora.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+AQUI = Path(__file__).resolve().parent
+if str(AQUI) not in sys.path:  # uma vez so: pasta_estado() e chamada varias vezes
+    sys.path.insert(0, str(AQUI))
+
+PORTAL = "https://notebooks-aft.vercel.app"
+ROTA = "/api/toolkit/versao"
+TIMEOUT = 30  # s
+
+ARQUIVO_TOKEN = ".aft-toolkit-token"
+ARQUIVO_CONSULTA = ".aft-toolkit-consulta.json"
+
+# Estados que o cliente sabe traduzir. Os quatro primeiros sao os da issue #142.
+ESTADOS = ("ok", "sem_token", "token_invalido", "sem_acesso", "sem_novidade",
+           "sem_gmail", "portal_indisponivel")
+
+
+# --------------------------------------------------------- onde ficam as coisas
+
+def pasta_estado() -> Path:
+    """A pasta de trabalho do AFT. Fora da pasta de skills, sempre - ver o
+    cabecalho. Se o pasta_aft.py nao puder responder (defeito ou maquina meio
+    instalada), cai para ~/.claude, que tambem sobrevive a atualizacao."""
+    try:
+        from pasta_aft import pasta_aft as _pasta_aft
+        return Path(_pasta_aft())
+    except Exception:
+        return Path.home() / ".claude"
+
+
+def caminho_token() -> Path:
+    return pasta_estado() / ARQUIVO_TOKEN
+
+
+def caminho_consulta() -> Path:
+    return pasta_estado() / ARQUIVO_CONSULTA
+
+
+# ------------------------------------------------------------------- o token
+
+def ler_token() -> str | None:
+    """O codigo de acesso, ou None se nao houver. Nunca levanta excecao: falta
+    de token e um estado previsto, nao um acidente."""
+    try:
+        valor = caminho_token().read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return valor or None
+
+
+def gravar_token(valor: str) -> Path:
+    """Guarda o codigo de acesso. Devolve o caminho; nunca devolve o valor."""
+    valor = (valor or "").strip()
+    if not valor:
+        raise ValueError("o código de acesso veio vazio")
+    if len(valor.split()) > 1:
+        raise ValueError("o código de acesso não pode ter espaço no meio - "
+                         "cole só o código, sem texto em volta")
+    alvo = caminho_token()
+    alvo.parent.mkdir(parents=True, exist_ok=True)
+    alvo.write_text(valor + "\n", encoding="utf-8")
+    try:  # so o dono le (no Windows nao existe, e nao faz falta)
+        os.chmod(alvo, 0o600)
+    except OSError:
+        pass
+    return alvo
+
+
+def tem_token() -> bool:
+    return ler_token() is not None
+
+
+# -------------------------------------------------------------------- o Gmail
+
+def gmail() -> str | None:
+    """O e-mail do cadastro, lido do aft-config.md. E o mesmo campo que as
+    skills do NotebookLM ja usam - nao se inventa um segundo lugar para a
+    mesma informacao."""
+    try:
+        cfg = pasta_estado() / "aft-config.md"
+        for linha in cfg.read_text(encoding="utf-8").splitlines():
+            m = re.match(r'\s*gmail\s*:\s*"?([^"#\s]+)"?', linha)
+            if m:
+                return m.group(1).strip()
+    except OSError:
+        pass
+    return None
+
+
+# ------------------------------------------------------- registro da consulta
+
+def _hoje() -> str:
+    return datetime.date.today().isoformat()
+
+
+def consulta_registrada(versao_instalada: str | None,
+                        base: str = PORTAL) -> dict | None:
+    """A resposta de hoje, se ja houver uma. None quando a data virou, quando
+    o AFT atualizou desde entao, quando a resposta veio de outro endereco (um
+    ensaio contra portal de mentira nao pode responder pelo portal de verdade
+    pelo resto do dia), ou quando nao ha registro nenhum."""
+    try:
+        dados = json.loads(caminho_consulta().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(dados, dict) or dados.get("dia") != _hoje():
+        return None
+    if dados.get("versao_instalada") != versao_instalada:
+        return None
+    if dados.get("portal") != base:
+        return None
+    resposta = dados.get("resposta")
+    return resposta if isinstance(resposta, dict) else None
+
+
+def registrar_consulta(resposta: dict, versao_instalada: str | None,
+                       base: str = PORTAL) -> None:
+    """Guarda a resposta do dia. A `url` assinada NAO entra (expira em minutos)
+    e o token nunca chega aqui. Falha de escrita e silenciosa de proposito:
+    disco cheio nao pode impedir a atualizacao de acontecer."""
+    limpa = {k: v for k, v in resposta.items() if k != "url"}
+    try:
+        caminho_consulta().parent.mkdir(parents=True, exist_ok=True)
+        caminho_consulta().write_text(json.dumps(
+            {"dia": _hoje(), "quando": datetime.datetime.now().isoformat(timespec="seconds"),
+             "portal": base, "versao_instalada": versao_instalada,
+             "resposta": limpa},
+            ensure_ascii=False, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+
+
+# ------------------------------------------------------------ a conversa em si
+
+def _erro_do_corpo(bruto: bytes) -> str | None:
+    """O campo `erro` do corpo, quando o portal manda um dos nomes que este
+    cliente conhece. E o que desempata um 403 que e falta de acesso de um 403
+    que e token cancelado."""
+    try:
+        dados = json.loads(bruto.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    nome = dados.get("erro") if isinstance(dados, dict) else None
+    return nome if nome in ESTADOS else None
+
+
+def consultar(gmail_do_aft: str, token: str, versao_instalada: str | None,
+              base: str = PORTAL) -> dict:
+    """Pergunta ao portal qual e a versao disponivel.
+
+    Devolve sempre um dicionario com `estado` - nunca levanta excecao e NUNCA
+    inclui o token no que devolve. Estado "ok" traz versao, sha256, novidades
+    e a url assinada do pacote.
+    """
+    corpo = json.dumps({"gmail": gmail_do_aft, "token": token,
+                        "versao_instalada": versao_instalada or ""}).encode("utf-8")
+    req = urllib.request.Request(
+        base.rstrip("/") + ROTA, data=corpo, method="POST",
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "aft-toolkit/atualizar"})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+            dados = json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        # Mapa do contrato. O corpo, quando traz um `erro` conhecido, vence o
+        # codigo - e ele que distingue os dois motivos possiveis de um 403.
+        try:
+            nome = _erro_do_corpo(e.read())
+        except Exception:
+            nome = None
+        if nome in ("token_invalido", "sem_acesso"):
+            return {"estado": nome}
+        if e.code == 401:
+            return {"estado": "token_invalido"}
+        if e.code == 403:
+            return {"estado": "sem_acesso"}
+        return {"estado": "portal_indisponivel",
+                "detalhe_tecnico": f"o portal respondeu {e.code}"}
+    except urllib.error.URLError as e:
+        # Sem rede, DNS fora, portal no chao, certificado recusado. O motivo
+        # tecnico vai junto porque e ele que distingue "sua internet caiu" de
+        # "o portal esta fora do ar" - mas nao substitui a frase em portugues.
+        return {"estado": "portal_indisponivel",
+                "detalhe_tecnico": str(getattr(e, "reason", e))}
+    except (ValueError, OSError) as e:
+        return {"estado": "portal_indisponivel",
+                "detalhe_tecnico": f"resposta ilegível do portal ({e})"}
+
+    if not isinstance(dados, dict) or not dados.get("versao") or not dados.get("sha256"):
+        return {"estado": "portal_indisponivel",
+                "detalhe_tecnico": "o portal respondeu sem versão ou sem soma "
+                                   "de verificação"}
+    return {"estado": "ok", "versao": str(dados["versao"]),
+            "sha256": str(dados["sha256"]).strip().lower(),
+            "novidades": dados.get("novidades") or "",
+            "url": dados.get("url") or ""}
+
+
+def verificar(versao_instalada: str | None, base: str = PORTAL,
+              forcar: bool = False) -> dict:
+    """A consulta completa: token, Gmail, registro do dia e portal.
+
+    Sempre devolve `estado`. Com `forcar`, ignora o registro do dia - e o que o
+    AFT usa quando soube por fora que saiu versao nova.
+    """
+    if not forcar:
+        guardada = consulta_registrada(versao_instalada, base)
+        if guardada:
+            return {**guardada, "de_registro": True}
+
+    token = ler_token()
+    if not token:
+        return {"estado": "sem_token"}
+    endereco = gmail()
+    if not endereco:
+        return {"estado": "sem_gmail"}
+
+    resposta = consultar(endereco, token, versao_instalada, base=base)
+    if resposta["estado"] == "ok":
+        registrar_consulta(resposta, versao_instalada, base)
+    return resposta
+
+
+def baixar(url: str, alvo: Path) -> None:
+    """Traz o pacote para um arquivo local. A conferencia do sha256 e a
+    descompactacao segura sao do atualizar_toolkit.py - aqui so se baixa."""
+    req = urllib.request.Request(url, headers={"User-Agent": "aft-toolkit/atualizar"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r, open(alvo, "wb") as f:
+        while True:
+            bloco = r.read(1 << 20)
+            if not bloco:
+                break
+            f.write(bloco)
+
+
+# ------------------------------------------------- as falhas, em portugues
+
+LINK = f"{PORTAL}/aft-toolkit"
+
+
+def mensagem(estado: str, **dados) -> str:
+    """A frase que o AFT le. Toda falha diz o que aconteceu E o proximo passo -
+    ele nao e programador e nao tem por que deduzir nada. Sem jargao, sem nome
+    de arquivo de codigo, e nunca o valor do token."""
+    if estado == "sem_token":
+        return (
+            "Falta nesta máquina o código de acesso ao toolkit. Ele chega uma "
+            "única vez, no e-mail de liberação do portal, e depois nunca mais "
+            f"incomoda.\n\nPróximo passo: peça o acesso em {LINK} com a sua "
+            "conta Google. Quando o código chegar, é só me passar que eu "
+            "guardo — não precisa de conta no GitHub nem de senha nova.")
+    if estado == "token_invalido":
+        return (
+            "O portal não aceitou o código de acesso guardado nesta máquina. "
+            "Em geral é código antigo: ele foi trocado ou cancelado.\n\n"
+            f"Próximo passo: peça um código novo em {LINK} e me passe — eu "
+            "substituo o antigo. Nada foi alterado na sua pasta.")
+    if estado == "sem_acesso":
+        quem = dados.get("gmail")
+        return (
+            "O portal reconheceu esta máquina, mas o e-mail do seu cadastro"
+            + (f" ({quem})" if quem else "")
+            + " ainda não está liberado para receber o toolkit.\n\n"
+            f"Próximo passo: peça a liberação em {LINK}, com a mesma conta "
+            "Google. Quem já usa os ementários do NotebookLM costuma ser "
+            "liberado na hora.")
+    if estado == "sem_gmail":
+        return (
+            "Não sei qual é o e-mail do seu cadastro no portal — é por ele que "
+            "o portal reconhece você. Ele deveria estar na sua ficha de "
+            "configuração (aft-config.md), na linha que começa com `gmail:`."
+            "\n\nPróximo passo: me diga qual e-mail você usou no portal que eu "
+            "escrevo na ficha e repito a consulta.")
+    if estado == "sem_novidade":
+        versao = dados.get("versao") or "a atual"
+        return (
+            f"Você já está com a versão mais recente do toolkit ({versao}). "
+            "Não há nada para instalar.")
+    if estado == "portal_indisponivel":
+        motivo = dados.get("detalhe_tecnico")
+        return (
+            "Não consegui falar com o portal agora"
+            + (f" ({motivo})" if motivo else "")
+            + ". Pode ser a sua conexão ou o portal fora do ar por alguns "
+            "minutos.\n\nPróximo passo: tente de novo mais tarde. Nada foi "
+            "alterado na sua pasta, e o toolkit que você já tem continua "
+            "funcionando normalmente.")
+    # Qualquer outra coisa - inclusive defeito nosso. Nao se finge que foi a
+    # rede: o AFT precisa saber que isto merece um relato ao mantenedor.
+    motivo = dados.get("detalhe_tecnico")
+    return (
+        "Não consegui completar a consulta ao portal"
+        + (f" ({motivo})" if motivo else "")
+        + ".\n\nPróximo passo: tente de novo. Se acontecer outra vez, isto é "
+        "defeito do toolkit e vale registrar com /aft-erro. Nada foi alterado "
+        "na sua pasta.")

--- a/_scripts/testar_portal.py
+++ b/_scripts/testar_portal.py
@@ -1,0 +1,355 @@
+# -*- coding: utf-8 -*-
+"""
+testar_portal.py - Prova o cliente do portal contra um portal de mentira.
+
+O portal de verdade ainda nao existe (ele e outro repositorio, ver a issue
+#138). O que existe e o CONTRATO - e contrato se exercita: este programa sobe
+um servidor local que responde exatamente o que o portal promete responder, e
+manda o atualizar_toolkit.py conversar com ele.
+
+O que se prova aqui:
+
+  * a consulta devolve versao, se ha novidade e o changelog, SEM baixar nada;
+  * a consulta acontece no maximo uma vez por dia (a segunda sai do registro,
+    sem tocar a rede) - e --forcar fura o registro quando o AFT manda;
+  * o codigo de acesso e lido de arquivo proprio, na pasta de trabalho do AFT,
+    e nunca do aft-config.md;
+  * o codigo de acesso nao aparece em saida nenhuma, nem no ticket de erro;
+  * sem codigo, codigo recusado, e-mail sem acesso e nada de novo: cada um com
+    a sua mensagem em portugues e o proximo passo;
+  * ponta a ponta: o pacote baixado do portal de mentira e realmente instalado
+    na pasta de destino.
+
+Nada real e tocado: nem ~/.claude/skills, nem a pasta de trabalho do AFT (o
+PASTA_AFT aponta para uma pasta descartavel durante o teste inteiro).
+
+Uso:
+    python testar_portal.py
+    python testar_portal.py --manter    # nao apaga a area de teste no fim
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+AQUI = Path(__file__).resolve().parent
+PY = sys.executable or "python3"
+
+TOKEN_BOM = "tk-de-mentira-0123456789abcdef"
+GMAIL_BOM = "aft.de.mentira@exemplo.invalido"
+GMAIL_SEM_ACESSO = "outro.aft@exemplo.invalido"
+
+falhas = []
+
+
+def checar(condicao, descricao, extra=""):
+    marca = "OK  " if condicao else "FALHOU"
+    print(f"  [{marca}] {descricao}" + (f"\n           {extra}" if extra and not condicao else ""))
+    if not condicao:
+        falhas.append(descricao)
+
+
+# ------------------------------------------------------- o portal de mentira
+
+class PortalDeMentira(HTTPServer):
+    """Responde o contrato da issue #138 e conta quantas vezes foi chamado -
+    e a contagem que prova a regra de uma consulta por dia."""
+
+    manifesto = {}          # o que a rota anuncia: versao, sha256, novidades
+    pacote = None           # Path do .zip que a url assinada entrega
+    consultas = 0
+
+
+class Rota(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # sem ruido no meio do relatorio
+        pass
+
+    def _responder(self, codigo, corpo):
+        dados = json.dumps(corpo).encode("utf-8")
+        self.send_response(codigo)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(dados)))
+        self.end_headers()
+        self.wfile.write(dados)
+
+    def do_GET(self):
+        # A "url assinada": aqui ela e so um caminho combinado, mas o que
+        # importa e que ela vem da resposta autenticada, e nao adivinhada.
+        if self.path.startswith("/pacote-assinado") and self.server.pacote:
+            dados = Path(self.server.pacote).read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/zip")
+            self.send_header("Content-Length", str(len(dados)))
+            self.end_headers()
+            self.wfile.write(dados)
+            return
+        self.send_error(404)
+
+    def do_POST(self):
+        tamanho = int(self.headers.get("Content-Length") or 0)
+        try:
+            pedido = json.loads(self.rfile.read(tamanho).decode("utf-8"))
+        except ValueError:
+            return self._responder(400, {"erro": "corpo ilegível"})
+        self.server.consultas += 1
+
+        if pedido.get("token") != TOKEN_BOM:
+            return self._responder(401, {"erro": "token_invalido"})
+        if pedido.get("gmail") != GMAIL_BOM:
+            return self._responder(403, {"erro": "sem_acesso"})
+        resposta = dict(self.server.manifesto)
+        resposta["url"] = f"http://127.0.0.1:{self.server.server_port}/pacote-assinado"
+        return self._responder(200, resposta)
+
+
+def subir_portal():
+    servidor = PortalDeMentira(("127.0.0.1", 0), Rota)
+    threading.Thread(target=servidor.serve_forever, daemon=True).start()
+    return servidor, f"http://127.0.0.1:{servidor.server_port}"
+
+
+# ------------------------------------------------------------------ o roteiro
+
+def rodar(base, ambiente):
+    from testar_aplicador import montar_pacotes  # o mesmo empacotador de verdade
+
+    print("Montando os pacotes de teste com o empacotar.py...")
+    v1, v2, _v3, _envenenado = montar_pacotes(base)
+
+    destino = base / "skills-de-mentira"
+    destino.mkdir()
+    pasta_aft = Path(ambiente["PASTA_AFT"])
+    pasta_aft.mkdir(parents=True, exist_ok=True)
+    (pasta_aft / "aft-config.md").write_text(
+        f'---\ngmail: "{GMAIL_BOM}"\ncif: "000000"\n---\n', encoding="utf-8")
+
+    servidor, endereco = subir_portal()
+    servidor.pacote = v2
+    servidor.manifesto = {
+        "versao": versao_do_pacote(v2),
+        "sha256": hashlib.sha256(Path(v2).read_bytes()).hexdigest(),
+        "novidades": ("## 29/08/2026\n\n**O toolkit passa a chegar por "
+                      "pacote.** Você recebe uma versão, e não dezenas de "
+                      "commits.\n"),
+    }
+
+    def rodar_script(*args, entrada=None):
+        r = subprocess.run([PY, str(AQUI / "atualizar_toolkit.py"), *args],
+                           input=entrada, capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", env=ambiente)
+        try:
+            return r.returncode, json.loads(r.stdout), r.stdout + r.stderr
+        except ValueError:
+            raise SystemExit(f"saída não era JSON:\n{r.stdout}\n{r.stderr}")
+
+    comum = ["--destino", str(destino), "--portal", endereco]
+
+    print("\n1. Sem código de acesso nesta máquina")
+    codigo, res, bruto = rodar_script("--verificar", *comum)
+    checar(codigo == 2 and res["estado"] == "sem_token",
+           "a falta de código de acesso tem estado próprio", str(res.get("estado")))
+    checar("código de acesso" in res["detalhe"]
+           and "Próximo passo" in res["detalhe"],
+           "a mensagem é em português e diz o próximo passo", res["detalhe"])
+    checar(servidor.consultas == 0,
+           "sem código de acesso, o portal nem chega a ser chamado")
+
+    codigo, res, _ = rodar_script("--estado-token", *comum)
+    checar(codigo == 0 and res["tem_token"] is False,
+           "o estado do código de acesso responde 'não configurado'")
+
+    print("\n2. Guardar o código de acesso")
+    codigo, res, bruto = rodar_script("--gravar-token", *comum, entrada=TOKEN_BOM + "\n")
+    arquivo = Path(res.get("arquivo", ""))
+    checar(codigo == 0 and res["ok"], "gravou o código de acesso", str(res))
+    checar(TOKEN_BOM not in bruto, "o código de acesso não aparece na saída")
+    checar(arquivo.is_file() and arquivo.parent == pasta_aft,
+           "o código foi guardado na pasta de trabalho do AFT", str(arquivo))
+    checar(str(destino) not in str(arquivo),
+           "e NÃO dentro da pasta de skills, que a atualização substitui")
+    cfg = (pasta_aft / "aft-config.md").read_text(encoding="utf-8")
+    checar(TOKEN_BOM not in cfg, "o código de acesso não foi parar no aft-config.md")
+
+    print("\n3. Código de acesso recusado pelo portal")
+    arquivo.write_text("tk-cancelado-999\n", encoding="utf-8")
+    codigo, res, bruto = rodar_script("--verificar", *comum)
+    checar(codigo == 2 and res["estado"] == "token_invalido",
+           "o código recusado tem estado próprio", str(res.get("estado")))
+    checar("Próximo passo" in res["detalhe"] and "novo" in res["detalhe"],
+           "a mensagem conduz a pedir um código novo", res["detalhe"])
+    checar("tk-cancelado-999" not in bruto,
+           "nem o código recusado aparece na saída")
+
+    print("\n4. E-mail sem acesso ao toolkit")
+    arquivo.write_text(TOKEN_BOM + "\n", encoding="utf-8")
+    (pasta_aft / "aft-config.md").write_text(
+        f'---\ngmail: "{GMAIL_SEM_ACESSO}"\n---\n', encoding="utf-8")
+    codigo, res, _ = rodar_script("--verificar", *comum)
+    checar(codigo == 2 and res["estado"] == "sem_acesso",
+           "o e-mail sem acesso tem estado próprio", str(res.get("estado")))
+    checar(GMAIL_SEM_ACESSO in res["detalhe"] and "liberação" in res["detalhe"],
+           "a mensagem diz qual e-mail e conduz ao pedido de liberação",
+           res["detalhe"])
+
+    print("\n4b. Ficha de configuração sem o e-mail do cadastro")
+    (pasta_aft / "aft-config.md").write_text("---\ncif: \"000000\"\n---\n",
+                                             encoding="utf-8")
+    codigo, res, _ = rodar_script("--verificar", *comum)
+    checar(codigo == 2 and res["estado"] == "sem_gmail",
+           "sem e-mail na ficha, o script pede o e-mail em vez de falhar",
+           str(res.get("estado")))
+    checar("Próximo passo" in res["detalhe"],
+           "com o próximo passo em português", res["detalhe"])
+
+    print("\n5. Consulta com tudo em ordem (sem baixar nada)")
+    (pasta_aft / "aft-config.md").write_text(
+        f'---\ngmail: "{GMAIL_BOM}"\n---\n', encoding="utf-8")
+    antes = retrato(destino)
+    servidor.consultas = 0
+    codigo, res, _ = rodar_script("--verificar", *comum)
+    checar(codigo == 0 and res["ok"] and res["ha_novidade"] is True,
+           "a consulta anuncia que há novidade", str(res.get("detalhe")))
+    checar(res["versao"] == servidor.manifesto["versao"],
+           "a consulta devolve a versão disponível")
+    checar("pacote" in res["novidades"],
+           "a consulta devolve o changelog", res.get("novidades", ""))
+    checar(res["versao_instalada"] is None,
+           "e diz que não há versão instalada nesta pasta ainda")
+    checar(retrato(destino) == antes, "a consulta não escreveu nada no destino")
+
+    print("\n6. Uma consulta por dia")
+    codigo, res, _ = rodar_script("--verificar", *comum)
+    checar(servidor.consultas == 1,
+           "a segunda consulta do dia não chamou o portal de novo",
+           f"{servidor.consultas} chamadas")
+    checar(res["consulta_de_hoje"] is True and res["ha_novidade"] is True,
+           "e mesmo assim respondeu a mesma coisa")
+    registro = pasta_aft / ".aft-toolkit-consulta.json"
+    checar(registro.is_file(), "o registro da consulta ficou na pasta do AFT")
+    checar(TOKEN_BOM not in registro.read_text(encoding="utf-8")
+           and "url" not in json.loads(registro.read_text(encoding="utf-8"))["resposta"],
+           "o registro não guarda nem o código de acesso nem o endereço assinado")
+    codigo, res, _ = rodar_script("--verificar", *comum, "--forcar")
+    checar(servidor.consultas == 2, "--forcar fura o registro do dia",
+           f"{servidor.consultas} chamadas")
+
+    print("\n7. Instalar o pacote que veio do portal")
+    codigo, res, _ = rodar_script("--aplicar", *comum)
+    checar(codigo == 0 and res["ok"], "aplicou o pacote baixado do portal",
+           str(res.get("detalhe")) + " / " + str(res.get("erro")))
+    checar((destino / "aft-teste-novata" / "SKILL.md").is_file(),
+           "a skill do pacote apareceu na pasta de destino")
+    checar((destino / "_scripts" / "versao.txt").is_file(),
+           "o carimbo de versão foi instalado")
+
+    print("\n8. Nada de novo")
+    servidor.consultas = 0
+    codigo, res, _ = rodar_script("--verificar", *comum, "--forcar")
+    checar(codigo == 0 and res["ok"] and res["ha_novidade"] is False
+           and res["estado"] == "sem_novidade",
+           "depois de instalar, a consulta diz que não há novidade",
+           str(res.get("detalhe")))
+    checar("mais recente" in res["detalhe"], "com mensagem própria em português",
+           res["detalhe"])
+    codigo, res, _ = rodar_script("--aplicar", *comum)
+    checar(codigo == 0 and res["estado"] == "sem_novidade",
+           "e o --aplicar sai barato, sem instalar nada", str(res.get("estado")))
+
+    print("\n9. Soma de verificação divergente (o portal anunciou outra coisa)")
+    servidor.manifesto = dict(servidor.manifesto, versao="9999.99.99-mentira",
+                              sha256="0" * 64)
+    antes = retrato(destino)
+    codigo, res, _ = rodar_script("--aplicar", *comum, "--forcar")
+    checar(codigo == 2 and res["erro"] == "soma_divergente",
+           "recusou o pacote cuja soma não bate com a anunciada",
+           str(res.get("erro")))
+    checar(retrato(destino) == antes, "e nada foi escrito na pasta de destino")
+
+    print("\n10. Portal fora do ar")
+    servidor.shutdown()
+    codigo, res, _ = rodar_script("--verificar", *comum, "--forcar")
+    checar(codigo == 2 and res["estado"] == "portal_indisponivel",
+           "o portal fora do ar tem estado próprio", str(res.get("estado")))
+    checar("Nada foi alterado" in res["detalhe"],
+           "e a mensagem tranquiliza o AFT", res["detalhe"])
+
+    print("\n11. O ticket de erro não leva o código de acesso junto")
+    arquivo.write_text(TOKEN_BOM + "\n", encoding="utf-8")
+    r = subprocess.run(
+        [PY, str(AQUI / "erro_ticket.py"), "--titulo", "ensaio",
+         "--mensagem", f"o script quebrou com o codigo {TOKEN_BOM} na mao"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        env=ambiente)
+    tickets = sorted((pasta_aft / "tickets").glob("*.md")) if (pasta_aft / "tickets").is_dir() else []
+    checar(bool(tickets), "o ticket foi gravado na pasta de mentira",
+           r.stdout + r.stderr)
+    if tickets:
+        texto = tickets[-1].read_text(encoding="utf-8")
+        checar(TOKEN_BOM not in texto,
+               "o código de acesso não aparece no ticket, nem vindo do traceback")
+        checar("<CODIGO DE ACESSO>" in texto,
+               "ele sai escondido, e não apagado em silêncio")
+        checar("Código de acesso ao portal | configurado" in texto,
+               "o ticket diz só que existe um código configurado")
+
+
+def versao_do_pacote(zip_path):
+    """A versao que o empacotar.py carimbou dentro do pacote - e ela que o
+    portal de mentira anuncia, para o teste nao inventar numero."""
+    import zipfile
+    with zipfile.ZipFile(zip_path) as z:
+        texto = z.read("_scripts/versao.txt").decode("utf-8")
+    for linha in texto.splitlines():
+        chave, _, valor = linha.partition(":")
+        if chave.strip() == "versao":
+            return valor.strip()
+    raise SystemExit("o pacote de teste saiu sem carimbo de versão")
+
+
+def retrato(pasta):
+    out = {}
+    for p in sorted(pasta.rglob("*")):
+        if p.is_file():
+            out[str(p.relative_to(pasta))] = hashlib.sha256(p.read_bytes()).hexdigest()
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Prova o cliente do portal")
+    ap.add_argument("--manter", action="store_true",
+                    help="não apaga a área de teste no fim")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(AQUI))
+    base = Path(tempfile.mkdtemp(prefix="aft-teste-portal-"))
+    # PASTA_AFT aponta para a pasta de mentira: e o que garante que o codigo de
+    # acesso, o registro da consulta e o ticket nao encostem na pasta real.
+    ambiente = dict(os.environ, PASTA_AFT=str(base / "AFT-de-mentira"))
+    print(f"Área de teste: {base}\n")
+    try:
+        rodar(base, ambiente)
+    finally:
+        if args.manter:
+            print(f"\nÁrea de teste mantida em {base}")
+        else:
+            shutil.rmtree(base, ignore_errors=True)
+
+    print()
+    if falhas:
+        print(f"{len(falhas)} verificação(ões) FALHARAM:")
+        for f in falhas:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("Todas as verificações passaram.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fecha #142. Quarta fatia da migração da distribuição (#138), sobre o aplicador da #141.

## O que entra

- **`_scripts/portal_toolkit.py` (novo)** — o lado cliente do portal: onde mora o código de acesso, o registro da última consulta, a chamada HTTP e as frases em português de cada falha.
- **`_scripts/atualizar_toolkit.py`** — `--verificar`, o caminho do portal no `--aplicar` (agora que `--origem-local` é opcional), `--gravar-token` e `--estado-token`. `--destino` ganhou o padrão `~/.claude/skills`, como a #138 já descrevia.
- **`_scripts/erro_ticket.py`** — não lê o arquivo do token para dentro do ticket; lê o valor apenas como agulha, para escondê-lo como `<CODIGO DE ACESSO>` se aparecer num traceback. O retrato da máquina ganhou uma linha dizendo só "configurado / não configurado".
- **`_scripts/testar_portal.py` (novo)** — sobe um portal de mentira que responde exatamente o contrato da #138 e percorre onze cenários.

## O contrato, exercitado antes de o portal existir

Uma rota autenticada só: `POST /api/toolkit/versao` com `{gmail, token, versao_instalada}`, devolvendo `{versao, sha256, novidades, url}`; `401` para código recusado, `403` para e-mail sem acesso. O token vai no corpo, nunca na URL. A versão instalada vai junto porque é o que permite ao portal montar o changelog **do período**. Quem decide se há novidade é o cliente.

## Onde mora o código de acesso

Nem em `~/.claude/skills` — que é justamente a pasta que a atualização substitui, e o token guardado ali seria destruído pela primeira atualização que ele mesmo autorizou —, nem no `aft-config.md`, que várias skills e o `/aft-doctor` imprimem na tela. Vai para a pasta de trabalho do AFT, descoberta pelo `pasta_aft.py`: `<pasta AFT>/.aft-toolkit-token` e `.aft-toolkit-consulta.json`. O valor entra pelo stdin (argumento fica no histórico do terminal) e o `--estado-token` responde só existe/não existe.

## Uma consulta por dia

O registro vale até a data virar e é considerado velho assim que a versão instalada muda. Não guarda a `url` assinada (expira em minutos) nem o token — por isso o `--aplicar` consulta o registro primeiro, de graça, e só repete a chamada de rede quando já sabe que há versão nova. Sem novidade, não gasta rede nenhuma.

## As falhas, em português

`sem_token`, `token_invalido`, `sem_acesso` e `sem_novidade` (os quatro do ticket), mais `sem_gmail` e `portal_indisponivel`. Defeito nosso sai como `falha_inesperada`, nunca disfarçado de portal fora do ar.

## Como se prova

```
python _scripts/testar_portal.py      # o portal de mentira, 11 cenários
python _scripts/testar_aplicador.py   # os cenários da #141, intactos
```

Os dois passam. Nem `~/.claude/skills` nem a pasta de trabalho real são tocados: o `PASTA_AFT` aponta para pasta descartável durante o teste inteiro.

## Achados da revisão, corrigidos antes do commit

- o nome do `.zip` baixado vinha da versão anunciada pelo portal (valor remoto decidindo caminho de escrita) — agora é fixo;
- a redação do token no `erro_ticket` rodava depois das regras de CNPJ/e-mail, que podiam mutilá-lo e fazer a troca falhar — passou a ser a primeira;
- o registro do dia não distinguia portal de mentira do real;
- a recusa da consulta era sempre rotulada modo `verificar`, mesmo durante o `--aplicar`.

## O que fica de fora

Sem entrada no `NOVIDADES.md`, pelo mesmo motivo da #141: a `/aft-atualizar` ainda faz `git pull` e o AFT não sente nada disto ainda — entra junto com a fiação (#143). O `/aft-doctor` não foi alterado (não está nos critérios da #142); o `--estado-token` já existe pronto para ele. Nota técnica atualizada em `distribuicao-por-pacote.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)